### PR TITLE
Update README.md with Discord/Matrix links and a "help" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,12 @@ Make sure you’re in normal mode not insert mode.
 | :messages                        | Print error messages. Useful when messages get cut off                                                                                                                                                                                                                                                                       |
 | :scriptnames                     | List all sourced files                                                                                                                                                                                                                                                                                                       |
 
+# Getting Help
+   
+* Check out the `#neovim` channel on the [Discord](https://discord.gg/Xb9B4Ny) or [lMatrix](https://matrix.to/#/+atmachine:matrix.org) server. There is a bridge between the Discord and Matrix server, so you only need to join one or the other! 
+* Check out the repos and communities specific to the plug-in in question. A lot of what LunarVim does is tie various plug-ins together
+* If all else fails, submit an issue.
+   
 # Uninstalling
 
 Changed your mind about LunarVim? To remove it entirely:


### PR DESCRIPTION
As I initially pointed out in #475, a lot of GH issues are probably better handled through some community. I was informed that it already existed, so this is just a update to the README pointing users to the Discord/Matrix server for help. I through in an additional two bullet points. Didn't want to be too rude, but many issues do seem to be better directed at the specific plug-in repos/communities and not here.