### PR TITLE
Enable the fzy file sorter for telescope

### DIFF
--- a/lua/lv-telescope/init.lua
+++ b/lua/lv-telescope/init.lua
@@ -15,7 +15,7 @@ require('telescope').setup {
         sorting_strategy = "descending",
         layout_strategy = "horizontal",
         layout_defaults = {horizontal = {mirror = false}, vertical = {mirror = false}},
-        file_sorter = require'telescope.sorters'.get_fuzzy_file,
+        file_sorter = require'telescope.sorters'.get_fzy_sorter,
         file_ignore_patterns = {},
         generic_sorter = require'telescope.sorters'.get_generic_fuzzy_sorter,
         shorten_path = true,


### PR DESCRIPTION
The current telescope configuration doesn't appear to actually use the fzy file sorter even though it intends to (override_file_sorter = true).