### PR TITLE
Define a form for general issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue-form.yaml
+++ b/.github/ISSUE_TEMPLATE/general-issue-form.yaml
@@ -1,0 +1,60 @@
+name: General Issue
+description: File a bug report
+title: "[Bug]: "
+labels: [bug]
+# assignees:
+#   - ChristianChiarulli 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping us improve !
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Problem description
+      description: Also tell us, what did you expect to happen?
+      placeholder: |
+        Steps to reproduce the behavior:
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: input
+    id: lunar-vim-version
+    attributes:
+      label: LunarVim version
+    validations:
+      required: true
+  - type: input
+    id: nvim-version
+    attributes:
+      label: Neovim version (>= 0.5)
+      placeholder: nvim --version
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      placeholder: |
+        nvim -v
+        :checkhealth
+        :messages
+      render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: I have read
+      options:
+      - label: The readme
+        required: true
+      - label: The wiki
+        required: true


### PR DESCRIPTION
Fixes [504](https://github.com/ChristianChiarulli/LunarVim/issues/504)

I used GitHub issue form syntax, which I think allows for more structure.
I plan on adding more forms:
- A feature form
- A LSP issue form

Let's first discuss and agree on this one.

![general-issue-form](https://user-images.githubusercontent.com/3267228/124362229-fd892b00-dc33-11eb-911b-6936455ba18d.png)
