### PR TITLE
switch to absolute line numbers in insert mode

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -284,4 +284,11 @@ require("lv-utils").define_augroups {
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
   },
+  _mode_switching = {
+    -- will switch between absolute and relative line numbers depending on mode
+    {'InsertEnter', '*', 'if &relativenumber | let g:backtorelative = 1 | setlocal number norelativenumber nocursorline | endif'},
+    {'InsertLeave', '*', 'if exists("g:backtorelative") | setlocal relativenumber cursorline | endif'},
+    {'WinEnter', '*', 'setlocal cursorline'},
+    {'WinLeave', '*', 'setlocal nocursorline'},
+  },
 }

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -294,9 +294,9 @@ require("lv-utils").define_augroups {
   },
   _mode_switching = {
     -- will switch between absolute and relative line numbers depending on mode
-    {'InsertEnter', '*', 'if &relativenumber | let g:backtorelative = 1 | setlocal number norelativenumber nocursorline | endif'},
-    {'InsertLeave', '*', 'if exists("g:backtorelative") | setlocal relativenumber cursorline | endif'},
-    {'WinEnter', '*', 'setlocal cursorline'},
-    {'WinLeave', '*', 'setlocal nocursorline'},
+    {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
+    {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
+    {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
+    {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
   },
 }


### PR DESCRIPTION
This switches to absolute line numbers in insert mode and back to relative line numbers when insert mode is left. if `relative_number` is set to `false` line numbers will stay absolute no matter which mode is active.