### PR TITLE
To fix settings include order

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,12 +1,12 @@
 require('lv-globals')
+vim.cmd('luafile ~/.config/nvim/lv-settings.lua')
 require('settings')
 require('plugins')
 require('lv-utils')
 require('lv-autocommands')
-vim.cmd('luafile ~/.config/nvim/lv-settings.lua')
 require('keymappings')
 require('lv-nvimtree') -- This plugin must be required somewhere before colorscheme.  Placing it after will break navigation keymappings
-require('colorscheme') -- This plugin must be required somewhere after nvimtree. Placing it before will break navigation keymappings 
+require('colorscheme') -- This plugin must be required somewhere after nvimtree. Placing it before will break navigation keymappings
 require('lv-galaxyline')
 require('lv-comment')
 require('lv-compe')

--- a/lv-settings.lua
+++ b/lv-settings.lua
@@ -14,7 +14,7 @@ O.auto_close_tree = 0
 O.wrap_lines = false
 O.timeoutlen = 100
 
--- dashboard 
+-- dashboard
 -- O.dashboard.custom_header = {""}
 -- O.dashboard.footer = {""}
 
@@ -60,3 +60,6 @@ O.json.autoformat = true
 -- ruby
 O.ruby.autoformat = true
 -- create custom autocommand field (This would be easy with lua)
+
+-- Turn off relative_numbers
+-- O.relative_number = false


### PR DESCRIPTION
moved the including of lv-settings to above the settings so local settings configured in lv-settings can override the globals that get loaded in settings, 0.relative_number for example