### PR TITLE
fixes condition to use local prettier

### DIFF
--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -10,7 +10,7 @@ M.setup = function()
         formatStdin = true
     }
 
-    if vim.fn.glob("node_modules/.bin/prettier") then
+    if vim.fn.glob("node_modules/.bin/prettier") ~= "" then
         prettier = {
             formatCommand = "./node_modules/.bin/prettier --stdin-filepath ${INPUT}",
             formatStdin = true


### PR DESCRIPTION
`vim.fn.glob("node_modules/.bin/prettier")` returns an empty string if the path does not exist which is a truthy value in lua. The effect is that the path to the global prettier is replaced by the potentially non existent prettier from the project level.