### PR TITLE
kmonad syntax support

### DIFF
--- a/ftdetect/kmonad.vim
+++ b/ftdetect/kmonad.vim
@@ -1,0 +1,1 @@
+au BufWinEnter,BufRead,BufNewFile *.kbd setlocal filetype=kmonad

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -422,6 +422,9 @@ return require("packer").startup(function(use)
     disable = not O.lang.rust.rust_tools.active,
   }
 
+  -- KMonad
+  use { "kmonad/kmonad-vim", ft = "kmonad" }
+
   -- Elixir
   use { "elixir-editors/vim-elixir", ft = { "elixir", "eelixir", "euphoria3" } }
 


### PR DESCRIPTION
Support for syntax highlighting of https://github.com/kmonad/kmonad

Requires a plugin, Do you want a flag to disable installing it? its already lazy loaded by filetype