### PR TITLE
✨  Python analysis options (pyright)

### DIFF
--- a/lua/lsp/python-ls.lua
+++ b/lua/lsp/python-ls.lua
@@ -8,7 +8,15 @@ require'lspconfig'.pyright.setup {
             signs = O.python.diagnostics.signs,
             underline = O.python.diagnostics.underline,
             update_in_insert = true
-
         })
+    },
+	 settings = {
+      python = {
+        analysis = {
+		  typeCheckingMode = O.python.analysis.type_checking,
+		  autoSearchPaths = O.python.analysis.auto_search_paths,
+          useLibraryCodeForTypes = O.python.analysis.use_library_code_types
+        }
+      }
     }
 }

--- a/lua/lv-globals.lua
+++ b/lua/lv-globals.lua
@@ -24,7 +24,8 @@ O = {
         formatter = '',
         autoformat = false,
         isort = false,
-        diagnostics = {virtual_text = true, signs = true, underline = true}
+        diagnostics = {virtual_text = true, signs = true, underline = true},
+		analysis = {type_checking = "basic", auto_search_paths = true, use_library_code_types = true}
     },
     dart = {sdk_path = '/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot'},
     lua = {

--- a/lv-settings.lua
+++ b/lv-settings.lua
@@ -34,6 +34,9 @@ O.python.autoformat = true
 O.python.diagnostics.virtual_text = true
 O.python.diagnostics.signs = true
 O.python.diagnostics.underline = true
+O.python.analysis.type_checking = "off"
+O.python.analysis.auto_search_paths = true
+O.python.analysis.use_library_code_types = true
 
 -- lua
 -- TODO look into stylua


### PR DESCRIPTION
## What's new
Options to better **python analysis** lsp configuration with global options. Can be changes by the user on `lv-settings.lua`

### Example:
```lua
O.python.analysis.type_checking = "off"
O.python.analysis.auto_search_paths = true
O.python.analysis.use_library_code_types = false

```