### PR TITLE
add top level keybinding for symbols outline.

### DIFF
--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -274,6 +274,11 @@ end
 --   }
 -- end
 
+if O.plugin.symbol_outline.active then
+    vim.api.nvim_set_keymap("n", "<leader>o", ":SymbolsOutline<CR>", { noremap = true, silent = true })
+    mappings["o"] = "Symbols outline"
+end
+
 if O.plugin.gitlinker.active then
   mappings["gy"] = "Gitlink"
 end


### PR DESCRIPTION
IMHO Symbols outline deserves a top level keybinding, same as `vimtree` explorer. On different scopes, both plugins help navigate code fast and efficiently.