### PR TITLE
fix expandtab

### DIFF
--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -21,7 +21,7 @@ vim.o.t_Co = "256" -- Support 256 colors
 vim.o.conceallevel = 0 -- So that I can see `` in markdown files
 vim.cmd('set ts=4') -- Insert 2 spaces for a tab
 vim.cmd('set sw=4') -- Change the number of space characters inserted for indentation
-vim.bo.expandtab = true -- Converts tabs to spaces
+vim.cmd('expandtab') -- Converts tabs to spaces
 vim.bo.smartindent = true -- Makes indenting smart
 vim.wo.number = O.number -- set numbered lines
 vim.wo.relativenumber = O.relative_number -- set relative number

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -21,7 +21,7 @@ vim.o.t_Co = "256" -- Support 256 colors
 vim.o.conceallevel = 0 -- So that I can see `` in markdown files
 vim.cmd('set ts=4') -- Insert 2 spaces for a tab
 vim.cmd('set sw=4') -- Change the number of space characters inserted for indentation
-vim.cmd('expandtab') -- Converts tabs to spaces
+vim.cmd('set expandtab') -- Converts tabs to spaces
 vim.bo.smartindent = true -- Makes indenting smart
 vim.wo.number = O.number -- set numbered lines
 vim.wo.relativenumber = O.relative_number -- set relative number


### PR DESCRIPTION
Apparently both `vim.bo.expandtab = true` and `vim.o.expandtab = true` have some inconsistent behavior in `NVIM v0.5.0-dev+1282-gfbe18d9ca`. See #372 for more information.

This PR reverts back to the vimscript way of setting this variable.