### PR TITLE
[LSP] clang - Support autoformat for all file-types.

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -23,9 +23,9 @@ require'lspconfig'.clangd.setup {
 if O.lang.clang.autoformat then
     require('lv-utils').define_augroups({
       _clang_autoformat = {
-      {
-        'BufWritePre *.cpp lua vim.lsp.buf.formatting_sync(nil,1000)'
-
-      }
-    } })
+         {'BufWritePre *.c lua vim.lsp.buf.formatting_sync(nil,1000)'},
+         {'BufWritePre *.h lua vim.lsp.buf.formatting_sync(nil,1000)'},
+         {'BufWritePre *.cpp lua vim.lsp.buf.formatting_sync(nil,1000)'},
+         {'BufWritePre *.hpp lua vim.lsp.buf.formatting_sync(nil,1000)'},
+    }})
 end


### PR DESCRIPTION
Improves the auto-format to support C and header files for C and CPP.