### PR TITLE
fix(emf-general-ls): fix black, add lua-fmt

### DIFF
--- a/lua/lsp/efm-general-ls.lua
+++ b/lua/lsp/efm-general-ls.lua
@@ -13,7 +13,7 @@ local flake8 = {
 local isort = {formatCommand = "isort --quiet -", formatStdin = true}
 
 local yapf = {formatCommand = "yapf --quiet", formatStdin = true}
-local black = {formatCommand = "black --quiet --stdin-filename ", formatStdin = true}
+local black = {formatCommand = "black --quiet -", formatStdin = true}
 
 if O.python.linter == 'flake8' then table.insert(python_arguments, flake8) end
 
@@ -27,12 +27,22 @@ end
 
 -- lua
 local lua_arguments = {}
+
 local luaFormat = {
     formatCommand = "lua-format -i --no-keep-simple-function-one-line --column-limit=120",
     formatStdin = true
 }
 
-if O.lua.formatter == 'lua-format' then table.insert(lua_arguments, luaFormat) end
+local lua_fmt = {
+    formatCommand = "luafmt --indent-count 2 --line-width 120 --stdin",
+    formatStdin = true
+}
+
+if O.lua.formatter == 'lua-format' then
+  table.insert(lua_arguments, luaFormat)
+elseif O.lua.formatter == 'lua-fmt' then
+  table.insert(lua_arguments, lua_fmt)
+end
 
 -- sh
 local sh_arguments = {}


### PR DESCRIPTION
`--stdin-filename` doesn't look to be a valid option for black (anymore?), so I removed it and added the requisite `-`.

While I was in there, I also added support for [lua-fmt](https://github.com/trixnz/lua-fmt).