### PR TITLE
Solargraph uses stdio instead of --stdio

### DIFF
--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -1,6 +1,6 @@
 -- If you are using rvm, make sure to change below configuration
 require'lspconfig'.solargraph.setup {
-    cmd = {DATA_PATH .. "/lspinstall/ruby/solargraph/solargraph", "--stdio"},
+    cmd = {DATA_PATH .. "/lspinstall/ruby/solargraph/solargraph", "stdio"},
     on_attach = require'lsp'.common_on_attach,
     handlers = {
         ["textDocument/publishDiagnostics"] = vim.lsp.with(


### PR DESCRIPTION
You can see this in the [default config](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/solargraph.lua).