### PR TITLE
Fix Autopairs Not working issue

### DIFF
--- a/lua/lv-autopairs/init.lua
+++ b/lua/lv-autopairs/init.lua
@@ -78,6 +78,7 @@
 
 local remap = vim.api.nvim_set_keymap
 local npairs = require('nvim-autopairs')
+local Rule = require('nvim-autopairs.rule')
 
 -- skip it, if you use another global object
 _G.MUtils= {}
@@ -97,3 +98,26 @@ end
 
 
 remap('i' , '<CR>','v:lua.MUtils.completion_confirm()', {expr = true , noremap = true})
+
+npairs.setup({
+    check_ts = true,
+    ts_config = {
+        lua = {'string'},-- it will not add pair on that treesitter node
+        javascript = {'template_string'},
+        java = false,-- don't check treesitter on java
+    }
+})
+
+require('nvim-treesitter.configs').setup {
+    autopairs = {enable = true}
+}
+
+local ts_conds = require('nvim-autopairs.ts-conds')
+
+-- press % => %% is only inside comment or string
+npairs.add_rules({
+  Rule("%", "%", "lua")
+    :with_pair(ts_conds.is_ts_node({'string','comment'})),
+  Rule("$", "$", "lua")
+    :with_pair(ts_conds.is_not_ts_node({'function'}))
+})


### PR DESCRIPTION
In the latest pull of LunarVim, the autopairs plugin doesn't work. (Issue #313)

Looks like it had a few rules missing.

Added them in this PR.