### PR TITLE
Add tool to profile startuptime for plugins

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -68,7 +68,8 @@ O = {
         diffview = {active = false},
         bracey = {active = false},
         telescope_project = {active = false},
-        dap_install = {active = false}
+        dap_install = {active = false},
+        startuptime = {active = false},
 
     },
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -411,6 +411,12 @@ return require("packer").startup(function(use)
         event = "BufRead",
         disable = not O.plugin.dap_install.active
     }
+    -- Startup profiler
+    use {
+        'tweekmonster/startuptime.vim',
+        cmd = "StartupTime",
+        disable = not O.plugin.startuptime.active
+    }
 
     -- LANGUAGE SPECIFIC GOES HERE
 


### PR DESCRIPTION
Adds a tool to profile startup time
Run with 

```
# Default is 10 runs
:StartupTime <num_of_runs>
:StartupTime 100
```

Activate with 
```
O.plugin.startuptime = true
```