### PR TITLE
Add default prefix for lsp settings.

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -31,6 +31,19 @@ vim.cmd("nnoremap <silent> <C-f> <cmd>lua require('lspsaga.action').smart_scroll
 vim.cmd("nnoremap <silent> <C-b> <cmd>lua require('lspsaga.action').smart_scroll_with_saga(-1)<CR>")
 vim.cmd('command! -nargs=0 LspVirtualTextToggle lua require("lsp/virtual_text").toggle()')
 
+-- Set Default Prefix.
+-- Note: You can set a prefix per lsp server in the lv-globals.lua file
+vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
+  vim.lsp.diagnostic.on_publish_diagnostics, {
+    virtual_text = {
+      prefix = "",
+      spacing = 0,
+    },
+    signs = true,
+    underline = true,
+  }
+)
+
 -- symbols for autocomplete
 vim.lsp.protocol.CompletionItemKind = {
     "   (Text) ",


### PR DESCRIPTION
This adds the circle as the default prefix for lsp servers not defined in lv-globals such as efm.
It also ads a not to inform users that they can have a prefix per lsp server by defining them in lv-globals

- for virtual text prefix and spacing
- for signs
- for underline