### PR TITLE
Fix error in ftplugin/php.lua when opening a PHP file.

### DIFF
--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -65,6 +65,12 @@ O.lang.php.environment.php_version = "7.4"
 O.lang.php.diagnostics.signs = true
 O.lang.php.diagnostics.underline = true
 O.lang.php.filetypes = {"php", "phtml"}
+O.lang.php.format = {
+  format = {
+    default = "psr12"
+  }
+}
+
 
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
 -- O.user_autocommands = {{ "BufWinEnter", "*", "echo \"hi again\""}}


### PR DESCRIPTION
Trying to open/edit a PHP file throws an error:
```
Error detected while processing /Users/xxx/.config/nvim/ftplugin/php.lua:
E5113: Error while calling lua chunk: /Users/xxx/.config/nvim/ftplugin/php.lua:16: attempt to index field 'format' (a nil value)
Error detected while processing FileType Autocommands for "*":
Error while processing file: /Users/xxx/.config/nvim/ftplugin/php.lua
/Users/joanlopez/.config/nvim/ftplugin/php.lua:16: attempt to index field 'format' (a nil value)
Press ENTER or type command to continue
```