### PR TITLE
add set shell=/bin/bash in init.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ eclipse.jdt.ls/
 .debuggers/
 spell/
 nv-settings.lua
+lv-settings.lua


### PR DESCRIPTION
some people (myself included) use fish shell as their default. which doesn't really play well in neovim

in my old init.vim I used to have a `set shell=/bin/bash`

I don't know if there is an equivalent in pure lua, but the dirty `vim.cmd('set shell=/bin/bash')` worked

feel free to change it if there is a more "lua" way to do it