### PR TITLE
Basics for php lsp

### DIFF
--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,4 +1,25 @@
 require'lspconfig'.intelephense.setup {
     cmd = { DATA_PATH .. "/lspinstall/php/node_modules/.bin/intelephense", "--stdio" },
-    on_attach = require'lsp'.common_on_attach
+    on_attach = require'lsp'.common_on_attach,
+    handlers = {
+        ["textDocument/publishDiagnostics"] = vim.lsp.with(
+            vim.lsp.diagnostic.on_publish_diagnostics, {
+                virtual_text = O.lang.php.diagnostics.virtual_text,
+                signs = O.lang.php.diagnostics.signs,
+                underline = O.lang.php.diagnostics.underline,
+                update_in_insert = true
+
+            })
+    },
+	filetypes = O.lang.php.filetypes,
+	settings = {
+		intelephense = {
+			format = {
+				braces = O.lang.php.format.braces
+			},
+			environment = {
+				phpVersion = O.lang.php.environment.php_version
+			},
+        }
+	};
 }

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -182,7 +182,21 @@ O = {
             }
         },
         svelte = {},
-        php = {},
+        php = {
+            format = {
+                braces = "psr12"
+            },
+            environment = {
+                php_version = "7.4"
+            },
+            autoformat = false,
+            diagnostics = {
+                virtual_text = {spacing = 0, prefix = ""},
+                signs = true,
+                underline = true
+                },
+            filetypes = {'php', 'phtml'}
+        },
         latex = {},
         kotlin = {},
         html = {},

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -87,7 +87,14 @@ O.lang.rust.autoformat = true
 -- clang
 O.lang.clang.autoformat = false -- Set to true to enable auto-format in C/C++ files.
 
-
+-- php
+O.lang.php.format.braces = "k&r" -- options: psr12, allman, k&r
+O.lang.php.environment.php_version = "7.4"
+-- TODO: autoformat seems not to work at the moment
+O.lang.php.autoformat = false
+O.lang.php.diagnostics.signs = true
+O.lang.php.diagnostics.underline = true
+O.lang.php.filetypes = { "php", "phtml"  }
 
 -- TODO Autocommands
 -- https://neovim.io/doc/user/autocmd.html


### PR DESCRIPTION
Added the possibility for basics settings regarding the php-lsp.

Nothing to fancy I think.

Autoformat doesn't seem to work. I left a TODO in utils/installer/lv-config.example.lua.