### PR TITLE
Fix: makes autopairs filetype specific rules work

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,7 +59,7 @@ return require("packer").startup(
         use {"windwp/nvim-ts-autotag", opt = true}
 
         -- Explorer
-        use "kyazdani42/nvim-tree.lua"
+        use {"kyazdani42/nvim-tree.lua", opt = true}
         -- TODO remove when open on dir is supported by nvimtree
         use "kevinhwang91/rnvimr"
 


### PR DESCRIPTION
In the current version, autopairs filetype specific rules don't work.   

```lua
npairs.add_rules({
-- This rule doesn't work
  Rule("(", ")",{"tex", "latex"})
    -- don't add a pair if  the previous character is xxx
    :with_pair(cond.not_before_regex_check("xxx", 3))
     },
-- This rule works
 Rule("(", "")
 -- don't add a pair if  the previous character is xxx
    :with_pair(cond.not_before_regex_check("xxx", 3))
)
```
The gif shows the way the current code is broken.  Rules only work if you don't add a filetype.  

![autopairs_not_working](https://user-images.githubusercontent.com/16025007/117002754-3fedc480-ace4-11eb-81a2-eadd1a099bf8.gif)


Changing the way LunarVim installs the two together in packer fixes the problem.  
I changed 
```bash
# This breaks autopairs.  Autopairs filetype rules will only work if I manually launch nvim-tree.  
use "kyazdani42/nvim-tree.lua"
``` 
to
```bash
# This code makes autopairs rules work regardless of whether nvim-tree has been launched.  
use {"kyazdani42/nvim-tree.lua", opt = true }
```
This is the longest I've ever spent adding two words to a codebase.  
