### PR TITLE
fix lazygit esc issue

### DIFF
--- a/lua/lv-floatterm/init.lua
+++ b/lua/lv-floatterm/init.lua
@@ -40,6 +40,17 @@ M.config = function()
     end
     lazy:toggle()
   end
+
+  -- Map esc to exit inside lazygit
+  vim.api.nvim_exec([[
+  function LazyGitNativation()
+    echom &filetype
+    if &filetype ==# 'FTerm'
+      tnoremap <Esc> q
+      tnoremap <C-v><Esc> <Esc>
+    endif
+  endfunction
+  ]], false)
 end
 
 return M

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -76,6 +76,10 @@ lv_utils.define_augroups {
     -- will cause split windows to be resized evenly if main window is resized
     { "VimResized ", "*", "wincmd =" },
   },
+  _fterm_lazygit = {
+    -- will cause esc key to exit lazy git
+    {"TermEnter", "*", "call LazyGitNativation()"}
+  },
   -- _mode_switching = {
   --   -- will switch between absolute and relative line numbers depending on mode
   --   {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},


### PR DESCRIPTION
Fixes #759 
While using `Lazygit` inside `FTerm`, `esc` key will act as quit instead of going to normal mode