### PR TITLE
Fix Vue LSP

### DIFF
--- a/lua/lsp/vue-ls.lua
+++ b/lua/lsp/vue-ls.lua
@@ -1,5 +1,6 @@
 
-local lsp = require'lspconfig'
-lsp.vuels.setup{
-root_dir = lsp.util.root_pattern(".git",".")
+require('lspconfig').vuels.setup {
+    cmd = {DATA_PATH .. "/lspinstall/vue/node_modules/.bin/vls", "--stdio"},
+    on_attach = require'lsp'.common_on_attach,
+    root_dir = require('lspconfig').util.root_pattern(".git", ".")
 }


### PR DESCRIPTION
For some reason, neovim lsp can't seem to detect the binary for `vuels`. So I had to fix it by explicitly specifying where it is located.