### PR TITLE
Show all LSP Clients attached to the Buffer in GalaxyLine Bar

### DIFF
--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -26,7 +26,7 @@ require"lspconfig".efm.setup {
     -- init_options = {initializationOptions},
     cmd = {DATA_PATH .. "/lspinstall/efm/efm-langserver"},
     init_options = {documentFormatting = true, codeAction = false},
-    filetypes = {"lua", "python", "javascriptreact", "javascript", "typescript","typescriptreact","sh", "html", "css", "yaml", "markdown", "vue"},
+    filetypes = {"python"},
     settings = {
         rootMarkers = {".git/", "requirements.txt"},
         languages = {

--- a/lua/lv-galaxyline/init.lua
+++ b/lua/lv-galaxyline/init.lua
@@ -178,9 +178,38 @@ table.insert(gls.right, {
     }
 })
 
+local get_lsp_client = function (msg)
+    msg = msg or "No Active LSP Client"
+    local buf_ft = vim.api.nvim_buf_get_option(0, 'filetype')
+    local clients = vim.lsp.get_active_clients()
+    if next(clients) == nil then
+        return msg
+    end
+    local lsps = ""
+    for _,client in ipairs(clients) do
+        local filetypes = client.config.filetypes
+        if filetypes and vim.fn.index(filetypes, buf_ft) ~=1 then
+            print(client.name)
+            if lsps == "" then
+                print("first", lsps)
+                lsps = client.name
+            else
+                lsps = lsps .. ", " .. client.name
+                print("more", lsps)
+            end
+        end
+    end
+    if lsps == "" then
+        return msg
+    else
+        return lsps
+    end
+end
+
+
 table.insert(gls.right, {
     ShowLspClient = {
-        provider = 'GetLspClient',
+        provider = get_lsp_client,
         condition = function()
             local tbl = {['dashboard'] = true, [' '] = true}
             if tbl[vim.bo.filetype] then return false end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52972480/124350226-10d6cf00-dc11-11eb-90d9-cd96c14be1f2.png)
When using Efm and sumneko_lua in lua
![image](https://user-images.githubusercontent.com/52972480/124350289-762ac000-dc11-11eb-9e16-6d3d97069bb2.png)
When using efm and pyright in python


also fixed the filetypes in Python ftplugin efm arguments. removed other filetypes and just kept python for python.