### PR TITLE
Add setting to enable/disable document highlighting

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -100,8 +100,10 @@ local function documentHighlight(client, bufnr)
 end
 local lsp_config = {}
 
-function lsp_config.common_on_attach(client, bufnr)
-    documentHighlight(client, bufnr)
+if O.document_highlight then
+    function lsp_config.common_on_attach(client, bufnr)
+        documentHighlight(client, bufnr)
+    end
 end
 
 function lsp_config.tsserver_on_attach(client, bufnr)

--- a/lv-settings.lua
+++ b/lv-settings.lua
@@ -13,6 +13,7 @@ O.colorscheme = 'lunar'
 O.auto_close_tree = 0
 O.wrap_lines = false
 O.timeoutlen = 100
+O.document_highlight = true
 
 -- dashboard
 -- O.dashboard.custom_header = {""}


### PR DESCRIPTION
Document highlighting is a personal preference, like line wrapping, so this option allows it to be configured via lv-settings.lua.