### PR TITLE
Pressing escape also clears search and spelling highlights

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -48,6 +48,10 @@ vim.cmd('inoremap <expr> <c-k> (\"\\<C-p>\")')
 
 vim.cmd('vnoremap p "0p')
 vim.cmd('vnoremap P "0P')
+
+-- Escape key clears search and spelling highlights
+vim.api.nvim_set_keymap('n', '<ESC>', ":nohls | :setlocal nospell<ESC>", {silent = true} )
+
 -- vim.api.nvim_set_keymap('v', 'p', '"0p', {silent = true})
 -- vim.api.nvim_set_keymap('v', 'P', '"0P', {silent = true})
 


### PR DESCRIPTION
In addition to normal function, pressing Escape also clears search and spelling highlights

To enable spelling or search highlights:

```
:set spell
:set hlsearch
```
