### PR TITLE
we don't need to remove autoformat group when there is none

### DIFF
--- a/lua/lv-neoformat/init.lua
+++ b/lua/lv-neoformat/init.lua
@@ -10,7 +10,3 @@ if O.format_on_save then
     },
   }
 end
-
-if not O.format_on_save then
-  vim.cmd ":autocmd! autoformat"
-end


### PR DESCRIPTION
Fixes #746
When we have 
```lua
O.format_on_save = false
```
inside `lv-config.lua`
we get the following error, because there is no `autoformat` group to be removed
![Screenshot-20210707103857-2632x372](https://user-images.githubusercontent.com/10992695/124708668-d3738980-df0f-11eb-97ed-07e9c70c615e.png)
