### PR TITLE
Gopls fixed. Root dir was causing problem

### DIFF
--- a/lua/lsp/go-ls.lua
+++ b/lua/lsp/go-ls.lua
@@ -1,4 +1,7 @@
 require'lspconfig'.gopls.setup{
     cmd = {DATA_PATH .. "/lspinstall/go/gopls"},
+    settings = {gopls = {analyses = {unusedparams = true}, staticcheck = true}},
+    root_dir = require'lspconfig'.util.root_pattern(".git","go.mod","."),
+    init_options = {usePlaceholders = true, completeUnimported = true},
     on_attach = require'lsp'.common_on_attach
 }


### PR DESCRIPTION
Fixed the issue of gopls unable to start unless current directory was git repo or contains a go.mod file.
Also added init_options that are kind of useful