### PR TITLE
Fish shell script support

### DIFF
--- a/ftdetect/fish.vim
+++ b/ftdetect/fish.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.fish setlocal filetype=fish

--- a/ftplugin/fish.lua
+++ b/ftplugin/fish.lua
@@ -1,0 +1,1 @@
+vim.opt_local.commentstring = "# %s"


### PR DESCRIPTION
Highlighting and comment correctly.

tree-sitter-fish is already supported, just need to set the filetype

I thought about using `ftdetect.fish.lua`, but that would just be calling `vim.cmd([[]])` anyway. What is the performance implications of that?