### PR TITLE
Fix Lint CodeActions + Better dev experience on JS/TS

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -106,8 +106,48 @@ if O.document_highlight then
 end
 
 function lsp_config.tsserver_on_attach(client, bufnr)
-    lsp_config.common_on_attach(client, bufnr)
+    -- lsp_config.common_on_attach(client, bufnr)
     client.resolved_capabilities.document_formatting = false
+
+    local ts_utils = require("nvim-lsp-ts-utils")
+
+    -- defaults
+    ts_utils.setup {
+        debug = false,
+        disable_commands = false,
+        enable_import_on_completion = false,
+        import_all_timeout = 5000, -- ms
+
+        -- eslint
+        eslint_enable_code_actions = true,
+        eslint_enable_disable_comments = true,
+        eslint_bin = O.lang.tsserver.linter,
+        eslint_config_fallback = nil,
+        eslint_enable_diagnostics = true,
+
+        -- formatting
+        enable_formatting = O.lang.tsserver.autoformat,
+        formatter = O.lang.tsserver.formatter,
+        formatter_config_fallback = nil,
+
+        -- parentheses completion
+        complete_parens = false,
+        signature_help_in_parens = false,
+
+        -- update imports on file move
+        update_imports_on_move = false,
+        require_confirmation_on_move = false,
+        watch_dir = nil,
+    }
+
+    -- required to fix code action ranges
+    ts_utils.setup_client(client)
+
+    -- TODO: keymap these?
+    -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gs", ":TSLspOrganize<CR>", {silent = true})
+    -- vim.api.nvim_buf_set_keymap(bufnr, "n", "qq", ":TSLspFixCurrent<CR>", {silent = true})
+    -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gr", ":TSLspRenameFile<CR>", {silent = true})
+    -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", {silent = true})
 end
 
 

--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -17,46 +17,18 @@ M.setup = function()
         }
     end
 
-    -- TODO global eslint?
-
-    local eslint = {
-        lintCommand = "./node_modules/.bin/eslint -f unix --stdin --stdin-filename ${INPUT}",
-        lintIgnoreExitCode = true,
-        lintStdin = true,
-        lintFormats = {"%f:%l:%c: %m"},
-        -- formatCommand = "./node_modules/.bin/eslint -f unix --fix --stdin-filename ${INPUT}", -- TODO check if eslint is the formatter then add this
-        formatStdin = true
-    }
-
-    if O.lang.tsserver.formatter == 'prettier' then
-        table.insert(tsserver_args, prettier)
-    end
-
-    if O.lang.tsserver.linter == 'eslint' then
-        table.insert(tsserver_args, eslint)
-    end
-
     require"lspconfig".efm.setup {
         -- init_options = {initializationOptions},
         cmd = {DATA_PATH .. "/lspinstall/efm/efm-langserver"},
         init_options = {documentFormatting = true, codeAction = false},
-        filetypes = {
-            "javascriptreact", "javascript", "typescript", "typescriptreact",
-            "html", "css", "yaml", "vue"
-        },
+        filetypes = {"html", "css", "yaml", "vue"},
         settings = {
             rootMarkers = {".git/", "package.json"},
             languages = {
-                javascript = tsserver_args,
-                javascriptreact = tsserver_args,
-                typescript = tsserver_args,
-                typescriptreact = tsserver_args,
                 html = {prettier},
                 css = {prettier},
                 json = {prettier},
                 yaml = {prettier}
-                -- javascriptreact = {prettier, eslint},
-                -- javascript = {prettier, eslint},
                 -- markdown = {markdownPandocFormat, markdownlint},
             }
         }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -429,6 +429,25 @@ return require("packer").startup(function(use)
     -- Elixir
     use {"elixir-editors/vim-elixir", ft = {"elixir", "eelixir", "euphoria3"}}
 
+    -- Javascript / Typescript
+    use {
+        "jose-elias-alvarez/nvim-lsp-ts-utils",
+        ft = {
+            "javascript", "javascriptreact", "javascript.jsx", "typescript",
+            "typescriptreact", "typescript.tsx"
+        }
+    }
+    use {
+        "jose-elias-alvarez/null-ls.nvim",
+        ft = {
+            "javascript", "javascriptreact", "javascript.jsx", "typescript",
+            "typescriptreact", "typescript.tsx"
+        },
+        config = function()
+            require('null-ls').setup()
+        end
+    }
+
     -- Tabnine
     use {
         "tzachar/compe-tabnine",


### PR DESCRIPTION
This makes CodeAction autofixes working

https://user-images.githubusercontent.com/51096534/124395931-e9493a80-dcd4-11eb-9b19-13cb85963f00.mp4


I changed efm to [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) on js/ts files only for now as it's less bloated than efm and it uses built-in neovim sources to provide out-of-the-box functionality. efm's codeActions also doesn't work.

Also added [nvim-lsp-ts-utils](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils) plugin to get usefull utils like Import all missing imports (exposed as :TSLspImportAll)