### PR TITLE
Remove `extras` Config option since extras plugins are enabled individualy now

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -15,7 +15,6 @@ O = {
     shell = 'bash',
     timeoutlen = 100,
     nvim_tree_disable_netrw = 0,
-    extras = false,
     ignore_case = true,
     smart_case = true,
     lushmode = false,
@@ -117,7 +116,7 @@ O = {
                 underline = true
             }
         },
-        tsserver = {
+        tsserver = { 
             -- @usage can be 'eslint'
             linter = '',
             -- @usage can be 'prettier'

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -116,7 +116,7 @@ O = {
                 underline = true
             }
         },
-        tsserver = { 
+        tsserver = {
             -- @usage can be 'eslint'
             linter = '',
             -- @usage can be 'prettier'

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -13,7 +13,6 @@ O.auto_close_tree = 0
 O.wrap_lines = false
 O.timeoutlen = 100
 O.document_highlight = true
-O.extras = false
 O.leader_key = ' '
 O.ignore_case = true
 O.smart_case = true


### PR DESCRIPTION
This only removes `O.extras` config option since it's no longer used. The extras plugins are activated individualy.