### PR TITLE
Fix vue lsp root_dir configuration

### DIFF
--- a/ftplugin/vue.lua
+++ b/ftplugin/vue.lua
@@ -1,5 +1,6 @@
+-- Vue language server configuration (vetur)
 require("lspconfig").vuels.setup {
   cmd = { DATA_PATH .. "/lspinstall/vue/node_modules/.bin/vls", "--stdio" },
   on_attach = require("lsp").common_on_attach,
-  root_dir = require("lspconfig").util.root_pattern(".git", "."),
+  root_dir = require("lspconfig").util.root_pattern(".git", "vue.config.js", "package.json", "yarn.lock"),
 }


### PR DESCRIPTION
More specific root_dir configuration for most (typical) vue projects. The "." does not work in certain cases.