### PR TITLE
vim-quick-scope plugin

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -70,8 +70,10 @@ O = {
     telescope_project = { active = false },
     dap_install = { active = false },
     tabnine = { active = false },
-    quickscope = { active = false, 
-        on_keys = {'f', 'F', 't', 'T'} -- Comment this line to have it always visible
+    quickscope = {
+      active = false,
+      event = "BufRead", -- Comment out this line to only load quickscope when keys are pressed. Then run :PackerSync
+      on_keys = { "f", "F", "t", "T" }, -- Comment this line to have it always visible
     },
   },
 

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -70,7 +70,9 @@ O = {
     telescope_project = { active = false },
     dap_install = { active = false },
     tabnine = { active = false },
-    quickscope = { active = false },
+    quickscope = { active = false, 
+        on_keys = {'f', 'F', 't', 'T'} -- Comment this line to have it always visible
+    },
   },
 
   lang = {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -70,6 +70,7 @@ O = {
     telescope_project = { active = false },
     dap_install = { active = false },
     tabnine = { active = false },
+    quickscope = { active = false },
   },
 
   lang = {

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -464,10 +464,11 @@ return require("packer").startup(function(use)
   use {
     "unblevable/quick-scope",
     keys = O.plugin.quickscope.on_keys,
-    event = (O.plugin.quickscope.on_keys ~= nil) and "BufRead" or nil,
+    event = O.plugin.quickscope.event,
     config = function()
         vim.g.qs_highlight_on_keys = O.plugin.quickscope.on_keys
     end,
     disable = not O.plugin.quickscope.active,
   }
+
 end)

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -463,8 +463,11 @@ return require("packer").startup(function(use)
   -- Vim quick-scope See jumpable characters
   use {
     "unblevable/quick-scope",
-    event = "BufRead",
+    keys = O.plugin.quickscope.on_keys,
+    event = (O.plugin.quickscope.on_keys ~= nil) and "BufRead" or nil,
+    config = function()
+        vim.g.qs_highlight_on_keys = O.plugin.quickscope.on_keys
+    end,
     disable = not O.plugin.quickscope.active,
   }
-
 end)

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -463,8 +463,8 @@ return require("packer").startup(function(use)
   -- Vim quick-scope See jumpable characters
   use {
     "unblevable/quick-scope",
-    disable = not O.plugin.quickscope.active,
     event = "BufRead",
+    disable = not O.plugin.quickscope.active,
   }
 
 end)

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -459,4 +459,12 @@ return require("packer").startup(function(use)
     requires = "hrsh7th/nvim-compe",
     disable = not O.plugin.tabnine.active,
   }
+
+  -- Vim quick-scope See jumpable characters
+  use {
+    "unblevable/quick-scope",
+    disable = not O.plugin.quickscope.active,
+    event = "BufRead",
+  }
+
 end)


### PR DESCRIPTION
Highlights a character in each word that is unique to that line.

Helps with jumping quickly as you can just eyeball that word and see what you should press after 'f'

This seems quite useful for beginners 