### PR TITLE
vscode use spacebar in other input

### DIFF
--- a/utils/vscode_config/keybindings.json
+++ b/utils/vscode_config/keybindings.json
@@ -165,7 +165,7 @@
   },
   {
     "key": "space",
-    "command": "whichkey.show && !inputFocus",
-    "when": "neovim.mode != 'insert'"
+    "command": "whichkey.show",
+    "when": "neovim.mode != 'insert' && !inputFocus"
   }
 ]

--- a/utils/vscode_config/keybindings.json
+++ b/utils/vscode_config/keybindings.json
@@ -165,7 +165,7 @@
   },
   {
     "key": "space",
-    "command": "whichkey.show",
+    "command": "whichkey.show && !inputFocus",
     "when": "neovim.mode != 'insert'"
   }
 ]


### PR DESCRIPTION
fixed use spacebar in other input(terminal, extensions, etc)
#217 
#256 
