### PR TITLE
Adds tree-sitter text objects

### DIFF
--- a/lua/lv-treesitter/init.lua
+++ b/lua/lv-treesitter/init.lua
@@ -31,6 +31,18 @@ require'nvim-treesitter.configs'.setup {
             goto_node = '<cr>',
             show_help = '?'
         }
+    },
+
+    textobjects = {
+        select = {
+            enable = true,
+            keymaps = {
+                ["af"] = "@function.outer",
+                ["if"] = "@function.inner",
+                ["ac"] = "@class.outer",
+                ["ic"] = "@class.inner"
+            }
+        }
     }
 }
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -67,6 +67,8 @@ return require("packer").startup(function(use)
     -- Treesitter
     use {"nvim-treesitter/nvim-treesitter", run = ":TSUpdate"}
 
+    use {"nvim-treesitter/nvim-treesitter-textobjects"}
+
     use {
         "kyazdani42/nvim-tree.lua",
         -- cmd = "NvimTreeToggle",


### PR DESCRIPTION
Adds the plugin treesitter-text-objects as a default and enabled plugin.  
Adds text-objects for: functions and classes
Enables keybinds like the following

```
af = function outer
if = function inner
ac = class outer
ic = class inner

yaf = yank around function
vif = select inside function
etc... 
```
