### PR TITLE
WhichKey: Make <leader>h clear search instead of toggling highlight

### DIFF
--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -48,7 +48,7 @@ vim.api.nvim_set_keymap('n', '<Space>', '<NOP>', {noremap = true, silent = true}
 vim.g.mapleader = ' '
 
 -- no hl
-vim.api.nvim_set_keymap('n', '<Leader>h', ':set hlsearch!<CR>', {noremap = true, silent = true})
+vim.api.nvim_set_keymap('n', '<Leader>h', ':let @/=""<CR>', {noremap = true, silent = true})
 
 -- explorer
 vim.api.nvim_set_keymap('n', '<Leader>e', ':NvimTreeToggle<CR>', {noremap = true, silent = true})


### PR DESCRIPTION
This may be controversial because it changes the functionality from "toggle highlighting forever" to "clear highlighting / current search"

I think the latter is the more natural behaviour, however, feel free to reject this change. There is also the potential to bind the clear search to `<leader>n` to keep it in line with `n/N` keybinds for next/prev search.