### PR TITLE
galaxyline themes for gruvbox and nvcode, restoring cursor shape

### DIFF
--- a/lua/lv-galaxyline/init.lua
+++ b/lua/lv-galaxyline/init.lua
@@ -21,6 +21,52 @@ local colors = {
     error_red = '#F44747',
     info_yellow = '#FFCC66'
 }
+
+-- galaxyline themes for Gruvbox and NVCode.
+-- Uncomment and change 'colors_colorschemeName'
+-- to 'colors' to enable.
+
+-- Colors for Gruvbox
+-- local colors_gruvbox = {
+--     bg = '#32302F',
+--     yellow = '#FABD2F',
+--     dark_yellow = '#D79921',
+--     cyan = '#689D6A',
+--     green = '#608B4E',
+--     light_green = '#B8BB26',
+--     string_orange = '#D65D0E',
+--     orange = '#FE8019',
+--     purple = '#B16286',
+--     magenta = '#D3869B',
+--     grey = '#A89984',
+--     blue = '#458588',
+--     -- vivid_blue = '#4FC1FF',
+--     light_blue = '#83A598',
+--     red = '#FB4834',
+--     error_red = '#CC241D',
+--     info_yellow = '#D79921'
+-- }
+-- colors for NVCode theme (very minimal changes)
+-- local colors_nvcode = {
+--     bg = '#2E2E2E',
+--     yellow = '#DCDCAA',
+--     dark_yellow = '#D7BA7D',
+--     cyan = '#4EC9B0',
+--     green = '#608B4E',
+--     light_green = '#B5CEA8',
+--     string_orange = '#CE9178',
+--     orange = '#FF8800',
+--     purple = '#C586C0',
+--     magenta = '#D16D9E',
+--     grey = '#729CB3',
+--     blue = '#569CD6',
+--     vivid_blue = '#4FC1FF',
+--     light_blue = '#9CDCFE',
+--     red = '#D16969',
+--     error_red = '#F44747',
+--     info_yellow = '#FFCC66'
+-- }
+
 local condition = require('galaxyline.condition')
 local gls = gl.section
 gl.short_line_list = {'NvimTree', 'vista', 'dbui', 'packer'}

--- a/lv-config.lua
+++ b/lv-config.lua
@@ -78,3 +78,16 @@ O.lang.go.autoformat = true
 
 -- Turn off cursorline
 -- O.cursorline = false
+
+-- Neovim turns the default cursor to 'Block' 
+-- when switched back into terminal.
+-- This below line fixes that. Uncomment if needed.
+
+-- vim.cmd('autocmd VimLeave,VimSuspend * set guicursor=a:ver90') -- Beam
+-- vim.cmd('autocmd VimLeave,VimSuspend * set guicursor=a:hor20') -- Underline
+
+-- NOTE: Above code doesn't take a value from the terminal's cursor and
+--       replace it. It hardcodes the cursor shape.
+--       And I think `ver` means vertical and `hor` means horizontal.
+--       The numbers didn't make a difference in alacritty. Please change
+--       the number to something that suits your needs if it looks weird.


### PR DESCRIPTION
I made two changes.

1. Added suitable galaxyline themes for the colorschemes `gruvbox` and `nvcode`.
2. Added two lines of code to restore cursor position to beam/underline since neovim changes cursor style and won't switch back after quitting.

Hope this is useful. Thanks :)