### PR TITLE
Use os-release file to check Ubuntu distro

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -33,7 +33,7 @@ installnodefedora() {
 installnode() {
 	echo "Installing node..."
 	[ "$(uname)" == "Darwin" ] && installnodemac
-	[ -n "$(uname -a | grep Ubuntu)" ] && installnodeubuntu
+	[ -n "$(cat /etc/os-release | grep Ubuntu)" ] && installnodeubuntu
 	[ -f "/etc/arch-release" ] && installnodearch
 	[ -f "/etc/artix-release" ] && installnodearch
 	[ -f "/etc/fedora-release" ] && installnodefedora
@@ -62,7 +62,7 @@ installpiponfedora() {
 installpip() {
 	echo "Installing pip..."
 	[ "$(uname)" == "Darwin" ] && installpiponmac
-	[ -n "$(uname -a | grep Ubuntu)" ] && installpiponubuntu
+	[ -n "$(cat /etc/os-release | grep Ubuntu)" ] && installpiponubuntu
 	[ -f "/etc/arch-release" ] && installpiponarch
 	[ -f "/etc/fedora-release" ] && installpiponfedora
 	[ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ] && echo "Windows not currently supported"
@@ -135,7 +135,7 @@ installonfedora() {
 
 installextrapackages() {
 	[ "$(uname)" == "Darwin" ] && installonmac
-	[ -n "$(uname -a | grep Ubuntu)" ] && installonubuntu
+	[ -n "$(cat /etc/os-release | grep Ubuntu)" ] && installonubuntu
 	[ -f "/etc/arch-release" ] && installonarch
 	[ -f "/etc/artix-release" ] && installonarch
 	[ -f "/etc/fedora-release" ] && installonfedora


### PR DESCRIPTION
Previous check uname -a does not work if user has changed kernel.
Use os-release for true operating system identification.

Reference #346