### PR TITLE
Adding DAPInstall.nvim

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -61,7 +61,8 @@ O = {
         lush = {active = false},
         diffview = {active = false},
         bracey = {active = false},
-        telescope_project = {active = false}
+        telescope_project = {active = false},
+        dap_install = {active = false}
 
     },
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -399,6 +399,12 @@ return require("packer").startup(function(use)
         run = 'npm install --prefix server',
         disable = not O.plugin.bracey.active
     }
+    -- Debugger management
+    use {
+        'Pocco81/DAPInstall.nvim',
+        event = "BufRead",
+        disable = not O.plugin.dap_install.active
+    }
 
     -- LANGUAGE SPECIFIC GOES HERE
 


### PR DESCRIPTION
This solves #574

you can enable the plugin by appending the following line to `lv-config.lua` and then running `:PackerSync`

```lua
O.plugin.dap_install.active = true
```

Afterward, while opening a file, you can install new debuggers using:
```
:DIInstall python_dbg
```
For a complete list of supported Debuggers , check [this](https://github.com/Pocco81/DAPInstall.nvim#list-of-debuggers) out 