### PR TITLE
Prototype global install of nvcode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ LunarVim provides neovim configuration files that take advantage of
 tree-sitter and language server protocol. The configuration is written
 in lua.
 
+# Global Install
+
+To install globally:
+
+```
+git clone https://github.com/jameswalmsley/nvcode.git -b global-install nvcode.global
+cd nvcode.global/utils/bin
+sudo ./nvcode-upgrade.sh -g
+```
+
+This install a copy of the nvcode config into `/usr/local/share/nvcode/nvim`, and installs the nv,
+starter script to `/usr/local/bin`
+
+The script will use sudo to run nvim as the calling user to sync plugins to `~/.local/share/nvcode/data/nvim`.
+
+It leaves nvim open, simply exit nvim when finished. (Couldn't get headless nvim to not quit early on packer).
+
+Once completed you should be able to run nv without interfering with the main .config/nvim config.
+
+NOTE.. This global install will use `.config/nvcode/nvim`
+
+
 ## Why do I want tree-sitter and LSP?
 
 - Normally, an editor uses regular expression parsing for things like

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,8 @@
 require('default-config')
-vim.cmd('luafile ' .. CONFIG_PATH .. '/lv-config.lua')
+if io.open(CONFIG_PATH .. '/lv-config.lua', 'r') then
+	vim.cmd('luafile ' .. CONFIG_PATH .. '/lv-config.lua')
+end
+require('environment')
 require('settings')
 require('plugins')
 require('lv-utils')

--- a/lua/environment.lua
+++ b/lua/environment.lua
@@ -1,0 +1,7 @@
+lv_base = vim.fn.stdpath('config')
+lv_global = false
+if os.getenv('LV_BASE') then
+	lv_global = true
+	lv_base = os.getenv('LV_BASE') .. '/nvim'
+end
+

--- a/utils/bin/nv
+++ b/utils/bin/nv
@@ -1,2 +1,19 @@
 #!/bin/bash
-nvim -u ~/.config/nvcode/init.lua
+
+GLOBAL=1
+
+source /opt/nvcode/nvim/utils/bin/nvcode-env.sh
+
+export LV_BASE=${NVCODE_BASE}
+
+nvim -u ${NVCODE_BASE_CONFIG} ${NVCODE_SYNC} $@
+
+if [ -v NVCODE_SYNC ]; then
+  touch ${NVCODE_USER}/.packer_sync
+fi
+
+if [ -v NVCODE_CONFIG_INIT ]; then
+  mkdir -p ${NVCODE_USER_CONFIG}
+  cp ${NVCODE_CONFIG_DIR}/nv-settings.lua ${NVCODE_USER_CONFIG}/nvim/nv-settings.lua
+  touch ${NVCODE_USER_CONFIG}/nvim/init.lua
+fi

--- a/utils/bin/nvcode-env.sh
+++ b/utils/bin/nvcode-env.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# PREFIX:
+#   Where to install nvcode.
+#
+if [ -v GLOBAL ]; then
+	PREFIX=${PREFIX:-/opt}
+else
+	PREFIX=${PREFIX:-$HOME/.config}
+fi
+
+
+# NVCODE_BASE:
+#   Path to the "base" NVCode configuration (the global repo).
+#
+NVCODE_BASE="${PREFIX}"
+[ -v GLOBAL ] && NVCODE_BASE=${NVCODE_BASE}/nvcode
+
+NVCODE_CONFIG_DIR=${NVCODE_BASE}/nvim
+
+# NVCODE_USER:
+#   Path to the "user" data/cache folders.
+#
+NVCODE_USER="$HOME/.local/share/nvcode"
+
+# NVCODE_USER_CONFIG:
+#   Path to the "users" local config dir.
+#
+NVCODE_USER_CONFIG="$HOME/.config/nvcode"
+
+# NVCODE_BASE_CONFIG: 
+#   Path to the "base" config file.
+#
+NVCODE_BASE_CONFIG=${NVCODE_CONFIG_DIR}/init.lua
+
+#
+# Initialise the users nvcode config if not already created.
+#
+if [ ! -f ${NVCODE_USER_CONFIG}/nvim/nv-settings.lua ]; then
+	NVCODE_CONFIG_INIT=1
+fi
+
+#
+# Force a PackerSync if nvcode is updated, since the last run.
+#
+if [ -v GLOBAL ]; then
+	if [ ${NVCODE_BASE}/.packer_sync -nt ${NVCODE_USER}/.packer_sync ] || [ ! -f ${NVCODE_USER}/.packer_sync ]; then
+		NVCODE_SYNC=+PackerSync
+		echo "Update required! ${NVCODE_SYNC}"
+	fi
+fi
+
+export SHELL=/bin/bash
+export XDG_CONFIG_HOME=${NVCODE_USER_CONFIG}
+export XDG_DATA_HOME="${NVCODE_USER}/data"	
+export XDG_CACHE_HOME="${NVCODE_USER}/cache"
+export XDG_CONFIG_DIRS="/usr/share:/usr/local/share:${NVCODE_BASE}"
+

--- a/utils/bin/nvcode-upgrade.sh
+++ b/utils/bin/nvcode-upgrade.sh
@@ -145,7 +145,7 @@ global_cmd=""
 [ -v GLOBAL ] && global_cmd="sudo"
 
 update_nv_script() {
-	${global_cmd} rm /usr/local/bin/nv
+	[ -f "/usr/local/bin/nv" ] && ${global_cmd} rm /usr/local/bin/nv
 	${global_cmd} ln -s ${NVCODE_CONFIG_DIR}/utils/bin/nv /usr/local/bin/nv
 	${global_cmd} sed -i "s:source.*:source ${NVCODE_CONFIG_DIR}/utils/bin/nvcode-env.sh:g" ${NVCODE_CONFIG_DIR}/utils/bin/nv
 }

--- a/utils/bin/nvcode-upgrade.sh
+++ b/utils/bin/nvcode-upgrade.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+set -o nounset # error when referencing undefined variable
+set -o errexit # exit when command fails
+
+PARAMS=""
+while (( "$#" )); do
+	case "$1" in
+		-g|--global)
+			GLOBAL=1
+			shift
+			;;
+		-i|--info)
+			INFO=1
+			shift
+			;;
+		-*|--*=) # unsupported flags
+			echo "Error: Unsupported flag $1" >&2
+			exit 1
+			;;
+		*) # preserve positional arguments
+			PARAMS="$PARAMS $1"
+			shift
+			;;
+	esac
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+source nvcode-env.sh
+
+if [[ -v INFO ]]; then
+	echo "NVCODE_BASE: ${NVCODE_BASE}"
+	echo "NVCODE_USER: ${NVCODE_USER}"
+	echo "NVCODE_USER_CONFIG: ${NVCODE_USER_CONFIG}"
+	exit 1
+fi
+
+installnodemac() {
+	brew install lua
+	brew install node
+	brew install yarn
+}
+
+installnodeubuntu() {
+	sudo apt install nodejs
+	sudo apt install npm
+}
+
+moveoldnvim() {
+	echo "Not installing NVCode"
+	echo "Please move your ${NVCODE_CONFIG_DIR} folder before installing"
+	exit
+}
+
+installnodearch() {
+	sudo pacman -S nodejs
+	sudo pacman -S npm
+}
+
+installnode() {
+	echo "Installing node..."
+	[ "$(uname)" == "Darwin" ] && installnodemac
+	[ -n "$(uname -a | grep Ubuntu)" ] && installnodeubuntu
+	[ -f "/etc/arch-release" ] && installnodearch
+	[ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ] && echo "Windows not currently supported"
+	sudo npm i -g neovim
+}
+
+installpiponmac() {
+	sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+	python3 get-pip.py
+	rm get-pip.py
+}
+
+installpiponubuntu() {
+	sudo apt install python3-pip >/dev/null
+}
+
+installpiponarch() {
+	pacman -S python-pip
+}
+
+installpip() {
+	echo "Installing pip..."
+	[ "$(uname)" == "Darwin" ] && installpiponmac
+	[ -n "$(uname -a | grep Ubuntu)" ] && installpiponubuntu
+	[ -f "/etc/arch-release" ] && installpiponarch
+	[ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ] && echo "Windows not currently supported"
+}
+
+installpynvim() {
+	echo "Installing pynvim..."
+	pip3 install pynvim --user
+}
+
+asktoinstallnode() {
+	echo "node not found"
+	echo -n "Would you like to install node now (y/n)? "
+	read answer
+	[ "$answer" != "${answer#[Yy]}" ] && installnode
+}
+
+asktoinstallpip() {
+	# echo "pip not found"
+	# echo -n "Would you like to install pip now (y/n)? "
+	# read answer
+	# [ "$answer" != "${answer#[Yy]}" ] && installpip
+	echo "Please install pip3 before continuing with install"
+	exit
+}
+
+installonmac() {
+	brew install ripgrep fzf ranger
+	npm install -g tree-sitter-cli
+}
+
+pipinstallueberzug() {
+	which pip3 >/dev/null && pip3 install ueberzug || echo "Not installing ueberzug pip not found"
+}
+
+installonubuntu() {
+	sudo apt install ripgrep fzf ranger
+	sudo apt install libjpeg8-dev zlib1g-dev python-dev python3-dev libxtst-dev
+	pip3 install ueberzug
+	pip3 install neovim-remote
+	npm install -g tree-sitter-cli
+}
+
+installonarch() {
+	sudo pacman -S ripgrep fzf ranger
+	which yay >/dev/null && yay -S python-ueberzug-git || pipinstallueberzug
+	pip3 install neovim-remote
+	npm install -g tree-sitter-cli
+}
+
+installextrapackages() {
+	[ "$(uname)" == "Darwin" ] && installonmac
+	[ -n "$(uname -a | grep Ubuntu)" ] && installonubuntu
+	[ -f "/etc/arch-release" ] && installonarch
+	[ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ] && echo "Windows not currently supported"
+}
+
+global_cmd=""
+[ -v GLOBAL ] && global_cmd="sudo"
+
+update_nv_script() {
+	${global_cmd} rm /usr/local/bin/nv
+	${global_cmd} ln -s ${NVCODE_CONFIG_DIR}/utils/bin/nv /usr/local/bin/nv
+	${global_cmd} sed -i "s:source.*:source ${NVCODE_CONFIG_DIR}/utils/bin/nvcode-env.sh:g" ${NVCODE_CONFIG_DIR}/utils/bin/nv
+}
+#
+# Upgrade is only used for global installations. 
+#
+upgrade_nvcode() {
+	echo upgrading
+	cd ${NVCODE_CONFIG_DIR} && sudo git fetch && sudo git reset --hard origin/global-install
+	update_nv_script
+	${global_cmd} touch ${NVCODE_BASE}/.packer_sync
+}
+
+install_nvcode() {
+	echo installing
+	echo "Cloning NVCode configuration"
+	${global_cmd} mkdir -p ${NVCODE_CONFIG_DIR}
+	${global_cmd} git clone https://github.com/jameswalmsley/nvcode.git -b global-install ${NVCODE_CONFIG_DIR}
+	if [ -v GLOBAL ]; then
+		update_nv_script
+		${global_cmd} touch ${NVCODE_BASE}/.packer_sync
+	fi
+}
+
+
+# Welcome
+echo 'Installing NVCode'
+
+if [ -v GLOBAL ]; then
+	echo "Install a global configuration to ${NVCODE_CONFIG_DIR}"
+else
+	echo "Installing a local configuration to ${NVCODE_CONFIG_DIR}"
+	[ -d "${NVCODE_CONFIG_DIR}" ] && moveoldnvim
+fi
+
+# install pip
+which pip3 >/dev/null && echo "pip installed, moving on..." || asktoinstallpip
+
+# install node and neovim support
+which node >/dev/null && echo "node installed, moving on..." || asktoinstallnode
+
+# install pynvim
+pip3 list | grep pynvim >/dev/null && echo "pynvim installed, moving on..." || installpynvim
+
+# Install nvcode configuration
+[ -d "${NVCODE_CONFIG_DIR}" ] && upgrade_nvcode || install_nvcode
+


### PR DESCRIPTION
I got a prototype of a global install config working.
This allows the user to use a standard nvim config under ~/.config/nvim when running `nvim`.

Or you can run nv and it will use the /usr/local/share/nvcode/init.lua config.

I managed to get this to install all packages into a separate folder, without affecting the users local config.

Just wanted to get your thoughts on this...