### PR TITLE
indent-blankline.nvim lua branch has been merged into master

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -221,7 +221,6 @@ return require("packer").startup(function(use)
 
     use {
         "lukas-reineke/indent-blankline.nvim",
-        branch = "lua",
         event = "BufRead",
         setup = function()
 


### PR DESCRIPTION
We no longer need to use the `lua` branch, it has been [merged](https://github.com/lukas-reineke/indent-blankline.nvim/commit/bbf592143b366e1bd20cffb5e84a9df6dfcc77d2) into `master`