### PR TITLE
nvim-compe key map added

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -70,3 +70,12 @@ vim.cmd('vnoremap P "0P')
 
 -- Toggle the QuickFix window
 vim.api.nvim_set_keymap('', '<C-q>', ':call QuickFixToggle()<CR>', {noremap = true, silent = true})
+
+
+
+-- nvim-compe key map
+vim.cmd('inoremap <silent><expr> <C-Space> compe#complete()')
+vim.cmd("inoremap <silent><expr> <CR>      compe#confirm('<CR>')")
+vim.cmd("inoremap <silent><expr> <C-e>     compe#close('<C-e>')")
+vim.cmd("inoremap <silent><expr> <C-f>     compe#scroll({ 'delta': +4 })")
+vim.cmd("inoremap <silent><expr> <C-d>     compe#scroll({ 'delta': -4 })")


### PR DESCRIPTION
I realize that nvim-compe key map is missing. it should be in lua/keymappings.lua.
