### PR TITLE
Snippets in config dir

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -22,6 +22,7 @@ O = {
     hl_search = false,
     transparent_window = false;
     leader_key = "space";
+    vnsip_dir = vim.fn.stdpath('config') .. "/snippets",
 
     -- @usage pass a table with your desired languages
     treesitter = {

--- a/lua/lv-compe/init.lua
+++ b/lua/lv-compe/init.lua
@@ -4,7 +4,7 @@
 
 local M = {}
 
-vim.g.vsnip_snippet_dir = vim.fn.stdpath("config") .. "/snippets"
+vim.g.vsnip_snippet_dir = O.vsnip_dir
 
 M.config = function()
 opt = {

--- a/lua/lv-compe/init.lua
+++ b/lua/lv-compe/init.lua
@@ -4,7 +4,7 @@
 
 local M = {}
 
-vim.g.vsnip_snippet_dir = O.vsnip_dir
+vim.g.vsnip_snippet_dir = O.vnsip_dir
 
 M.config = function()
 opt = {

--- a/lua/lv-compe/init.lua
+++ b/lua/lv-compe/init.lua
@@ -4,6 +4,8 @@
 
 local M = {}
 
+vim.g.vsnip_snippet_dir = vim.fn.stdpath("config") .. "/snippets"
+
 M.config = function()
 opt = {
     enabled = O.auto_complete,


### PR DESCRIPTION
Sets the default directory for the vsnip-snippet to ~/.config/nvim/snippets/.

The directory can be changed via O.vsnip_dir.