### PR TITLE
lazy load lspinstall

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -34,7 +34,9 @@ return require("packer").startup(function(use)
     -- TODO refactor all of this (for now it works, but yes I know it could be wrapped in a simpler function)
     use {"neovim/nvim-lspconfig"}
     use {"glepnir/lspsaga.nvim"}
-    use {"kabouzeid/nvim-lspinstall"}
+    use {"kabouzeid/nvim-lspinstall", 
+        cmd = "LspInstall",
+    }
     -- Telescope
     use {"nvim-lua/popup.nvim"}
     use {"nvim-lua/plenary.nvim"}


### PR DESCRIPTION
LspInstall is currently loaded automatically at start.  This pull request sets it to be lazy loaded.

LspInstall was lazy loaded last week with 'BufRead'.  But this did not work correctly in all cases and was changed to load at start.

Loading with the 'cmd' option seems to work reliably and it's how I've loaded it in my own config for a while.  