### PR TITLE
Ensure the keymap set in lua/lv-autopairs/init.lua works as expected.

### DIFF
--- a/lua/lv-compe/init.lua
+++ b/lua/lv-compe/init.lua
@@ -90,7 +90,7 @@ M.config = function()
   vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
 
   vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
-  vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
+  -- vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-e>", "compe#close('<C-e>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-f>", "compe#scroll({ 'delta': +4 })", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })


### PR DESCRIPTION
Please refer [https://github.com/windwp/nvim-autopairs#mapping-cr](https://github.com/windwp/nvim-autopairs#mapping-cr) **nvim-compe** section.

If this keymap is preferred, maybe we can remove the map set in [autopairs](https://github.com/ChristianChiarulli/LunarVim/blob/bd9296c4e86b9223cce9ee3dd0d04c3f9e7cc370/lua/lv-autopairs/init.lua).