### PR TITLE
Add snap as an optional alternative to telescope

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -50,6 +50,7 @@ O = {
         codi = {active = false},
         telescope_fzy = {active = false},
         sanegx = {active = false},
+        snap = {active = false},
         ranger = {active = false},
         todo_comments = {active = false},
         lsp_colors = {active = false},

--- a/lua/lv-snap/init.lua
+++ b/lua/lv-snap/init.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+M.config = function()
+    local snap = require "snap"
+    local layout = snap.get"layout".bottom
+    local file = snap.config.file:with {consumer = "fzy", layout = layout}
+    local vimgrep = snap.config.vimgrep:with {layout = layout}
+    snap.register.command("find_files", file {producer = "ripgrep.file"})
+    snap.register.command("buffers", file {producer = "vim.buffer"})
+    snap.register.command("oldfiles", file {producer = "vim.oldfile"})
+    snap.register.command("live_grep", vimgrep {})
+end
+
+return M

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -68,9 +68,14 @@ vim.api.nvim_set_keymap('n', '<Leader>e',
 --                         ":NvimTreeToggle<CR>",
 --                         {noremap = true, silent = true})
 
--- telescope
-vim.api.nvim_set_keymap('n', '<Leader>f', ':Telescope find_files<CR>',
-                        {noremap = true, silent = true})
+-- telescope or snap
+if O.plugin.snap.active then
+    vim.api.nvim_set_keymap('n', '<Leader>f', ':Snap find_files<CR>',
+                            {noremap = true, silent = true})
+else
+    vim.api.nvim_set_keymap('n', '<Leader>f', ':Telescope find_files<CR>',
+                            {noremap = true, silent = true})
+end
 
 -- dashboard
 vim.api.nvim_set_keymap('n', '<Leader>;', ':Dashboard<CR>',
@@ -98,7 +103,7 @@ local mappings = {
     b = {
         name = "Buffers",
         j = {"<cmd>BufferPick<cr>", "jump to buffer"},
-        f = {"<cmd>Telescope buffers<cr>", "Find buffer"},
+        f = {O.plugin.snap.active and "<cmd>Snap buffers<cr>" or "<cmd>Telescope buffers<cr>", "Find buffer"},
         w = {"<cmd>BufferWipeout<cr>", "wipeout buffer"},
         e = {
             "<cmd>BufferCloseAllButCurrent<cr>", "close all but current buffer"
@@ -233,13 +238,13 @@ local mappings = {
         --     "<cmd>Telescope lsp_workspace_diagnostics<cr>",
         --     "Workspace Diagnostics"
         -- },
-        f = {"<cmd>Telescope find_files<cr>", "Find File"},
+        f = {O.plugin.snap.active and "<cmd>Snap find_files<cr>" or "<cmd>Telescope find_files<cr>", "Find File"},
         h = {"<cmd>Telescope help_tags<cr>", "Find Help"},
         -- m = {"<cmd>Telescope marks<cr>", "Marks"},
         M = {"<cmd>Telescope man_pages<cr>", "Man Pages"},
-        r = {"<cmd>Telescope oldfiles<cr>", "Open Recent File"},
+        r = {O.plugin.snap.active and "<cmd>Snap oldfiles<cr>" or "<cmd>Telescope oldfiles<cr>", "Open Recent File"},
         R = {"<cmd>Telescope registers<cr>", "Registers"},
-        t = {"<cmd>Telescope live_grep<cr>", "Text"}
+        t = {O.plugin.snap.active and "<cmd>Snap live_grep<cr>" or "<cmd>Telescope live_grep<cr>", "Text"}
     },
     S = {
         name = "Session",

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -45,6 +45,15 @@ return require("packer").startup(function(use)
         config = [[require('lv-telescope')]],
         cmd = "Telescope"
     }
+    -- Snap
+    use {
+        "camspiers/snap",
+        rocks = "fzy",
+        config = function()
+          require("lv-snap").config()
+        end,
+        disable = not O.plugin.snap.active,
+    }
     -- Autocomplete
     use {
         "hrsh7th/nvim-compe",


### PR DESCRIPTION
Worth testing it first of course, but this is a first pass at adding snap as an optional plugin, if enabled it will use the same bindings as Telescope does, at least for the a subset of Telescopes features. I can follow up with the other features that Snap supports and more, like grepping under cursor, grepping selection, etc.

It works for me locally, but please test.