### PR TITLE
Cleaner and Faster `settings.lua` File

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1,6 +1,7 @@
 CONFIG_PATH = vim.fn.stdpath('config')
 DATA_PATH = vim.fn.stdpath('data')
 CACHE_PATH = vim.fn.stdpath('cache')
+TERMINAL = vim.fn.expand('$TERMINAL')
 
 O = {
     auto_close_tree = 0,
@@ -18,6 +19,7 @@ O = {
     ignore_case = true,
     smart_case = true,
     lushmode = false,
+    hl_search = false,
     leader_key = "space";
 
     -- @usage pass a table with your desired languages
@@ -188,8 +190,7 @@ O = {
             formatter = '',
             autoformat = false,
             virtual_text = true
-        },
-        zig = {}
+        }
 
     },
 

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,50 +1,58 @@
-vim.cmd('set iskeyword+=-') -- treat dash separated words as a word text object" 
-vim.opt.shortmess:append("c") -- Don't pass messages to |ins-completion-menu|.
-vim.cmd('set inccommand=split') -- Make substitution work in realtime
-vim.o.hidden = O.hidden_files -- Required to keep multiple buffers open multiple buffers
-vim.o.title = true
-TERMINAL = vim.fn.expand('$TERMINAL')
-vim.cmd('let &titleold="'..TERMINAL..'"')
-vim.o.titlestring="%<%F%=%l/%L - nvim"
-vim.wo.wrap = O.wrap_lines -- Display long lines as just one line
-vim.cmd('set whichwrap+=<,>,[,],h,l') -- move to next line with theses keys
-vim.o.pumheight = 10 -- Makes popup menu smaller
-vim.o.fileencoding = "utf-8" -- The encoding written to file
-vim.o.cmdheight = 2 -- More space for displaying messages
-vim.cmd('set colorcolumn=99999') -- fix indentline for now
-vim.o.mouse = "a" -- Enable your mouse
-vim.o.splitbelow = true -- Horizontal splits will automatically be below
-vim.o.termguicolors = true -- set term gui colors most terminals support this
-vim.o.splitright = true -- Vertical splits will automatically be to the right
--- vim.o.t_Co = "256" -- Support 256 colors
-vim.o.conceallevel = 0 -- So that I can see `` in markdown files
-vim.opt.tabstop = 4 -- Insert 2 spaces for a tab
-vim.opt.shiftwidth = 4 -- Change the number of space characters inserted for indentation
---vim.opt.softtabstop = 4
-vim.opt.expandtab = true -- Converts tabs to spaces
-vim.o.completeopt = "menuone,noselect"
-vim.bo.smartindent = true -- Makes indenting smart
-vim.wo.number = O.number -- set numbered lines
-vim.wo.relativenumber = O.relative_number -- set relative number
-vim.wo.cursorline = O.cursorline -- set highlighting of the current line
-vim.o.showtabline = 2 -- Always show tabs
-vim.o.showmode = false -- We don't need to see things like -- INSERT -- anymore
-vim.o.backup = false -- This is recommended by coc
-vim.o.writebackup = false -- This is recommended by coc
-vim.o.swapfile = false -- Do not write any swp files
-vim.o.undodir = CACHE_PATH .. '/undo' -- Set undo directory
-vim.o.undofile = true -- Enable persistent undo
-vim.wo.signcolumn = "yes" -- Always show the signcolumn, otherwise it would shift the text each time
-vim.o.updatetime = 300 -- Faster completion
-vim.o.timeoutlen = O.timeoutlen -- By default timeoutlen is 1000 ms
-vim.o.clipboard = "unnamedplus" -- Copy paste between vim and everything else
--- vim.g.nvim_tree_disable_netrw = O.nvim_tree_disable_netrw -- enable netrw for remote gx gf support (must be set before plugin's packadd)
-vim.cmd('filetype plugin on') -- filetype detection
--- vim.o.guifont = "JetBrainsMono\\ Nerd\\ Font\\ Mono:h18"
--- vim.o.guifont = "Hack\\ Nerd\\ Font\\ Mono"
--- vim.o.guifont = "SauceCodePro Nerd Font:h17"
-vim.o.guifont = "FiraCode Nerd Font:h17"
+---  HELPERS  ---
 
--- vim.o.guifont = "JetBrains\\ Mono\\ Regular\\ Nerd\\ Font\\ Complete"
-vim.o.ignorecase = O.ignore_case
-vim.o.smartcase = O.smart_case
+
+local cmd = vim.cmd
+local opt = vim.opt
+
+
+---  VIM ONLY COMMANDS  ---
+
+
+cmd('filetype plugin on')               -- filetype detection
+cmd('let &titleold="'..TERMINAL..'"')   
+cmd('set inccommand=split')             -- show what you are substituting in real time
+cmd('set iskeyword+=-')                 -- treat dash as a separate word
+cmd('set whichwrap+=<,>,[,],h,l')       -- move to next line with theses keys
+
+
+---  SETTINGS  ---
+
+
+opt.backup          = false                     -- creates a backup file
+opt.clipboard       = "unnamedplus"             -- allows neovim to access the system clipboard
+opt.cmdheight       = 2                         -- more space in the neovim command line for displaying messages
+opt.colorcolumn     = "99999"                   -- fix indentline for now
+opt.completeopt     = {'menuone', 'noselect'}
+opt.conceallevel    = 0                         -- so that `` is visible in markdown files
+opt.fileencoding    = "utf-8"                   -- the encoding written to a file
+opt.guifont         = "monospace:h17"           -- the font used in graphical neovim applications
+opt.hidden          = O.hidden_files            -- required to keep multiple buffers and open multiple buffers
+opt.hlsearch        = O.hl_search               -- highlight all matches on previous search pattern
+opt.ignorecase      = O.ignore_case             -- ignore case in search patterns
+opt.mouse           = "a"                       -- allow the mouse to be used in neovim
+opt.pumheight       = 10                        -- pop up menu height
+opt.showmode        = false                     -- we don't need to see things like -- INSERT -- anymore
+opt.showtabline     = 2                         -- always show tabs
+opt.smartcase       = O.smart_case              -- smart case
+opt.smartindent     = true                      -- make indenting smarter again
+opt.splitbelow      = true                      -- force all horizontal splits to go below current window
+opt.splitright      = true                      -- force all vertical splits to go to the right of current window
+opt.swapfile        = false                     -- creates a swapfile
+opt.termguicolors   = true                      -- set term gui colors (most terminals support this)
+opt.timeoutlen      = O.timeoutlen              -- time to wait for a mapped sequence to complete (in milliseconds)
+opt.title           = true                      -- set the title of window to the value of the titlestring
+opt.titlestring     = "%<%F%=%l/%L - nvim"      -- what the title of the window will be set to
+opt.undodir         = CACHE_PATH .. '/undo'     -- set an undo directory
+opt.undofile        = true                      -- enable persisten undo
+opt.updatetime      = 300                       -- faster completion
+opt.writebackup     = false                     -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
+opt.expandtab       = true                      -- convert tabs to spaces
+opt.shiftwidth      = 4                         -- the number of spaces inserted for each indentation
+opt.shortmess:append("c")                       -- don't pass messages to |ins-completion-menu|
+opt.tabstop         = 4                         -- insert 4 spaces for a tab
+opt.cursorline      = O.cursorline              -- highlight the current line
+opt.number          = O.number                  -- set numbered lines
+opt.relativenumber  = O.relative_number         -- set relative numbered lines
+opt.signcolumn      = "yes"                     -- always show the sign column, otherwise it would shift the text each time
+opt.wrap            = O.wrap_lines              -- display lines as one long line
+


### PR DESCRIPTION
Before, the `settings.lua` file was quite messy and was hard to understand. It also used a mixture of `vim.o`, `vim.wo`, `vim.bo`, and `vim.opt`, when everything could just be placed with `vim.opt`.

This (for my slow and crispy computer) had shaved off 14 milliseconds (average of100 takes of all vim.opt `-` average of 100 takes of current). But even if this doesn't make much of a performance difference, it at least makes the `settings.lua` file easier to work with.

ALL SETTINGS WERE KEPT INTACT (mostly)