### PR TITLE
(feat) use neoformat as the defalt format option

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -18,14 +18,3 @@ require("lspconfig").clangd.setup {
     }),
   },
 }
-
-if O.lang.clang.autoformat then
-  require("lv-utils").define_augroups {
-    _clang_autoformat = {
-      { "BufWritePre *.c lua vim.lsp.buf.formatting_sync(nil,1000)" },
-      { "BufWritePre *.h lua vim.lsp.buf.formatting_sync(nil,1000)" },
-      { "BufWritePre *.cpp lua vim.lsp.buf.formatting_sync(nil,1000)" },
-      { "BufWritePre *.hpp lua vim.lsp.buf.formatting_sync(nil,1000)" },
-    },
-  }
-end

--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -6,17 +6,7 @@ require("lspconfig").gopls.setup {
   on_attach = require("lsp").common_on_attach,
 }
 
-if O.lang.go.autoformat then
-  require("lv-utils").define_augroups {
-    _go_format = {
-      { "BufWritePre", "*.go", "lua vim.lsp.buf.formatting_sync(nil,1000)" },
-    },
-    _go = {
-      -- Go generally requires Tabs instead of spaces.
-      { "FileType", "go", "setlocal tabstop=4" },
-      { "FileType", "go", "setlocal shiftwidth=4" },
-      { "FileType", "go", "setlocal softtabstop=4" },
-      { "FileType", "go", "setlocal noexpandtab" },
-    },
-  }
-end
+vim.opt_local.tabstop = 4
+vim.opt_local.shiftwidth = 4
+vim.opt_local.softtabstop = 4
+vim.opt_local.expandtab = false

--- a/ftplugin/javascript.lua
+++ b/ftplugin/javascript.lua
@@ -34,40 +34,5 @@ require("lspconfig").tsserver.setup {
     }),
   },
 }
-
 require("lsp.ts-fmt-lint").setup()
-
-if O.lang.tsserver.autoformat then
-  require("lv-utils").define_augroups {
-    _javascript_autoformat = {
-      {
-
-        "BufWritePre",
-        "*.js",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _javascriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.jsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescript_autoformat = {
-      {
-        "BufWritePre",
-        "*.ts",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.tsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/javascriptreact.lua
+++ b/ftplugin/javascriptreact.lua
@@ -34,40 +34,5 @@ require("lspconfig").tsserver.setup {
     }),
   },
 }
-
 require("lsp.ts-fmt-lint").setup()
-
-if O.lang.tsserver.autoformat then
-  require("lv-utils").define_augroups {
-    _javascript_autoformat = {
-      {
-
-        "BufWritePre",
-        "*.js",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _javascriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.jsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescript_autoformat = {
-      {
-        "BufWritePre",
-        "*.ts",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.tsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/json.lua
+++ b/ftplugin/json.lua
@@ -15,15 +15,3 @@ require("lspconfig").jsonls.setup {
     },
   },
 }
-
-if O.lang.json.autoformat then
-  require("lv-utils").define_augroups {
-    _json_format = {
-      {
-        "BufWritePre",
-        "*.json",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end

--- a/ftplugin/lua.lua
+++ b/ftplugin/lua.lua
@@ -40,34 +40,3 @@ if O.lang.lua.autoformat then
     },
   }
 end
-
-local lua_arguments = {}
-
-local luaFormat = {
-  formatCommand = "lua-format -i --no-keep-simple-function-one-line --column-limit=80",
-  formatStdin = true,
-}
-
-local lua_fmt = {
-  formatCommand = "luafmt --indent-count 2 --line-width 120 --stdin",
-  formatStdin = true,
-}
-
-if O.lang.lua.formatter == "lua-format" then
-  table.insert(lua_arguments, luaFormat)
-elseif O.lang.lua.formatter == "lua-fmt" then
-  table.insert(lua_arguments, lua_fmt)
-end
-
-require("lspconfig").efm.setup {
-  -- init_options = {initializationOptions},
-  cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
-  init_options = { documentFormatting = true, codeAction = false },
-  filetypes = { "lua" },
-  settings = {
-    rootMarkers = { ".git/" },
-    languages = {
-      lua = lua_arguments,
-    },
-  },
-}

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -20,12 +20,6 @@ if O.lang.python.isort then
   table.insert(python_arguments, isort)
 end
 
-if O.lang.python.formatter == "yapf" then
-  table.insert(python_arguments, yapf)
-elseif O.lang.python.formatter == "black" then
-  table.insert(python_arguments, black)
-end
-
 require("lspconfig").efm.setup {
   -- init_options = {initializationOptions},
   cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
@@ -64,19 +58,7 @@ require("lspconfig").pyright.setup {
     },
   },
 }
-if O.lang.python.autoformat then
-  require("lv-utils").define_augroups {
-    _python_autoformat = {
-      {
-        "BufWritePre",
-        "*.py",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end
-
 if O.plugin.dap_install.active then
-  local dap_install = require("dap-install")
+  local dap_install = require "dap-install"
   dap_install.config("python_dbg", {})
 end

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -12,11 +12,3 @@ require("lspconfig").solargraph.setup {
   },
   filetypes = O.lang.ruby.filetypes,
 }
-
-if O.lang.ruby.autoformat then
-  require("lv-utils").define_augroups {
-    _ruby_format = {
-      { "BufWritePre", "*.rb", "lua vim.lsp.buf.formatting_sync(nil,1000)" },
-    },
-  }
-end

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -91,11 +91,3 @@ vim.api.nvim_exec(
     ]],
   true
 )
-
-if O.lang.rust.autoformat then
-  require("lv-utils").define_augroups {
-    _rust_format = {
-      { "BufWritePre", "*.rs", "lua vim.lsp.buf.formatting_sync(nil,1000)" },
-    },
-  }
-end

--- a/ftplugin/sh.lua
+++ b/ftplugin/sh.lua
@@ -15,10 +15,6 @@ local shellcheck = {
   lintFormats = { "%f:%l:%c: %trror: %m", "%f:%l:%c: %tarning: %m", "%f:%l:%c: %tote: %m" },
 }
 
-if O.lang.sh.formatter == "shfmt" then
-  table.insert(sh_arguments, shfmt)
-end
-
 if O.lang.sh.linter == "shellcheck" then
   table.insert(sh_arguments, shellcheck)
 end

--- a/ftplugin/typescript.lua
+++ b/ftplugin/typescript.lua
@@ -34,40 +34,5 @@ require("lspconfig").tsserver.setup {
     }),
   },
 }
-
 require("lsp.ts-fmt-lint").setup()
-
-if O.lang.tsserver.autoformat then
-  require("lv-utils").define_augroups {
-    _javascript_autoformat = {
-      {
-
-        "BufWritePre",
-        "*.js",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _javascriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.jsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescript_autoformat = {
-      {
-        "BufWritePre",
-        "*.ts",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.tsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/typescriptreact.lua
+++ b/ftplugin/typescriptreact.lua
@@ -34,40 +34,5 @@ require("lspconfig").tsserver.setup {
     }),
   },
 }
-
 require("lsp.ts-fmt-lint").setup()
-
-if O.lang.tsserver.autoformat then
-  require("lv-utils").define_augroups {
-    _javascript_autoformat = {
-      {
-
-        "BufWritePre",
-        "*.js",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _javascriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.jsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescript_autoformat = {
-      {
-        "BufWritePre",
-        "*.ts",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-    _typescriptreact_autoformat = {
-      {
-        "BufWritePre",
-        "*.tsx",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/zig.lua
+++ b/ftplugin/zig.lua
@@ -8,7 +8,6 @@ require("lspconfig").zls.setup {
 }
 require("lv-utils").define_augroups {
   _zig_autoformat = {
-    { "BufWritePre", "*.zig", "lua vim.lsp.buf.formatting_sync(nil, 1000)" },
     { "BufEnter", "*.zig", ':lua vim.api.nvim_buf_set_option(0, "commentstring", "// %s")' },
   },
 }

--- a/ftplugin/zsh.lua
+++ b/ftplugin/zsh.lua
@@ -15,16 +15,10 @@ require("lspconfig").bashls.setup {
 -- sh
 local sh_arguments = {}
 
-local shfmt = { formatCommand = "shfmt -ci -s -bn", formatStdin = true }
-
 local shellcheck = {
   LintCommand = "shellcheck -f gcc -x",
   lintFormats = { "%f:%l:%c: %trror: %m", "%f:%l:%c: %tarning: %m", "%f:%l:%c: %tote: %m" },
 }
-
-if O.lang.sh.formatter == "shfmt" then
-  table.insert(sh_arguments, shfmt)
-end
 
 if O.lang.sh.linter == "shellcheck" then
   table.insert(sh_arguments, shellcheck)

--- a/init.lua
+++ b/init.lua
@@ -16,9 +16,11 @@ end
 if O.format_on_save then
   require("lv-utils").define_augroups {
     autoformat = {
-      "BufWritePre",
-      "*",
-      [[try | undojoin | Neoformat | catch /^Vim\%((\a\+)\)\=:E790/ | finally | silent Neoformat | endtry]],
+      {
+        "BufWritePre",
+        "*",
+        [[try | undojoin | Neoformat | catch /^Vim\%((\a\+)\)\=:E790/ | finally | silent Neoformat | endtry]],
+      },
     },
   }
 end

--- a/init.lua
+++ b/init.lua
@@ -11,3 +11,14 @@ require "lsp"
 if O.lang.emmet.active then
   require "lsp.emmet-ls"
 end
+
+-- autoformat
+if O.format_on_save then
+  require("lv-utils").define_augroups {
+    autoformat = {
+      "BufWritePre",
+      "*",
+      [[try | undojoin | Neoformat | catch /^Vim\%((\a\+)\)\=:E790/ | finally | silent Neoformat | endtry]],
+    },
+  }
+end

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -4,6 +4,7 @@ CACHE_PATH = vim.fn.stdpath "cache"
 TERMINAL = vim.fn.expand "$TERMINAL"
 
 O = {
+  format_on_save = true,
   auto_close_tree = 0,
   auto_complete = true,
   colorscheme = "lunar",
@@ -31,6 +32,13 @@ O = {
     rainbow = { enabled = false },
   },
 
+<<<<<<< HEAD
+=======
+  lsp = {
+    popup_border = "single",
+  },
+
+>>>>>>> 786d7f8... Add forma_on_save on option
   database = { save_location = "~/.config/nvcode_db", auto_execute = 1 },
 
   plugin = {
@@ -75,9 +83,6 @@ O = {
   lang = {
     python = {
       linter = "",
-      -- @usage can be 'yapf', 'black'
-      formatter = "",
-      autoformat = false,
       isort = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
@@ -94,8 +99,6 @@ O = {
       sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
     },
     lua = {
-      -- @usage can be 'lua-format'
-      formatter = "",
       autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
@@ -107,8 +110,6 @@ O = {
       -- @usage can be 'shellcheck'
       linter = "",
       -- @usage can be 'shfmt'
-      formatter = "",
-      autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
@@ -118,9 +119,6 @@ O = {
     tsserver = {
       -- @usage can be 'eslint'
       linter = "",
-      -- @usage can be 'prettier'
-      formatter = "",
-      autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
@@ -128,9 +126,6 @@ O = {
       },
     },
     json = {
-      -- @usage can be 'prettier'
-      formatter = "",
-      autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
@@ -156,7 +151,6 @@ O = {
       },
       cross_file_rename = true,
       header_insertion = "never",
-      autoformat = false, -- update this to true for enabling autoformat
     },
     ruby = {
       diagnostics = {
@@ -176,8 +170,6 @@ O = {
         active = false,
       },
       linter = "",
-      formatter = "",
-      autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
@@ -186,13 +178,9 @@ O = {
     },
     svelte = {},
     php = {
-      format = {
-        braces = "psr12",
-      },
       environment = {
         php_version = "7.4",
       },
-      autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
@@ -211,8 +199,6 @@ O = {
     cmake = {},
     java = {},
     css = {
-      formatter = "",
-      autoformat = false,
       virtual_text = true,
     },
   },
@@ -284,4 +270,11 @@ require("lv-utils").define_augroups {
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
   },
+<<<<<<< HEAD
+=======
+  _auto_resize = {
+    -- will cause split windows to be resized evenly if main window is resized
+    { "VimResized ", "*", "wincmd =" },
+  },
+>>>>>>> 786d7f8... Add forma_on_save on option
 }

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -32,13 +32,10 @@ O = {
     rainbow = { enabled = false },
   },
 
-<<<<<<< HEAD
-=======
   lsp = {
     popup_border = "single",
   },
 
->>>>>>> 786d7f8... Add forma_on_save on option
   database = { save_location = "~/.config/nvcode_db", auto_execute = 1 },
 
   plugin = {
@@ -99,7 +96,6 @@ O = {
       sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
     },
     lua = {
-      autoformat = false,
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
@@ -270,11 +266,8 @@ require("lv-utils").define_augroups {
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
   },
-<<<<<<< HEAD
-=======
   _auto_resize = {
     -- will cause split windows to be resized evenly if main window is resized
     { "VimResized ", "*", "wincmd =" },
   },
->>>>>>> 786d7f8... Add forma_on_save on option
 }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -66,6 +66,9 @@ return require("packer").startup(function(use)
   -- Treesitter
   use { "nvim-treesitter/nvim-treesitter", run = ":TSUpdate" }
 
+  -- Neoformat
+  use { "sbdchd/neoformat", event = "BufEnter" }
+
   use {
     "kyazdani42/nvim-tree.lua",
     -- cmd = "NvimTreeToggle",
@@ -253,9 +256,9 @@ return require("packer").startup(function(use)
   use {
     "mfussenegger/nvim-dap",
     config = function()
-        require('dap')
-        vim.fn.sign_define('DapBreakpoint', {text='🛑', texthl='', linehl='', numhl=''})
-        require('dap').defaults.fallback.terminal_win_cmd = '50vsplit new'
+      require "dap"
+      vim.fn.sign_define("DapBreakpoint", { text = "🛑", texthl = "", linehl = "", numhl = "" })
+      require("dap").defaults.fallback.terminal_win_cmd = "50vsplit new"
     end,
     disable = not O.plugin.debug.active,
   }
@@ -435,7 +438,7 @@ return require("packer").startup(function(use)
       "typescript",
       "typescriptreact",
       "typescript.tsx",
-    }
+    },
   }
   -- use {
   --   "jose-elias-alvarez/null-ls.nvim",

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -1,13 +1,14 @@
 --[[
 O is the global options object
 
-Formatters and linters should be
+Linters should be
 filled in as strings with either
 a global executable or a path to
 an executable
 ]]
 -- THESE ARE EXAMPLE CONFIGS FEEL FREE TO CHANGE TO WHATEVER YOU WANT
 -- general
+O.format_on_save = true
 O.auto_complete = true
 O.colorscheme = "spacegray"
 O.auto_close_tree = 0
@@ -46,13 +47,9 @@ O.lang.clang.diagnostics.signs = true
 O.lang.clang.diagnostics.underline = true
 
 -- python
--- add things like O.python.formatter.yapf.exec_path
 -- add things like O.python.linter.flake8.exec_path
--- add things like O.python.formatter.isort.exec_path
-O.lang.python.formatter = "yapf"
 -- O.python.linter = 'flake8'
 O.lang.python.isort = true
-O.lang.python.autoformat = true
 O.lang.python.diagnostics.virtual_text = true
 O.lang.python.diagnostics.signs = true
 O.lang.python.diagnostics.underline = true
@@ -60,37 +57,11 @@ O.lang.python.analysis.type_checking = "off"
 O.lang.python.analysis.auto_search_paths = true
 O.lang.python.analysis.use_library_code_types = true
 
--- lua
--- TODO look into stylua
-O.lang.lua.formatter = "lua-format"
--- O.lua.formatter = 'lua-format'
-O.lang.lua.autoformat = false
-
 -- javascript
-O.lang.tsserver.formatter = "prettier"
 O.lang.tsserver.linter = nil
-O.lang.tsserver.autoformat = true
-
--- json
-O.lang.json.autoformat = true
-
--- ruby
-O.lang.ruby.autoformat = true
-
--- go
-O.lang.go.autoformat = true
-
--- rust
-O.lang.rust.autoformat = true
-
--- clang
-O.lang.clang.autoformat = false -- Set to true to enable auto-format in C/C++ files.
 
 -- php
-O.lang.php.format.braces = "k&r" -- options: psr12, allman, k&r
 O.lang.php.environment.php_version = "7.4"
--- TODO: autoformat seems not to work at the moment
-O.lang.php.autoformat = false
 O.lang.php.diagnostics.signs = true
 O.lang.php.diagnostics.underline = true
 O.lang.php.filetypes = { "php", "phtml" }


### PR DESCRIPTION
* Get rid of all unnecessary complexity for setting up efm for formatting

* No need for efm server since it's no going to be used for formatting
  (some languages need it for lint, e.g python, if those cases the efm
  server was left and not completely removed)

*  Add `forma_on_save` option and remove all unnecessary format options for specific languages

### Benefits

1. Users can toggle format_on_save for all languages, and not have an option for every single language as it was before.
2. We don't need to worry about setting up formatters with efm anymore (which can be a pain to do)
3. Simplify the config, and get rid of a ton of unnecessary settings for specific languages. We don't have to parse x formatter that an user want to efm or whatever. Just having the formatter you want installed and in your path will work out of the box.

Hey @ChristianChiarulli this is done, and tested in my machine, all working as expected. Take a look a let me know if you want any change (also test this to be 100% sure before merging)