### PR TITLE
fixes indenting by adding compe setup in autopairs config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,6 @@ require('lv-utils')
 require('keymappings')
 require('lv-galaxyline')
 require('lv-treesitter')
-require('lv-autopairs')
 require('lv-which-key')
 
 -- LSP

--- a/lua/lv-autopairs/init.lua
+++ b/lua/lv-autopairs/init.lua
@@ -19,7 +19,10 @@ MUtils.completion_confirm=function()
 end
 
 
-remap('i' , '<CR>','v:lua.MUtils.completion_confirm()', {expr = true , noremap = true})
+require("nvim-autopairs.completion.compe").setup({
+  map_cr = true, --  map <CR> on insert mode
+  map_complete = true -- it will auto insert `(` after select function or method item
+})
 
 npairs.setup({
     check_ts = true,

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -47,7 +47,6 @@ return require("packer").startup(function(use)
     -- Autocomplete
     use {
         "hrsh7th/nvim-compe",
-        event = "InsertEnter",
         config = function()
             require("lv-compe").config()
         end
@@ -80,7 +79,9 @@ return require("packer").startup(function(use)
     use {"folke/which-key.nvim"}
 
     -- Autopairs
-    use {"windwp/nvim-autopairs"}
+    use {"windwp/nvim-autopairs",
+        config = function() require'lv-autopairs' end
+    }
 
     -- Comments
     use {


### PR DESCRIPTION
Fixes issue https://github.com/ChristianChiarulli/LunarVim/issues/563

Autopairs replaced the old style of carriage return bindings with a setup function for compe.  Implemented the new setup.  I also had to disable lazy loading for compe since I could only make the two plugins work together if they are both loaded at start.  

