### PR TITLE
Added editorconfig plugin

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -70,6 +70,7 @@ O = {
     telescope_project = { active = false },
     dap_install = { active = false },
     tabnine = { active = false },
+    editorconfig = {active = false},
   },
 
   lang = {

--- a/lua/lv-editorconfig/init.lua
+++ b/lua/lv-editorconfig/init.lua
@@ -1,0 +1,4 @@
+vim.g.EditorConfig_exclude_patterns = {
+    'fugitive://.*',
+    'scp://.*'
+}

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -411,6 +411,17 @@ return require("packer").startup(function(use)
     disable = not O.plugin.dap_install.active,
   }
 
+  -- Editorconfig support
+  use {
+    event = "BufRead",
+   "editorconfig/editorconfig-vim",
+    config = function()
+      require 'lv-editorconfig'
+    end,
+    disable = not O.plugin.editorconfig.active,
+    opt = true
+  }
+
   -- LANGUAGE SPECIFIC GOES HERE
 
   use { "lervag/vimtex", ft = "tex" }


### PR DESCRIPTION
Added support for basic code format `.editorconfig` files, using official plugin editorconfig/editorconfig. See https://editorconfig.org/