### PR TITLE
Fix neovim installation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ git clone https://github.com/neovim/neovim --depth 1
 cd neovim
 sudo make CMAKE_BUILD_TYPE=Release install
 cd ..
-rm -rf neovim
+sudo rm -r neovim
 ```
 
 or if you are on Arch you can get it from the AUR


### PR DESCRIPTION
Got these on debian: `rm: cannot remove 'neovim/.deps/build/src/luajit/src/lib_init_dyn.o': Permission denied ...`