### PR TITLE
Implement fzy native to speed up telescope

### DIFF
--- a/lua/lv-telescope/init.lua
+++ b/lua/lv-telescope/init.lua
@@ -61,5 +61,11 @@ require('telescope').setup {
                 -- ["<C-i>"] = my_cool_custom_action,
             }
         }
+    },
+    extensions = {
+        fzy_native = {
+            override_generic_sorter = false,
+            override_file_sorter = true,
+        }
     }
 }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -44,6 +44,7 @@ return require("packer").startup(
         use {"nvim-lua/popup.nvim", opt = true}
         use {"nvim-lua/plenary.nvim", opt = true}
         use {"nvim-telescope/telescope.nvim", opt = true}
+        use 'nvim-telescope/telescope-fzy-native.nvim'
 
         -- Debugging
         use {"mfussenegger/nvim-dap", opt = true}

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -44,7 +44,7 @@ return require("packer").startup(
         use {"nvim-lua/popup.nvim", opt = true}
         use {"nvim-lua/plenary.nvim", opt = true}
         use {"nvim-telescope/telescope.nvim", opt = true}
-        use 'nvim-telescope/telescope-fzy-native.nvim'
+        use {"nvim-telescope/telescope-fzy-native.nvim", opt = true}
 
         -- Debugging
         use {"mfussenegger/nvim-dap", opt = true}


### PR DESCRIPTION
I think this is worth adding as a default. It will significantly speed up telescope

References
https://github.com/nvim-telescope/telescope-fzy-native.nvim
which uses
https://github.com/romgrk/fzy-lua-native

The main highlight is
```
Lines: 100000

Native:
 -> Total: 34130
 -> Time:  69.418 ms
Original:
 -> Total: 34130
 -> Time:  835.683 ms
```