### PR TITLE
Add a git-ignored folder for users to store their personal configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ spell/
 nv-settings.lua
 lv-settings.lua
 .stylua.toml
+lua/lv-user-config

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ spell/
 nv-settings.lua
 lv-settings.lua
 .stylua.toml
-lua/lv-user-config
+lua/lv-user-config/


### PR DESCRIPTION
I'm requesting the addition of a .gitignored folder for user configuration.  This can be useful if you want to split up your lv-config.lua into smaller files.  

Additionally, it compliments the management strategy I created here:
https://github.com/ChristianChiarulli/LunarVim/issues/758

This makes it so you don't see the git submodule every time you run 'git status'.  

I'm flexible on the name of the folder if you want to suggest something else. 
