### PR TITLE
Fixed possible typo on settings.json

### DIFF
--- a/utils/vscode_config/settings.json
+++ b/utils/vscode_config/settings.json
@@ -976,7 +976,7 @@
   "java.semanticHighlighting.enabled": true,
   "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx1G -Xms100m -javaagent:\"/home/chris/.vscode-oss/extensions/gabrielbb.vscode-lombok-1.0.1/server/lombok.jar\"",
   "workbench.list.automaticKeyboardNavigation": false,
-  "oneDarkPro.editorTheme": "onedarkPro",
+  "oneDarkPro.editorTheme": "oneDarkPro",
   "python.languageServer": "Pylance",
   "editor.scrollbar.horizontal": "hidden",
   "editor.scrollbar.vertical": "hidden",


### PR DESCRIPTION
Fixing possible typo on the `oneDarkPro` theme name. The theme name might have been changed from the creation of the file