### PR TITLE
QuickFix quality of life

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -58,3 +58,6 @@ vim.cmd('inoremap <expr> <c-k> (\"\\<C-p>\")')
 -- map <leader>n <Plug>(miniyank-cycle)
 -- map <leader>N <Plug>(miniyank-cycleback)
 -- ]])
+
+-- Toggle the QuickFix window
+vim.api.nvim_set_keymap('', '<C-q>', ':call QuickFixToggle()<CR>', {noremap = true, silent = true})

--- a/lua/lv-autocommands/init.lua
+++ b/lua/lv-autocommands/init.lua
@@ -34,7 +34,8 @@ utils.define_augroups({
         {'BufWinEnter', '*', 'setlocal formatoptions-=c formatoptions-=r formatoptions-=o'},
         {'BufRead', '*', 'setlocal formatoptions-=c formatoptions-=r formatoptions-=o'},
         {'BufNewFile', '*', 'setlocal formatoptions-=c formatoptions-=r formatoptions-=o'},
-        {'VimLeavePre', '*', 'set title set titleold='}
+        {'VimLeavePre', '*', 'set title set titleold='},
+        {'FileType', 'qf', 'set nobuflisted'},
 
         -- {'User', 'GoyoLeave', 'lua require(\'galaxyline\').disable_galaxyline()'},
         -- {'User', 'GoyoEnter', 'lua require(\'galaxyline\').galaxyline_augroup()'},

--- a/vimscript/functions.vim
+++ b/vimscript/functions.vim
@@ -63,3 +63,11 @@ autocmd User GoyoLeave set laststatus=2
 
 " autocmd! User GoyoEnter lua require('galaxyline').disable_galaxyline()
 " autocmd! User GoyoLeave lua require('galaxyline').galaxyline_augroup()
+
+function! QuickFixToggle()
+    if empty(filter(getwininfo(), 'v:val.quickfix'))
+        copen
+    else
+        cclose
+    endif
+function


### PR DESCRIPTION
Including the quickfix buffer in the buffer list can lead to surprising circumstances where the quickfix buffer is displayed both in the typical place at the bottom of the UI and in the main window at the same time. Setting `nobuflisted` for quickfix buffers prevents this.

A mapping to toggle the quickfix window is also a relatively ubiquitous need, so this is also included.