### PR TITLE
add missing QuickFixToggle() function

### DIFF
--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -85,6 +85,17 @@ lv_utils.define_augroups {
   -- },
 }
 
+vim.cmd([[
+  function! QuickFixToggle()
+    if empty(filter(getwininfo(), 'v:val.quickfix'))
+      copen
+    else
+      cclose
+    endif
+endfunction
+]]
+)
+
 return lv_utils
 
 -- TODO find a new home for these autocommands


### PR DESCRIPTION
Fixes #750 

@ChristianChiarulli  we can either do this or remove the `<C-q>` [binding](https://github.com/ChristianChiarulli/LunarVim/blob/master/lua/keymappings.lua#L86).
