### PR TITLE
fix pip install on Arch Linux

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -52,7 +52,7 @@ installpiponubuntu() {
 }
 
 installpiponarch() {
-	pacman -S python-pip
+    sudo pacman -S python-pip
 }
 
 installpiponfedora() {


### PR DESCRIPTION
The function ```installpiponarch``` does not have the call to ```sudo``` resulting in a error during the installation of LunarVim if the arch-based OS does not have ```pip```  pre-installed