### PR TITLE
Add file types to terraform language server config

### DIFF
--- a/lua/lsp/terraform-ls.lua
+++ b/lua/lsp/terraform-ls.lua
@@ -1,4 +1,5 @@
 require'lspconfig'.terraformls.setup{
     cmd = {DATA_PATH .. "/lspinstall/terraform/terraform-ls", "serve"},
-    on_attach = require'lsp'.common_on_attach
+    on_attach = require'lsp'.common_on_attach,
+    filetypes = { "tf", "terraform", "hcl" }
 }


### PR DESCRIPTION
This PR adds terraform extension to the terraform-ls configuration, since no ls was being attached to the buffer.