### PR TITLE
WIP: virtual text highlight

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -1,4 +1,4 @@
--- TODO figure out why this don't work
+vim.cmd('highlight! link LspDiagnosticsDefaultError WarningMsg')
 vim.fn.sign_define("LspDiagnosticsSignError", {
     texthl = "LspDiagnosticsSignError",
     text = "",


### PR DESCRIPTION
@ChristianChiarulli If I remember correctly you wanted to highlight the virtual text warnings/errors from lsp. I don't know if it's the best solution but what worked for me was to override the Lsp* highlights (using `!`). See example in this PR. If this works for you you can add the rests or let me know which ones you wanted.