### PR TITLE
Fix go root pattern in go ls setup

### DIFF
--- a/lua/lsp/go-ls.lua
+++ b/lua/lsp/go-ls.lua
@@ -1,7 +1,7 @@
 require'lspconfig'.gopls.setup{
     cmd = {DATA_PATH .. "/lspinstall/go/gopls"},
     settings = {gopls = {analyses = {unusedparams = true}, staticcheck = true}},
-    root_dir = require'lspconfig'.util.root_pattern(".git","go.mod","."),
+    root_dir = require'lspconfig'.util.root_pattern(".git","go.mod"),
     init_options = {usePlaceholders = true, completeUnimported = true},
     on_attach = require'lsp'.common_on_attach
 }


### PR DESCRIPTION
This PR removes "." from root pattern in the go ls setup.
This was causing nvim to  cwd after opening any `*.go` file in a project package, causing nvimtree to change directory  and making telescope finders unusable as well.

`go.mod` and `.git`  should be enough as project boundaries.