### PR TITLE
Added VimTeX plugin for LaTeX support

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -47,6 +47,7 @@ else
   source ~/.config/nvim/plug-config/lightbulb.vim
   source ~/.config/nvim/lua/lsp-wrapper.vim
   source ~/.config/nvim/plug-config/lsp-config.vim
+  source ~/.config/nvim/plug-config/vimtex.vim
   luafile ~/.config/nvim/lua/lsp/general-ls.lua
   luafile ~/.config/nvim/lua/plugins/galaxyline-config.lua
   luafile ~/.config/nvim/lua/plugins/nvimtree-config.lua

--- a/keys/which-key.vim
+++ b/keys/which-key.vim
@@ -310,4 +310,14 @@ let g:which_key_map.t = {
       \ 'u' : [':FloatermNew ncdu'                              , 'ncdu'],
       \ }
 
+" L is for LaTeX
+let g:which_key_map.L = {
+      \ 'name' : '+LaTeX' ,
+      \ 'i' : ['<plug>(vimtex-info-full)'        , 'Full Info'],
+      \ 't' : ['<plug>(vimtex-toc-toggle)'       , 'TOC toggle'],
+      \ 'v' : ['<plug>(vimtex-view)'             , 'View'],
+      \ 'q' : ['<plug>(vimtex-log)'              , 'Log'],
+      \ 'L' : ['<plug>(vimtex-compile)'          , 'Compile'],
+      \ }
+
 call which_key#register('<Space>', "g:which_key_map")

--- a/plug-config/vimtex.vim
+++ b/plug-config/vimtex.vim
@@ -1,0 +1,30 @@
+
+" Choose pdf viewer skim (easier for MacOS) or Zathura (primarily Linux but works also on MacOS)
+let g:latex_view_general_viewer = "zathura"
+" let g:latex_view_general_viewer = "skim"
+let g:vimtex_view_method = "zathura"
+" let g:vimtex_view_method = "skim"
+let g:tex_flavor = "latex"
+let g:vimtex_quickfix_open_on_warning = 0
+let g:vimtex_quickfix_mode = 2
+let g:vimtex_compiler_method = "latexmk"
+let g:vimtex_compiler_progname = 'nvr'
+let g:vimtex_compiler_latexmk = {
+    \ 'background' : 1,
+    \ 'build_dir' : '',
+    \ 'callback' : 1,
+    \ 'continuous' : 1,
+    \ 'executable' : 'latexmk',
+    \ 'options' : [
+    \   '-verbose',
+    \   '-file-line-error',
+    \   '-synctex=1',
+    \   '-interaction=nonstopmode',
+    \ ],
+    \}
+  " Compile on initialization, cleanup on quit
+  augroup vimtex_event_1
+    au!
+    au User VimtexEventQuit     call vimtex#compiler#clean(0)
+    au User VimtexEventInitPost call vimtex#compiler#compile()
+  augroup END


### PR DESCRIPTION
Intellisense for LaTeX currently does not work (because this plugin does not use the language server protocol? need to check it out).
Syntax highlighting, folding, latex compile, 2 way sync with pdf viewer (zathura) works.
Added also some basic Which-key mappings under the "L". Will add more in a future commit.