### PR TITLE
Fix barbar integration with nvim-tree

### DIFF
--- a/lua/lv-nvimtree/init.lua
+++ b/lua/lv-nvimtree/init.lua
@@ -20,6 +20,7 @@ vim.g.nvim_tree_indent_markers = 1 -- "0 by default, this option shows indent ma
 vim.g.nvim_tree_follow = 1 -- "0 by default, this option allows the cursor to be updated when entering a buffer
 vim.g.nvim_tree_auto_close = O.auto_close_tree -- 0 by default, closes the tree when it's the last window
 vim.g.nvim_tree_auto_ignore_ft = 'startify' --empty by default, don't auto open tree on specific filetypes.
+vim.g.nvim_tree_quit_on_open = 0 -- this doesn't play well with barbar
 local tree_cb = require'nvim-tree.config'.nvim_tree_callback
     vim.g.nvim_tree_bindings = {
       -- ["<CR>"] = ":YourVimFunction()<cr>",
@@ -63,3 +64,19 @@ vim.g.nvim_tree_icons = {
     git = {unstaged = "", staged = "✓", unmerged = "", renamed = "➜", untracked = ""},
     folder = {default = "", open = "", empty = "", empty_open = "", symlink = ""}
 }
+
+local view = require'nvim-tree.view'
+
+local _M = {}
+_M.toggle_tree = function()
+  if view.win_open() then
+    require'nvim-tree'.close()
+    require'bufferline.state'.set_offset(0)
+  else
+    require'bufferline.state'.set_offset(31, 'File Explorer')
+    require'nvim-tree'.find_file(true)
+  end
+
+end
+
+return _M

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -51,7 +51,7 @@ vim.g.mapleader = ' '
 vim.api.nvim_set_keymap('n', '<Leader>h', ':set hlsearch!<CR>', {noremap = true, silent = true})
 
 -- explorer
-vim.api.nvim_set_keymap('n', '<Leader>e', ':NvimTreeToggle<CR>', {noremap = true, silent = true})
+vim.api.nvim_set_keymap('n', '<Leader>e', ":lua require'lv-nvimtree'.toggle_tree()<CR>", {noremap = true, silent = true})
 
 -- telescope
 vim.api.nvim_set_keymap('n', '<Leader>f', ':Telescope find_files<CR>', {noremap = true, silent = true})
@@ -78,6 +78,16 @@ local mappings = {
     ["f"] = "Find File",
     ["h"] = "No Highlight",
     ["p"] = "Projects",
+    b = {
+      name = "+Buffers",
+      j = {"<cmd>BufferPick<cr>", "jump to buffer"},
+      w = {"<cmd>BufferWipeout<cr>", "wipeout buffer"},
+      e = {"<cmd>BufferCloseAllButCurrent<cr>", "close all but current buffer"},
+      h = {"<cmd>BufferCloseBuffersLeft<cr>", "close all buffers to the left"},
+      l = {"<cmd>BufferCloseBuffersRight<cr>", "close all BufferLines to the right"},
+      D = {"<cmd>BufferOrderByDirectory<cr>", "sort BufferLines automatically by directory"},
+      L = {"<cmd>BufferOrderByLanguage<cr>", "sort BufferLines automatically by language"},
+    },
     d = {
         name = "+Diagnostics",
         t = {"<cmd>TroubleToggle<cr>", "trouble"},


### PR DESCRIPTION
- Add an offset to display NvimTree buffer in barbar.
_It won't work correctly if you enable "vim.g.nvim_tree_quit_on_open"._
- Add which-key support to barbar to enable missing mappings.
