### PR TITLE
fix commentary to execute properly in visual mode

### DIFF
--- a/plug-config/vim-commentary.vim
+++ b/plug-config/vim-commentary.vim
@@ -5,6 +5,6 @@ function! Comment()
     execute "'<,'>Commentary"
   endif
  endfunction
-vnoremap <silent> <space>/ :call Comment()
+vnoremap <silent> <space>/ :call Comment()<cr>
 autocmd! BufRead,BufNewFile *.{jsx,jx,js} setlocal filetype=javascript.jsx
 autocmd FileType javascript.jsx setlocal commentstring={/*\ %s\ */}


### PR DESCRIPTION
It was not pressing enter for comment It, so always needed to press comment 2 times.