### PR TITLE
justfile syntax support

### DIFF
--- a/ftdetect/just.vim
+++ b/ftdetect/just.vim
@@ -1,0 +1,2 @@
+au BufWinEnter,BufRead,BufNewFile *.just setlocal filetype=just
+au BufWinEnter,BufRead,BufNewFile Justfile setlocal filetype=just

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -422,6 +422,9 @@ return require("packer").startup(function(use)
     disable = not O.lang.rust.rust_tools.active,
   }
 
+  -- Justfile
+  use { "NoahTheDuke/vim-just", ft = "just" }
+
   -- Elixir
   use { "elixir-editors/vim-elixir", ft = { "elixir", "eelixir", "euphoria3" } }
 


### PR DESCRIPTION
Adds a plugin to support https://github.com/casey/just

Do you want a flag to disable installing vim-just? its already lazy loaded by filetype