### PR TITLE
Change Workspace Symbols binding to Telescope DynamicFinder

### DIFF
--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -126,7 +126,7 @@ local mappings = {
         t = {"<cmd>LspTypeDefinition<cr>", "Type Definition"},
         x = {"<cmd>cclose<cr>", "Close Quickfix"},
         s = {"<cmd>Telescope lsp_document_symbols<cr>", "Document Symbols"},
-        S = {"<cmd>Telescope lsp_workspace_symbols<cr>", "Workspace Symbols"}
+        S = {"<cmd>Telescope lsp_dynamic_workspace_symbols<cr>", "Workspace Symbols"}
     },
     s = {
         name = "+Search",


### PR DESCRIPTION
This PR changes the which-key binding `<leader>lS` to the new Telescope DynamicFinder (`Telescope lsp_dynamic_workspace_symbols`), fixing https://github.com/ChristianChiarulli/LunarVim/issues/425 as suggested in the issue comments.