### PR TITLE
[CONFIG] No default for leader_key.

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -18,6 +18,7 @@ O = {
     ignore_case = true,
     smart_case = true,
     lushmode = false,
+    leader_key = "space";
 
     -- @usage pass a table with your desired languages
     treesitter = {


### PR DESCRIPTION
Currently there is no default leader_key set, which causes the which-key config to break if 
there is no lv-config.lua file in the users config dir.

