### PR TITLE
[LSP] clang - Better defaults for clangd.

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -1,5 +1,13 @@
+local clangd_flags = {"--background-index"};
+
+if O.lang.clang.cross_file_rename then
+   table.insert(clangd_flags, "--cross-file-rename")
+end
+
+table.insert(clangd_flags, "--header-insertion=" .. O.lang.clang.header_insertion)
+
 require'lspconfig'.clangd.setup {
-    cmd = {DATA_PATH .. "/lspinstall/cpp/clangd/bin/clangd"},
+    cmd = {DATA_PATH .. "/lspinstall/cpp/clangd/bin/clangd",  unpack(clangd_flags)},
     on_attach = require'lsp'.common_on_attach,
     handlers = {
         ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -143,7 +143,9 @@ O = {
             diagnostics = {
                 virtual_text = {spacing = 0, prefix = ""},
                 signs = true,
-                underline = true
+                underline = true,
+                cross_file_rename = true,
+                header_insertion = 'never'
             }
         },
         ruby = {

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -40,9 +40,9 @@ O.treesitter.ensure_installed = "all"
 O.treesitter.ignore_install = {"haskell"}
 O.treesitter.highlight.enabled = true
 
-O.lang.clang.diagnostics.virtual_text = false
-O.lang.clang.diagnostics.signs = false
-O.lang.clang.diagnostics.underline = false
+O.lang.clang.diagnostics.virtual_text = true
+O.lang.clang.diagnostics.signs = true
+O.lang.clang.diagnostics.underline = true
 
 -- python
 -- add things like O.python.formatter.yapf.exec_path


### PR DESCRIPTION
This improves the default config for C/C++.

I've also enable cross-file rename, which allows an lsp rename to work across an entire project.
Table insertion is set to never by default, and can be customised by the user.

