### PR TITLE
Fix spectre

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -30,6 +30,7 @@ if O.extras then
     require('lv-dial')
     require('lv-hop')
     require('lv-colorizer')
+    require('lv-spectre')
     require('lv-symbols-outline')
 end
 

--- a/lua/lv-spectre/init.lua
+++ b/lua/lv-spectre/init.lua
@@ -1,0 +1,51 @@
+require('spectre').setup({
+ mapping={
+    ['toggle_line'] = {
+        map = "dd",
+        cmd = "<cmd>lua require('spectre').toggle_line()<CR>",
+        desc = "toggle current item"
+    },
+    ['enter_file'] = {
+        map = "<cr>",
+        cmd = "<cmd>lua require('spectre.actions').select_entry()<CR>",
+        desc = "goto current file"
+    },
+    ['send_to_qf'] = {
+        map = "<Blash>q",
+        cmd = "<cmd>lua require('spectre.actions').send_to_qf()<CR>",
+        desc = "send all item to quickfix"
+    },
+    ['replace_cmd'] = {
+        map = "<Bslash>c",
+        cmd = "<cmd>lua require('spectre.actions').replace_cmd()<CR>",
+        desc = "input replace vim command"
+    },
+    ['show_option_menu'] = {
+        map = "<Bslash>o",
+        cmd = "<cmd>lua require('spectre').show_options()<CR>",
+        desc = "show option"
+    },
+    ['run_replace'] = {
+        map = "<Bslash>R",
+        cmd = "<cmd>lua require('spectre.actions').run_replace()<CR>",
+        desc = "replace all"
+    },
+    ['change_view_mode'] = {
+        map = "<Bslash>v",
+        cmd = "<cmd>lua require('spectre').change_view()<CR>",
+        desc = "change result view mode"
+    },
+    ['toggle_ignore_case'] = {
+      map = "ti",
+      cmd = "<cmd>lua require('spectre').change_options('ignore-case')<CR>",
+      desc = "toggle ignore case"
+    },
+    ['toggle_ignore_hidden'] = {
+      map = "th",
+      cmd = "<cmd>lua require('spectre').change_options('hidden')<CR>",
+      desc = "toggle search hidden"
+    },
+    -- you can put your mapping here it only use normal mode
+  }
+})
+

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -47,37 +47,16 @@ local opts = {
 vim.api.nvim_set_keymap('n', '<Space>', '<NOP>', {noremap = true, silent = true})
 vim.g.mapleader = ' '
 
--- no hl
-vim.api.nvim_set_keymap('n', '<Leader>h', ':set hlsearch!<CR>', {noremap = true, silent = true})
-
--- explorer
-vim.api.nvim_set_keymap('n', '<Leader>e', ':NvimTreeToggle<CR>', {noremap = true, silent = true})
-
--- telescope
-vim.api.nvim_set_keymap('n', '<Leader>f', ':Telescope find_files<CR>', {noremap = true, silent = true})
-
--- dashboard
-vim.api.nvim_set_keymap('n', '<Leader>;', ':Dashboard<CR>', {noremap = true, silent = true})
-
--- Comments
-vim.api.nvim_set_keymap("n", "<leader>/", ":CommentToggle<CR>", {noremap = true, silent = true})
-vim.api.nvim_set_keymap("v", "<leader>/", ":CommentToggle<CR>", {noremap = true, silent = true})
-
--- close buffer
-vim.api.nvim_set_keymap("n", "<leader>c", ":BufferClose<CR>", {noremap = true, silent = true})
-
--- open projects
-vim.api.nvim_set_keymap('n', '<leader>p', ":lua require'telescope'.extensions.project.project{}<CR>",
-                        {noremap = true, silent = true})
 -- TODO create entire treesitter section
 
 local mappings = {
-    ["/"] = "Comment",
-    ["c"] = "Close Buffer",
-    ["e"] = "Explorer",
-    ["f"] = "Find File",
-    ["h"] = "No Highlight",
-    ["p"] = "Projects",
+    ["/"] = {"<cmd>CommentToggle<cr>", "Comment"},
+    [";"] = {"<cmd>Dashboard<cr>", "Dashboard"},
+    ["c"] = {"<cmd>BufferClose<cr>", "Close Buffer"},
+    ["e"] = {"<cmd>NvimTreeToggle<cr>", "Explorer"},
+    ["f"] = {"<cmd>Telescope find_files<cr>", "Find File"},
+    ["h"] = {"<cmd>set hlsearch!<cr>", "No Highlight"},
+    ["p"] = {"<cmd>lua require'telescope'.extensions.project.project{}<cr>", "Projects"},
     d = {
         name = "+Diagnostics",
         t = {"<cmd>TroubleToggle<cr>", "trouble"},
@@ -128,6 +107,11 @@ local mappings = {
         s = {"<cmd>Telescope lsp_document_symbols<cr>", "Document Symbols"},
         S = {"<cmd>Telescope lsp_dynamic_workspace_symbols<cr>", "Workspace Symbols"}
     },
+    r = {
+        name = "+Replace",
+        f = {"<cmd>lua require('spectre').open_file_search()<cr>", "Current File"},
+        p = {"<cmd>lua require('spectre').open()<cr>", "Project"}
+    },
     s = {
         name = "+Search",
         b = {"<cmd>Telescope git_branches<cr>", "Checkout branch"},
@@ -152,5 +136,25 @@ local mappings = {
     }
 }
 
+local visualOpts = {
+    mode = "v", -- Visual mode
+    prefix = "<leader>",
+    buffer = nil, -- Global mappings. Specify a buffer number for buffer local mappings
+    silent = true, -- use `silent` when creating keymaps
+    noremap = true, -- use `noremap` when creating keymaps
+    nowait = false -- use `nowait` when creating keymaps
+}
+
+local visualMappings = {
+    ["/"] = {"<cmd>CommentToggle<cr>", "Comment"},
+    r = {
+        name = "+Replace",
+        f = {"<cmd>lua require('spectre').open_visual({path = vim.fn.expand('%')})<cr>", "File"},
+        p = {"<cmd>lua require('spectre').open_visual()<cr>", "Project"}
+    }
+}
+
 local wk = require("which-key")
 wk.register(mappings, opts)
+wk.register(visualMappings, visualOpts)
+

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -58,16 +58,16 @@ local mappings = {
     ["h"] = {"<cmd>set hlsearch!<cr>", "No Highlight"},
     ["p"] = {"<cmd>lua require'telescope'.extensions.project.project{}<cr>", "Projects"},
     d = {
-        name = "+Diagnostics",
+        name = "Diagnostics",
         t = {"<cmd>TroubleToggle<cr>", "trouble"},
         w = {"<cmd>TroubleToggle lsp_workspace_diagnostics<cr>", "workspace"},
         d = {"<cmd>TroubleToggle lsp_document_diagnostics<cr>", "document"},
         q = {"<cmd>TroubleToggle quickfix<cr>", "quickfix"},
         l = {"<cmd>TroubleToggle loclist<cr>", "loclist"},
-        r = {"<cmd>TroubleToggle lsp_references<cr>", "references"},
+        r = {"<cmd>TroubleToggle lsp_references<cr>", "references"}
     },
     D = {
-        name = "+Debug",
+        name = "Debug",
         b = {"<cmd>DebugToggleBreakpoint<cr>", "Toggle Breakpoint"},
         c = {"<cmd>DebugContinue<cr>", "Continue"},
         i = {"<cmd>DebugStepInto<cr>", "Step Into"},
@@ -76,7 +76,7 @@ local mappings = {
         s = {"<cmd>DebugStart<cr>", "Start"}
     },
     g = {
-        name = "+Git",
+        name = "Git",
         j = {"<cmd>NextHunk<cr>", "Next Hunk"},
         k = {"<cmd>PrevHunk<cr>", "Prev Hunk"},
         p = {"<cmd>PreviewHunk<cr>", "Preview Hunk"},
@@ -87,10 +87,10 @@ local mappings = {
         o = {"<cmd>Telescope git_status<cr>", "Open changed file"},
         b = {"<cmd>Telescope git_branches<cr>", "Checkout branch"},
         c = {"<cmd>Telescope git_commits<cr>", "Checkout commit"},
-        C = {"<cmd>Telescope git_bcommits<cr>", "Checkout commit(for current file)"},
+        C = {"<cmd>Telescope git_bcommits<cr>", "Checkout commit(for current file)"}
     },
     l = {
-        name = "+LSP",
+        name = "LSP",
         a = {"<cmd>Lspsaga code_action<cr>", "Code Action"},
         A = {"<cmd>Lspsaga range_code_action<cr>", "Selected Action"},
         d = {"<cmd>Telescope lsp_document_diagnostics<cr>", "Document Diagnostics"},
@@ -108,12 +108,12 @@ local mappings = {
         S = {"<cmd>Telescope lsp_dynamic_workspace_symbols<cr>", "Workspace Symbols"}
     },
     r = {
-        name = "+Replace",
+        name = "Replace",
         f = {"<cmd>lua require('spectre').open_file_search()<cr>", "Current File"},
         p = {"<cmd>lua require('spectre').open()<cr>", "Project"}
     },
     s = {
-        name = "+Search",
+        name = "Search",
         b = {"<cmd>Telescope git_branches<cr>", "Checkout branch"},
         c = {"<cmd>Telescope colorscheme<cr>", "Colorscheme"},
         d = {"<cmd>Telescope lsp_document_diagnostics<cr>", "Document Diagnostics"},
@@ -125,14 +125,17 @@ local mappings = {
         R = {"<cmd>Telescope registers<cr>", "Registers"},
         t = {"<cmd>Telescope live_grep<cr>", "Text"}
     },
-    S = {name = "+Session", s = {"<cmd>SessionSave<cr>", "Save Session"}, l = {"<cmd>SessionLoad<cr>", "Load Session"}},
-
+    S = {
+        name = "Session",
+        s = {"<cmd>SessionSave<cr>", "Save Session"},
+        l = {"<cmd>SessionLoad<cr>", "Load Session"}
+    },
     -- extras
     z = {
-        name = "+Zen",
+        name = "Zen",
         s = {"<cmd>TZBottom<cr>", "toggle status line"},
         t = {"<cmd>TZTop<cr>", "toggle tab bar"},
-        z = {"<cmd>TZAtaraxis<cr>", "toggle zen"},
+        z = {"<cmd>TZAtaraxis<cr>", "toggle zen"}
     }
 }
 
@@ -148,7 +151,7 @@ local visualOpts = {
 local visualMappings = {
     ["/"] = {"<cmd>CommentToggle<cr>", "Comment"},
     r = {
-        name = "+Replace",
+        name = "Replace",
         f = {"<cmd>lua require('spectre').open_visual({path = vim.fn.expand('%')})<cr>", "File"},
         p = {"<cmd>lua require('spectre').open_visual()<cr>", "Project"}
     }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -142,7 +142,7 @@ return require("packer").startup(function(use)
         use {'norcalli/nvim-colorizer.lua', opt = true}
         require_plugin('nvim-colorizer.lua')
         use {'windwp/nvim-spectre', opt = true}
-        require_plugin('windwp/nvim-spectre')
+        require_plugin('nvim-spectre')
         use {'simrat39/symbols-outline.nvim', opt = true}
         require_plugin('symbols-outline.nvim')
         use {'nvim-treesitter/playground', opt = true}


### PR DESCRIPTION
Correctly load the Spectre plugin + add which-key integrations.

I configured the backlash key for Spectre options (leader is the default) as otherwise, key descriptions like "require('spectre.actions').replace_cmd()" are mixed with the which-key mappings (ugly). Also, Spectre options are only available from the buffer it opens.

I also took some time to refactor which-key mappings definitions to explicitly split normal from visual mappings.

IMO the plugin has some flows and could be improved, but it's already a good starting point.