### PR TITLE
Add empty buffer option to dashboard

### DIFF
--- a/lua/lv-dashboard/init.lua
+++ b/lua/lv-dashboard/init.lua
@@ -17,18 +17,22 @@ M.config = function()
       command = "Telescope oldfiles",
     },
     c = {
+      description = { "  Empty Buffer       " },
+      command = ":enew",
+    },
+    d = {
       description = { "  Load Last Session  " },
       command = "SessionLoad",
     },
-    d = {
+    e = {
       description = { "  Find Word          " },
       command = "Telescope live_grep",
     },
-    e = {
+    f = {
       description = { "  Settings           " },
       command = ":e " .. CONFIG_PATH .. "/lv-config.lua",
     },
-    -- f = {
+    -- g = {
     --   description = { "  Neovim Config Files" },
     --   command = "Telescope find_files cwd=" .. CONFIG_PATH,
     -- },


### PR DESCRIPTION
An empty buffer would be helpful I believe. [vim-startify](https://github.com/mhinz/vim-startify) has something like it too.
Something like this:
![image](https://user-images.githubusercontent.com/56478603/124774920-ced4c280-df5b-11eb-879d-b2f1797ff793.png)
