### PR TITLE
Lua settings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,4 @@
+require('globals')
 require('plugins')
 require('keymappings')
 require('settings')

--- a/lua/globals/init.lua
+++ b/lua/globals/init.lua
@@ -1,0 +1,1 @@
+require(globals.settings)

--- a/lua/globals/settings.lua
+++ b/lua/globals/settings.lua
@@ -1,0 +1,263 @@
+--[[ To use a more declarative syntax, you could do something like this:
+
+local function set_opts(opts_table)
+  for k, v in pairs(opts_table) do
+    vim.opt[k] = v
+  end
+end
+
+set_opts {
+  mouse = 'n',
+  fillchars = { eob = "~" },
+}
+
+--]]
+
+--[[ Global option names
+
+For those wondering how to get the values at the top level,
+    you could use Lua's `setfenv` function to set the environment
+    equal to the vim.opt dict
+
+cc @mccanch
+
+setfenv(function()
+    mouse = 'n'
+end, vim.opt)()
+
+--]]
+
+local if_nil = function(a, b)
+  if a == nil then
+    return b
+  end
+  return a
+end
+
+local singular_values = {
+  ['boolean'] = true,
+  ['number']  = true,
+  ['nil']     = true,
+}
+
+local set_key_value = function(t, key_value_str)
+  assert(string.find(key_value_str, ":"), "Must have a :" .. tostring(key_value_str))
+
+  local key, value = unpack(vim.split(key_value_str, ":"))
+  key = vim.trim(key)
+  value = vim.trim(value)
+
+  t[key] = value
+end
+
+local convert_vimoption_to_lua = function(option, val)
+  -- Short circuit if we've already converted!
+  if type(val) == 'table' then
+    return val
+  end
+
+  if singular_values[type(val)] then
+    return val
+  end
+
+  if type(val) == "string" then
+    -- TODO: Bad hax I think
+    if string.find(val, ":") then
+      local result = {}
+      local items = vim.split(val, ",")
+      for _, item in ipairs(items) do
+        set_key_value(result, item)
+      end
+
+      return result
+    else
+      return vim.split(val, ",")
+    end
+  end
+end
+
+-- local concat_keys = function(t, sep)
+--   return table.concat(vim.tbl_keys(t), sep)
+-- end
+
+local concat_key_values = function(t, sep, divider)
+  local final = {}
+  for k, v in pairs(t) do
+    table.insert(final, string.format('%s%s%s', k, divider, v))
+  end
+
+  table.sort(final)
+  return table.concat(final, sep)
+end
+
+local remove_duplicate_values = function(t)
+  local result = {}
+  for _, v in ipairs(t) do
+    result[v] = true
+  end
+
+  return vim.tbl_keys(result)
+end
+
+local remove_value = function(t, val)
+  if vim.tbl_islist(t) then
+    local remove_index = nil
+    for i, v in ipairs(t) do
+      if v == val then
+        remove_index = i
+      end
+    end
+
+    if remove_index then
+      table.remove(t, remove_index)
+    end
+  else
+    t[val] = nil
+  end
+
+  return t
+end
+
+local add_value = function(current, new)
+  if singular_values[type(current)] then
+    error(
+      "This is not possible to do. Please do something different: "
+      .. tostring(current)
+      .. " // "
+      .. tostring(new)
+    )
+  end
+
+  if type(new) == 'string' then
+    if vim.tbl_islist(current) then
+      table.insert(current, new)
+    else
+      set_key_value(current, new)
+    end
+
+    return current
+  elseif type(new) == 'table' then
+    if vim.tbl_islist(current) then
+      assert(vim.tbl_islist(new))
+      vim.list_extend(current, new)
+    else
+      assert(not vim.tbl_islist(new), vim.inspect(new) .. vim.inspect(current))
+      current = vim.tbl_extend("force", current, new)
+    end
+
+    return current
+  else
+    error("Unknown type")
+  end
+end
+
+local convert_lua_to_vimoption = function(t)
+  if vim.tbl_islist(t) then
+    t = remove_duplicate_values(t)
+
+    table.sort(t)
+    return table.concat(t, ',')
+  else
+    return concat_key_values(t, ',', ':')
+  end
+end
+
+local clean_value = function(v)
+  if singular_values[type(v)] then
+    return v
+  end
+
+  local result = v:gsub('^,', '')
+
+  return result
+end
+
+local opt_mt
+
+opt_mt = {
+  __index = function(t, k)
+    if k == '_value' then
+      return rawget(t, k)
+    end
+
+    return setmetatable({ _option = k, }, opt_mt)
+  end,
+
+  __newindex = function(t, k, v)
+    if k == '_value' then
+      return rawset(t, k, v)
+    end
+
+    if type(v) == 'table' then
+      local new_value
+      if getmetatable(v) ~= opt_mt then
+        new_value = v
+      else
+        assert(v._value, "Must have a value to set this")
+        new_value = v._value
+      end
+
+      vim.o[k] = convert_lua_to_vimoption(new_value)
+      return
+    end
+
+    if v == nil then
+      v = ''
+    end
+
+    -- TODO: Figure out why nvim_set_option doesn't override values the same way.
+    -- @bfredl said he will fix this for me, so I can just use nvim_set_option
+    if type(v) == 'boolean' then
+      vim.o[k] = clean_value(v)
+      if v then
+        vim.cmd(string.format("set %s", k))
+      else
+        vim.cmd(string.format("set no%s", k))
+      end
+    else
+      vim.cmd(string.format("set %s=%s", k, clean_value(v)))
+    end
+  end,
+
+  __add = function(left, right)
+    --[[
+    set.wildignore = set.wildignore + 'hello'
+    set.wildignore = set.wildignore + { '*.o', '*~', }
+    --]]
+
+    assert(left._option, "must have an option key")
+    if left._option == 'foldcolumn' then
+      error("not implemented for foldcolumn.. use a string")
+    end
+
+    local existing = if_nil(left._value, vim.o[left._option])
+    local current = convert_vimoption_to_lua(left._option, existing)
+    if not current then
+      left._value = convert_vimoption_to_lua(right)
+    end
+
+    left._value = add_value(current, right)
+    return left
+  end,
+
+  __sub = function(left, right)
+    assert(left._option, "must have an option key")
+
+    local existing = if_nil(left._value, vim.o[left._option])
+    local current = convert_vimoption_to_lua(left._option, existing)
+    if not current then
+      return left
+    end
+
+    left._value = remove_value(current, right)
+    return left
+  end
+}
+
+vim.opt = setmetatable({}, opt_mt)
+
+return {
+  convert_vimoption_to_lua = convert_vimoption_to_lua,
+  opt = vim.opt,
+  opt_mt = opt_mt
+}

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,39 +1,42 @@
---vim.o.iskeyword="+=-"                     --treat dash separated words as a word text object"
---vim.o.shortmess="c"                        --Don't pass messages to |ins-completion-menu|.
+-- TODO: REMOVE when https://github.com/neovim/neovim/pull/13479 comes
 
---vim.o.formatoptions="cro"                  --Stop newline continution of comments
-vim.o.hidden=true                              --Required to keep multiple buffers open multiple buffers
-vim.o.wrap=false                              --Display long lines as just one line
---vim.o.whichwrap="+=<,>,[,],h,l"
-vim.o.encoding="utf-8"                      --The encoding displayed
-vim.o.pumheight=10                        --Makes popup menu smaller
-vim.o.fileencoding="utf-8"                  --The encoding written to file
-vim.o.ruler=true              		  --                " Show the cursor position all the time
-vim.o.cmdheight=2                         --More space for displaying messages
-vim.o.mouse="a"                             --Enable your mouse
-vim.o.splitbelow=true                          --Horizontal splits will automatically be below
-vim.o.termguicolors=true
-vim.o.splitright=true                          --Vertical splits will automatically be to the right
-vim.o.t_Co="256"                            --Support 256 colors
-vim.o.conceallevel=0                      --So that I can see `` in markdown files
-vim.o.tabstop=2                           --Insert 2 spaces for a tab
-vim.o.shiftwidth=2                        --Change the number of space characters inserted for indentation
-vim.o.smarttab=true                            --Makes tabbing smarter will realize you have 2 vs 4
-vim.o.expandtab=true                           --Converts tabs to spaces
-vim.o.smartindent=true                         --Makes indenting smart
-vim.o.autoindent=true                          --Good auto indent
-vim.o.laststatus=2                        --Always display the status line
---vim.o.number=true                              --Line numbers
-vim.wo.number = true
-vim.o.cursorline=true                          --Enable highlighting of the current line
-vim.o.background="dark"                     --tell vim what the background color looks like
-vim.o.showtabline=2                       --Always show tabs
-vim.o.showmode=false                          --We don't need to see things like -- INSERT -- anymore
-vim.o.backup=false                            --This is recommended by coc
-vim.o.writebackup=false                       --This is recommended by coc
-vim.o.signcolumn="yes"                      --Always show the signcolumn, otherwise it would shift the text each time
-vim.o.updatetime=300                      --Faster completion
-vim.o.timeoutlen=1000                      --By default timeoutlen is 1000 ms
-vim.o.clipboard="unnamedplus"               --Copy paste between vim and everything else
-vim.o.incsearch=true
-vim.o.guifont="JetBrainsMono\\ Nerd\\ Font\\ Mono:h18"
+local opt = vim.opt
+
+opt.iskeyword=opt.iskeyword + '-'            --treat dash separated words as a word text object"
+-- opt.shortmess="c"                         --Don't pass messages to |ins-completion-menu|.
+
+-- opt.formatoptions="cro"                   --Stop newline continution of comments
+opt.hidden=true                           --Required to keep multiple buffers open multiple buffers
+opt.wrap=false                            --Display long lines as just one line
+--opt.whichwrap="+=<,>,[,],h,l"
+opt.encoding="utf-8"                      --The encoding displayed
+opt.pumheight=10                          --Makes popup menu smaller
+opt.fileencoding="utf-8"                  --The encoding written to file
+opt.ruler=true              		  --      --Show the cursor position all the time
+opt.cmdheight=2                           --More space for displaying messages
+opt.mouse="a"                             --Enable your mouse
+opt.splitbelow=true                       --Horizontal splits will automatically be below
+opt.termguicolors=true
+opt.splitright=true                       --Vertical splits will automatically be to the right
+opt.t_Co="256"                            --Support 256 colors
+opt.conceallevel=0                        --So that I can see `` in markdown files
+opt.tabstop=2                             --Insert 2 spaces for a tab
+opt.shiftwidth=2                          --Change the number of space characters inserted for indentation
+opt.smarttab=true                         --Makes tabbing smarter will realize you have 2 vs 4
+opt.expandtab=true                        --Converts tabs to spaces
+opt.smartindent=true                      --Makes indenting smart
+opt.autoindent=true                       --Good auto indent
+opt.laststatus=2                          --Always display the status line
+opt.number=true                           --Line numbers
+opt.cursorline=true                       --Enable highlighting of the current line
+opt.background="dark"                     --tell vim what the background color looks like
+opt.showtabline=2                         --Always show tabs
+opt.showmode=false                        --We don't need to see things like -- INSERT -- anymore
+opt.backup=false                          --This is recommended by coc
+opt.writebackup=false                     --This is recommended by coc
+opt.signcolumn="yes"                      --Always show the signcolumn, otherwise it would shift the text each time
+opt.updatetime=300                        --Faster completion
+opt.timeoutlen=1000                       --By default timeoutlen is 1000 ms
+opt.clipboard="unnamedplus"               --Copy paste between vim and everything else
+opt.incsearch=true
+opt.guifont="JetBrainsMono\\ Nerd\\ Font\\ Mono:h18"


### PR DESCRIPTION
I added a wrapper for vim.opt in lua/globals/settings.lua and required it first, in lua it is common to set some globals for nvim config, that way you can just use `opt.{option}` I highly recommend using this because if not you have to be guessing what type of option is what you are setting, I also wrote the pull request in which is being worked this as a TODO so when it comes you can remove it.