### PR TITLE
Use setlocal insted of set

### DIFF
--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -1,2 +1,2 @@
-set ts=2
-set sw=2             
+setl ts=2
+setl sw=2             

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -1,2 +1,2 @@
-set ts=2
-set sw=2             
+setl ts=2
+setl sw=2             

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,2 +1,2 @@
-set ts=2
-set sw=2             
+setl ts=2
+setl sw=2             

--- a/ftplugin/javascriptreact.vim
+++ b/ftplugin/javascriptreact.vim
@@ -1,3 +1,3 @@
-setlocal commentstring={/*%s*/}
-set ts=2
-set sw=2             
+setl commentstring={/*%s*/}
+setl ts=2
+setl sw=2             

--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -1,3 +1,2 @@
 set ts=2
 set sw=2             
-


### PR DESCRIPTION
If you are editing multiple files at the same time, set will make those options for all buffers, while setlocal will only enable options for that buffer.