### PR TITLE
Adding tabnine for compe

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -68,7 +68,8 @@ O = {
         diffview = {active = false},
         bracey = {active = false},
         telescope_project = {active = false},
-        dap_install = {active = false}
+        dap_install = {active = false},
+        tabnine = {active = false}
 
     },
 

--- a/lua/lv-compe/init.lua
+++ b/lua/lv-compe/init.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.config = function()
-require'compe'.setup {
+opt = {
     enabled = O.auto_complete,
     autocomplete = true,
     debug = false,
@@ -33,6 +33,12 @@ require'compe'.setup {
         -- for emoji press : (idk if that in compe tho)
     }
 }
+
+if O.plugin.tabnine.active then
+    opt.source.tabnine = {kind = " ", priority=200, max_reslts=6}
+end
+
+require'compe'.setup(opt)
 
 local t = function(str)
   return vim.api.nvim_replace_termcodes(str, true, true, true)

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -423,4 +423,12 @@ return require("packer").startup(function(use)
 
     -- Elixir
     use {"elixir-editors/vim-elixir", ft = {"elixir", "eelixir", "euphoria3"}}
+
+    -- Tabnine
+    use {
+        "tzachar/compe-tabnine",
+        run="./install.sh",
+        requires = "hrsh7th/nvim-compe",
+        disable = not O.plugin.tabnine.active
+    }
 end)


### PR DESCRIPTION
Fixed #631 

For activation, you need to add the following line to your `lv-config.lua`
```lua
O.plugin.tabnine.active = true
```
Due to this [issue](https://github.com/tzachar/compe-tabnine#packer-issues), sometimes you might need to do this after `:PackerSync`
```bash
cd ~/.local/share/nvim/site/pack/packer/start/compe-tabnine
./install.sh
```