### PR TITLE
Fix: Correctly require FTerm in plugins.lua

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -127,7 +127,7 @@ return require("packer").startup(function(use)
         use {'iamcco/markdown-preview.nvim', run = 'cd app && npm install', opt = true}
         require_plugin('markdown-preview.nvim')
         use {'numToStr/FTerm.nvim', opt = true}
-        require_plugin('numToStr/FTerm.nvim')
+        require_plugin('FTerm.nvim')
         use {'monaqa/dial.nvim', opt = true}
         require_plugin('dial.nvim')
         use {'nacro90/numb.nvim', opt = true}


### PR DESCRIPTION
It looks like `master` is not correctly loading `FTerm`, this is not a major issue because `FTerm` is not used in the base config. However, if people start to dip into `extras` they will get caught by this like I did