### PR TITLE
add autoformat for elixir - default to false

### DIFF
--- a/ftplugin/elixir.lua
+++ b/ftplugin/elixir.lua
@@ -2,6 +2,18 @@ require("lspconfig").elixirls.setup {
   cmd = { DATA_PATH .. "/lspinstall/elixir/elixir-ls/language_server.sh" },
 }
 
+if O.lang.elixir.autoformat then
+  require("lv-utils").define_augroups {
+    _elixir_autoformat = {
+      { "BufWritePre", "*.ex", "lua vim.lsp.buf.formatting_sync(nil, 1000)" },
+    },
+    _elixir_script_autoformat = {
+      { "BufWritePre", "*.exs", "lua vim.lsp.buf.formatting_sync(nil, 1000)" },
+    },
+  }
+end
+
+
 -- needed for the LSP to recognize elixir files (alternativly just use elixir-editors/vim-elixir)
 -- vim.cmd([[
 --   au BufRead,BufNewFile *.ex,*.exs set filetype=elixir

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -176,7 +176,7 @@ O = {
       filetypes = { "rb", "erb", "rakefile", "ruby" },
     },
     go = {},
-    elixir = {},
+    elixir = { autoformat = false },
     vim = {},
     yaml = {},
     terraform = {},


### PR DESCRIPTION
added autoformat for elixir, default to false, can be activated with 
```
O.elixir.autoformat = true
```
in lv-config.lua