### PR TITLE
telescope project and packer had the same keybinding

### DIFF
--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -295,7 +295,7 @@ if O.plugin.telescope_project.active then
   -- open projects
   vim.api.nvim_set_keymap(
     "n",
-    "<leader>p",
+    "<leader>P",
     ":lua require'telescope'.extensions.project.project{}<CR>",
     { noremap = true, silent = true }
   )


### PR DESCRIPTION
Just changed the telescope project keybinding to `<leader>P` instead of `<leader>p`