### PR TITLE
Enable auto format on save with vim api autocmd.

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -73,12 +73,8 @@ vim.lsp.protocol.CompletionItemKind = {
     "   (TypeParameter)"
 }
 
---[[ " autoformat
-autocmd BufWritePre *.js lua vim.lsp.buf.formatting_sync(nil, 100)
-autocmd BufWritePre *.jsx lua vim.lsp.buf.formatting_sync(nil, 100)
-autocmd BufWritePre *.lua lua vim.lsp.buf.formatting_sync(nil, 100) ]]
--- Java
--- autocmd FileType java nnoremap ca <Cmd>lua require('jdtls').code_action()<CR>
+-- autoformat
+vim.api.nvim_command('autocmd BufWritePre *.rs,*.js,*.lua,*.jsx lua vim.lsp.buf.formatting_sync(nil, 500)')
 
 local function documentHighlight(client, bufnr)
     -- Set autocommands conditional on server_capabilities


### PR DESCRIPTION
This change enables auto formatting on save by using the vim api and creating an autocmd for the lsp (I have only tested it for rust).

I'm not really sure on how to allow the user to configure auto formatting for only certain file types.