### PR TITLE
only call dap_install.config if plugins are installed

### DIFF
--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -76,5 +76,7 @@ if O.lang.python.autoformat then
   }
 end
 
-local dap_install = require("dap-install")
-dap_install.config("python_dbg", {})
+if O.plugin.debug.active and O.plugin.dap_install.active then
+  local dap_install = require "dap-install"
+  dap_install.config("python_dbg", {})
+end


### PR DESCRIPTION
namely dap_install and nvim-dap.

Or else you can't open python files