### PR TITLE
bug fix for netrw's gx command

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -47,6 +47,11 @@ vim.api.nvim_set_keymap('x', 'J', ':move \'>+1<CR>gv-gv', {noremap = true, silen
 -- Better nav for omnicomplete
 vim.cmd('inoremap <expr> <c-j> (\"\\<C-n>\")')
 vim.cmd('inoremap <expr> <c-k> (\"\\<C-p>\")')
+
+-- fix to get netrw's gx command to work correctly 
+vim.api.nvim_set_keymap('n', 'gx', ":call netrw#BrowseX(expand((exists('g:netrw_gx')? g:netrw_gx : '<cfile>')),netrw#CheckIfRemote())<cr>", {noremap = true, silent = true})
+
+
 -- vim.cmd('inoremap <expr> <TAB> (\"\\<C-n>\")')
 -- vim.cmd('inoremap <expr> <S-TAB> (\"\\<C-p>\")')
 

--- a/lua/lv-globals.lua
+++ b/lua/lv-globals.lua
@@ -11,8 +11,8 @@ O = {
     number = true,
     relative_number = true,
     shell = 'bash',
-	timeoutlen = 100,
-    nvim_tree_disable_netrw = 0, -- "1 by default, disables netrw (must be set before plugin's packadd)
+	  timeoutlen = 100,
+    nvim_tree_disable_netrw = 0, 
 
     -- @usage pass a table with your desired languages
     treesitter = {

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -34,7 +34,9 @@ vim.wo.signcolumn = "yes" -- Always show the signcolumn, otherwise it would shif
 vim.o.updatetime = 300 -- Faster completion
 vim.o.timeoutlen = O.timeoutlen -- By default timeoutlen is 1000 ms
 vim.o.clipboard = "unnamedplus" -- Copy paste between vim and everything else
-vim.g.nvim_tree_disable_netrw = O.nvim_tree_disable_netrw
+vim.g.nvim_tree_disable_netrw = O.nvim_tree_disable_netrw -- enable netrw for remote gx gf support (must be set before plugin's packadd)
+vim.g.loaded_netrwPlugin = 1 -- needed for netrw gx command to open remote links in browser
+vim.cmd('filetype plugin on') -- filetype detection
 -- vim.o.guifont = "JetBrainsMono\\ Nerd\\ Font\\ Mono:h18"
 -- vim.o.guifont = "Hack\\ Nerd\\ Font\\ Mono"
 -- vim.o.guifont = "SauceCodePro Nerd Font:h17"


### PR DESCRIPTION
* open remote link in browser correctly with gx, not in a tmp file

apparently this is a long standing issue, but [this](https://github.com/vim/vim/issues/4738#issuecomment-845318201) seems to fix this bug. Now `gx` will open remote http links properly in the browser.  
