### PR TITLE
Add dashboard entry to search nvim config files

### DIFF
--- a/lua/lv-dashboard/init.lua
+++ b/lua/lv-dashboard/init.lua
@@ -45,6 +45,10 @@ M.config = function()
         e = {
             description = {'  Settings           '},
             command = ':e ' .. CONFIG_PATH .. '/lv-config.lua'
+        },
+        f = {
+            description = {'  Neovim Config Files'},
+            command = 'lua require(\'telescope.builtin\').find_files({search_dirs = {"~/.config/nvim"}})'
         }
         -- e = {description = {'  Marks              '}, command = 'Telescope marks'}
     }


### PR DESCRIPTION
This entry allows quick access to the neovim config files from anywhere. I find that I'm typically inspired to make changes to my nvim config when I run into something that irritates/annoys me while working on other projects. Having this dashboard entry allows me to open the relevant file, make the change, and get back to work with minimal context switching.