### PR TITLE
Add csharp language server (omnisharp) setup for cs filetype

### DIFF
--- a/ftplugin/cs.lua
+++ b/ftplugin/cs.lua
@@ -1,0 +1,6 @@
+-- C# language server (csharp/OmniSharp) setup
+require("lspconfig").omnisharp.setup{
+  on_attach = require("lsp").common_on_attach,
+  root_dir = require("lspconfig").util.root_pattern(".sln",".git"),
+  cmd = { DATA_PATH .. "/lspinstall/csharp/omnisharp/run", "--languageserver", "--hostPID", tostring(vim.fn.getpid()) },
+}


### PR DESCRIPTION
Add csharp language server (omnisharp) setup for .cs filetype. 
Requires csharp language server (":LspInstall csharp"). First time loading of omnisharp takes few seconds (2-10 sec).