### PR TITLE
Fix packer and nvim already installed check

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -157,13 +157,13 @@ which node >/dev/null && echo "node installed, moving on..." || asktoinstallnode
 # install pynvim
 pip3 list | grep pynvim >/dev/null && echo "pynvim installed, moving on..." || installpynvim
 
-if [ -a "$HOME/.local/share/nvim/site/pack/packer/start/packer.nvim" ]; then
+if [ -e "$HOME/.local/share/nvim/site/pack/packer/start/packer.nvim" ]; then
 	echo 'packer already installed'
 else
 	installpacker
 fi
 
-if [ -a "$HOME/.config/nvim/init.lua" ]; then
+if [ -e "$HOME/.config/nvim/init.lua" ]; then
 	echo 'nvcode already installed'
 else
 	# clone config down


### PR DESCRIPTION
It was not possible to install LunarVim if these programs were already
installed. The check is syntactically incorrect and would always return
non-0 status. The installer would always continue to install packer and
nvim even though they were already installed. This failed with an error:
"fatal: destination path '<PATH>/packer.nvim' already exists and is not
an empty directory."

Correct the syntax error by using test -e to check if the file exists.