### PR TITLE
Allow cursorline option to be configured by lv-settings

### DIFF
--- a/lua/lv-globals.lua
+++ b/lua/lv-globals.lua
@@ -10,6 +10,7 @@ O = {
     wrap_lines = false,
     number = true,
     relative_number = true,
+    cursorline = true,
     shell = 'bash',
 	timeoutlen = 100,
     nvim_tree_disable_netrw = 0,

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -25,7 +25,7 @@ vim.cmd('set expandtab') -- Converts tabs to spaces
 vim.bo.smartindent = true -- Makes indenting smart
 vim.wo.number = O.number -- set numbered lines
 vim.wo.relativenumber = O.relative_number -- set relative number
-vim.wo.cursorline = true -- Enable highlighting of the current line
+vim.wo.cursorline = O.cursorline -- set highlighting of the current line
 vim.o.showtabline = 2 -- Always show tabs
 vim.o.showmode = false -- We don't need to see things like -- INSERT -- anymore
 vim.o.backup = false -- This is recommended by coc

--- a/lv-settings.lua
+++ b/lv-settings.lua
@@ -68,3 +68,6 @@ O.go.autoformat = true
 
 -- Turn off relative_numbers
 -- O.relative_number = false
+
+-- Turn off cursorline
+-- O.cursorline = false


### PR DESCRIPTION
Cursorline is another one of those options that some people really like and others really hate. Providing a toggle for it in lv-settings without changing the current default allows those in the latter camp to quickly set their preference.