### PR TITLE
Add Treesitter extensions for better textobjects

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -29,6 +29,29 @@ O = {
     ignore_install = { "haskell" },
     highlight = { enabled = true },
     rainbow = { enabled = false },
+    -- The below are for treesitter-textobjects plugin
+    textobj_prefixes = {
+      goto_next = "]", -- Go to next
+      goto_previous = "[", -- Go to previous
+      inner = "i", -- Select inside
+      outer = "a", -- Selct around
+      swap = "<leader>a", -- Swap with next
+    },
+    textobj_suffixes = {
+      -- Start and End respectively for the goto keys
+      -- for other keys it only uses the first
+      ["function"] = { "f", "F" },
+      ["class"] = { "m", "M" },
+      ["parameter"] = { "a", "A" },
+      ["block"] = { "k", "K" },
+      ["conditional"] = { "i", "I" },
+      ["call"] = { "c", "C" },
+      ["loop"] = { "l", "L" },
+      ["statement"] = { "s", "S" },
+      ["comment"] = { "/", "?" },
+    },
+    -- The below is for treesitter hint textobjects plugin
+    hint_labels = { "h", "j", "f", "d", "n", "v", "s", "l", "a" },
   },
 
   database = { save_location = "~/.config/nvcode_db", auto_execute = 1 },
@@ -70,6 +93,9 @@ O = {
     telescope_project = { active = false },
     dap_install = { active = false },
     tabnine = { active = false },
+    ts_hintobjects = { active = false },
+    ts_textobjects = { active = false },
+    ts_textsubjects = { active = false },
   },
 
   lang = {

--- a/lua/lv-treesitter/init.lua
+++ b/lua/lv-treesitter/init.lua
@@ -1,6 +1,85 @@
--- if not package.loaded['nvim-treesitter'] then
---   return
--- end
+-- if not package.loaded['nvim-treesitter'] then return end
+--
+-- Custom parsers
+local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+-- parser_config.make = {
+--     install_info = {
+--         url = "https://github.com/alemuller/tree-sitter-make", -- local path or git repo
+--         files = {"src/parser.c"},
+--         requires_generate_from_grammar = true
+--     }
+-- }
+-- parser_config.just = {
+--     install_info = {
+--         url = "~/dev/tree-sitter-just", -- local path or git repo
+--         files = {"src/parser.c"}
+--     }
+--     -- filetype = "just", -- if filetype does not agrees with parser name
+--     -- used_by = {"bar", "baz"} -- additional filetypes that use this parser
+-- }
+
+-- Custom text objects
+local textobj_prefixes = O.treesitter.textobj_prefixes
+local textobj_suffixes = O.treesitter.textobj_suffixes
+local textobj_sel_keymaps = {}
+local textobj_swap_keymaps = {}
+local textobj_move_keymaps = {
+  enable = O.plugin.ts_textobjects,
+  set_jumps = true, -- whether to set jumps in the jumplist
+  goto_next_start = {},
+  goto_next_end = {},
+  goto_previous_start = {},
+  goto_previous_end = {},
+}
+for obj, suffix in pairs(textobj_suffixes) do
+  if textobj_prefixes["goto_next"] ~= nil then
+    textobj_move_keymaps["goto_next_start"][textobj_prefixes["goto_next"] .. suffix[1]] = "@" .. obj .. ".outer"
+    textobj_move_keymaps["goto_next_end"][textobj_prefixes["goto_next"] .. suffix[2]] = "@" .. obj .. ".outer"
+  end
+  if textobj_prefixes["goto_prev"] ~= nil then
+    textobj_move_keymaps["goto_previous_start"][textobj_prefixes["goto_previous"] .. suffix[2]] = "@" .. obj .. ".outer"
+    textobj_move_keymaps["goto_previous_end"][textobj_prefixes["goto_previous"] .. suffix[1]] = "@" .. obj .. ".outer"
+  end
+
+  if textobj_prefixes["inner"] ~= nil then
+    textobj_sel_keymaps[textobj_prefixes["inner"] .. suffix[1]] = "@" .. obj .. ".inner"
+  end
+  if textobj_prefixes["outer"] ~= nil then
+    textobj_sel_keymaps[textobj_prefixes["outer"] .. suffix[1]] = "@" .. obj .. ".outer"
+  end
+
+  if textobj_prefixes["swap"] ~= nil then
+    textobj_swap_keymaps[textobj_prefixes["swap"] .. suffix[1]] = "@" .. obj .. ".outer"
+  end
+end
+vim.g.ts_hint_textobject_keys = O.treesitter.hint_labels -- Requires https://github.com/mfussenegger/nvim-ts-hint-textobject/pull/2
+
+-- Add which key menu entries
+local status, wk = pcall(require, "which-key")
+if status then
+  local normal = {
+    mode = "n", -- Normal mode
+  }
+  local operators = {
+    mode = "o", -- Operator mode
+  }
+  wk.register(textobj_sel_keymaps, operators)
+  wk.register({
+    ["m"] = "Hint Objects",
+    ["."] = "Textsubject",
+    [";"] = "Textsubject-big",
+  }, operators)
+  wk.register(textobj_swap_keymaps, normal)
+  wk.register({
+    [textobj_prefixes["swap"]] = "Swap",
+    -- [textobj_prefixes["goto_next"]] = "Jump [",
+    -- [textobj_prefixes["goto_previous"]] = "Jump ]"
+  }, normal)
+  wk.register(textobj_move_keymaps["goto_next_start"], normal)
+  wk.register(textobj_move_keymaps["goto_next_end"], normal)
+  wk.register(textobj_move_keymaps["goto_previous_start"], normal)
+  wk.register(textobj_move_keymaps["goto_previous_end"], normal)
+end
 
 require("nvim-treesitter.configs").setup {
   ensure_installed = O.treesitter.ensure_installed, -- one of "all", "maintained" (parsers with maintainers), or a list of languages
@@ -10,14 +89,33 @@ require("nvim-treesitter.configs").setup {
     -- disable = { "c", "ruby" },  -- optional, list of language that will be disabled
   },
   highlight = {
-    enable = O.treesitter.highlight.enabled, -- false will disable the whole extension
+    enable = O.treesitter.enabled, -- false will disable the whole extension
+    additional_vim_regex_highlighting = true,
+    disable = { "latex" },
   },
-  context_commentstring = { enable = O.plugin.ts_context_commentstring, config = { css = "// %s" } },
+  context_commentstring = {
+    enable = O.plugin.ts_context_commentstring.active,
+    config = { css = "// %s" },
+  },
   -- indent = {enable = true, disable = {"python", "html", "javascript"}},
   -- TODO seems to be broken
   indent = { enable = { "javascriptreact" } },
-  autotag = { enable = true },
-
+  autotag = { enable = O.plugin.ts_autotag.active },
+  textobjects = {
+    swap = {
+      enable = O.plugin.ts_textobjects,
+      swap_next = textobj_swap_keymaps,
+    },
+    move = textobj_move_keymaps,
+    select = {
+      enable = O.plugin.ts_textobjects,
+      keymaps = textobj_sel_keymaps,
+    },
+  },
+  textsubjects = {
+    enable = O.plugin.ts_textsubjects,
+    keymaps = { ["."] = "textsubjects-smart", [";"] = "textsubjects-big" },
+  },
   playground = {
     enable = O.plugin.ts_playground.active,
     disable = {},
@@ -35,5 +133,10 @@ require("nvim-treesitter.configs").setup {
       goto_node = "<cr>",
       show_help = "?",
     },
+  },
+  rainbow = {
+    enable = O.plugin.ts_rainbow.active,
+    extended_mode = true, -- Highlight also non-parentheses delimiters, boolean or table: lang -> boolean
+    max_file_lines = 1000, -- Do not enable for files with more than 1000 lines, int
   },
 }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -459,4 +459,22 @@ return require("packer").startup(function(use)
     requires = "hrsh7th/nvim-compe",
     disable = not O.plugin.tabnine.active,
   }
+
+  -- Custom semantic text objects
+  use {
+    "nvim-treesitter/nvim-treesitter-textobjects",
+    disable = not O.plugin.ts_textobjects.active,
+  }
+  -- Smart text objects
+  use {
+    "RRethy/nvim-treesitter-textsubjects",
+    disable = not O.plugin.ts_textsubjects.active,
+  }
+  -- Text objects using hint labels
+  use {
+    "mfussenegger/nvim-ts-hint-textobject",
+    event = "BufRead",
+    disable = not O.plugin.ts_hintobjects.active,
+  }
+
 end)


### PR DESCRIPTION
This adds three plugins that use treesitters parsing to provide smarter text objects

[ts_textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) lets you define text objects for things like functions and classes

[ts_textsubjects](https://github.com/RRethy/nvim-treesitter-textsubjects.git) defines a smart text object that selects a semantic block around the cursor

[ts_hintobjects](https://github.com/mfussenegger/nvim-ts-hint-textobject) uses easymotion style hint labeling to show all the surrounding semantic blocks, letting you choose the correct one

I have also added which-key entries for all the above