### PR TITLE
Configure the template chooser to include community links.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+
+contact_links:
+  - name: Matrix community
+    url: https://matrix.to/#/+atmachine:matrix
+    about: Please ask and answer questions on Matrix.
+  - name: Discord community
+    url: https://discord.gg/Xb9B4Ny
+    about: Please ask and answer questions on Discord.


### PR DESCRIPTION
Blank issues are still allowed, as all cases aren't potentially covered (we will see in the future)

![community-links](https://user-images.githubusercontent.com/3267228/124376647-50042f00-dca8-11eb-98de-d1d82884eba9.png)
