### PR TITLE
lua keybindings

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,36 +1,60 @@
-vim.api.nvim_set_keymap('n', '<Space>', '<NOP>', { noremap = true, silent = true })
+-- Helper function
+function map(mode, lhs, rhs, opts)
+    local options = {noremap = true, silent = true}
+    if opts then options = vim.tbl_extend('force', options, opts) end
+    vim.api.nvim_set_keymap(mode, lhs, rhs, options)
+end
+
+map('n', '<Space>', '<NOP>')
 vim.g.mapleader = ' '
 
 -- no hl
-vim.api.nvim_set_keymap('n', '<Leader>h', ':set hlsearch!<CR>', { noremap = true, silent = true })
+map('n', '<Leader>h', ':set hlsearch!<CR>')
 
 -- explorer
-vim.api.nvim_set_keymap('n', '<Leader>e', ':NvimTreeToggle<CR>', { noremap = true, silent = true })
+map('n', '<Leader>e', ':NvimTreeToggle<CR>')
 
 
 -- better window movement
-vim.api.nvim_set_keymap('n', '<C-h>', '<C-w>h', { silent = true })
-vim.api.nvim_set_keymap('n', '<C-j>', '<C-w>j', { silent = true })
-vim.api.nvim_set_keymap('n', '<C-k>', '<C-w>k', { silent = true })
-vim.api.nvim_set_keymap('n', '<C-l>', '<C-w>l', { silent = true })
+map('n', '<C-h>', '<C-w>h')
+map('n', '<C-j>', '<C-w>j')
+map('n', '<C-k>', '<C-w>k')
+map('n', '<C-l>', '<C-w>l')
 
 -- better indenting
-vim.api.nvim_set_keymap('v', '<', '<gv', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('v', '>', '>gv', { noremap = true, silent = true })
+map('v', '<', '<gv')
+map('v', '>', '>gv')
 
 -- I hate escape
-vim.api.nvim_set_keymap('i', 'jk', '<ESC>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', 'kj', '<ESC>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('i', 'jj', '<ESC>', { noremap = true, silent = true })
+map('i', 'jk', '<ESC>')
+map('i', 'kj', '<ESC>')
+map('i', 'jj', '<ESC>')
 
 -- Tab switch buffer
-vim.api.nvim_set_keymap('n', '<TAB>', ':bnext<CR>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<S-TAB>', ':bprevious<CR>', { noremap = true, silent = true })
+map('n', '<TAB>', ':bnext<CR>')
+map('n', '<S-TAB>', ':bprevious<CR>')
 
 -- Move selected line / block of text in visual mode
-vim.api.nvim_set_keymap('x', 'K', ':move \'<-2<CR>gv-gv\'', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('x', 'J', ':move \'>+1<CR>gv-gv\'', { noremap = true, silent = true })
+map('x', 'K', ':move \'<-2<CR>gv-gv\'')
+map('x', 'J', ':move \'>+1<CR>gv-gv\'')
 
 -- TAB Complete
---vim.api.nvim_set_keymap('i', '<expr><TAB>', 'pumvisible() ? \"\\<C-n>\" : \"\\<TAB>\"', { noremap = true, silent = true })
+map('i', '<Tab>', 'pumvisible() ? "\\<C-n>" : "\\<Tab>"', {expr = true})
+map('i', '<S-Tab>', 'pumvisible() ? "\\<C-p>" : "\\<Tab>"', {expr = true})
 
+-- Terminal window navigation
+map('t', '<C-h>', '<C-\\><C-N><C-w>h')
+map('t', '<C-j>', '<C-\\><C-N><C-w>j')
+map('t', '<C-k>', '<C-\\><C-N><C-w>k')
+map('t', '<C-l>', '<C-\\><C-N><C-w>l')
+map('t', '<Esc>', '<C-\\><C-n>')
+
+-- Window Resizing
+map('n', '<C-Up>', ':resize -2<CR>')
+map('n', '<C-Down>', ':resize +2<CR>')
+map('n', '<C-Left>', ':vertical resize -2<CR>')
+map('n', '<C-Right>', ':vertical resize +2<CR>')
+
+-- Better nav for omnicomplete
+map('i', '<c-j>', '("\\<C-n>")', {expr = true})
+map('i', '<c-k>', '("\\<C-p>")', {expr = true})


### PR DESCRIPTION
I added a helper function for setting up the keybindings, `{noremap = true, silent = true}` are set by default so code is so much cleaner but you still can overwrite them and set them to false by passing them as a table like I did with `{expr = true}`.
You can now remove the block of code you copy for tab-completion in nv-compe and tab-completion will work just fine, I tested all the keybindings and they work.
I have my [nvim config](https://github.com/martinsione/dotfiles/tree/master/src/.config/nvim) almost completely in lua so if you wanna take a look you are more than welcome.
Hope you find it useful.