### PR TITLE
[REFACTOR] allow customizing efm configuration

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -22,3 +22,7 @@ require("lspconfig").clangd.setup {
     }),
   },
 }
+
+if O.lang.clang.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"c", "cpp"})
+end

--- a/ftplugin/css.lua
+++ b/ftplugin/css.lua
@@ -14,3 +14,7 @@ if not require("lv-utils").check_lsp_client_active "cssls" then
 end
 
 vim.cmd "setl ts=2 sw=2"
+
+if O.lang.css.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"css"})
+end

--- a/ftplugin/html.lua
+++ b/ftplugin/html.lua
@@ -15,3 +15,7 @@ if not require("lv-utils").check_lsp_client_active "html" then
 end
 
 vim.cmd "setl ts=2 sw=2"
+
+if O.lang.html.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"html"})
+end

--- a/ftplugin/javascript.lua
+++ b/ftplugin/javascript.lua
@@ -1,3 +1,6 @@
 require "lsp.tsserver-ls"
 
+if O.lang.javascript.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"javascript"})
+end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/javascriptreact.lua
+++ b/ftplugin/javascriptreact.lua
@@ -1,3 +1,7 @@
 require "lsp.tsserver-ls"
 
+if O.lang.javascriptreact.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"javascriptreact"})
+end
+
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/lua.lua
+++ b/ftplugin/lua.lua
@@ -45,3 +45,7 @@ if O.lang.lua.autoformat then
 end
 
 vim.cmd "setl ts=2 sw=2"
+
+if O.lang.lua.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"lua"})
+end

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -67,3 +67,7 @@ if O.plugin.dap.active then
   local dap_install = require "dap-install"
   dap_install.config("python_dbg", {})
 end
+
+if O.lang.python.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"python"})
+end

--- a/ftplugin/sh.lua
+++ b/ftplugin/sh.lua
@@ -1,37 +1,16 @@
-if not require("lv-utils").check_lsp_client_active "bashls" then
-  -- npm i -g bash-language-server
-  require("lspconfig").bashls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server", "start" },
-    on_attach = require("lsp").common_on_attach,
-    filetypes = { "sh", "zsh" },
-  }
-end
+-- npm i -g bash-language-server
+local	ft = { "sh", "bash" }
 
--- sh
-local sh_arguments = {}
+require("lspconfig").bashls.setup({
+	cmd = {
+		DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server",
+		"start",
+	},
+	on_attach = require("lsp").common_on_attach,
+	filetypes = ft,
+})
 
-local shfmt = { formatCommand = "shfmt -ci -s -bn", formatStdin = true }
 
-local shellcheck = {
-  LintCommand = "shellcheck -f gcc -x",
-  lintFormats = { "%f:%l:%c: %trror: %m", "%f:%l:%c: %tarning: %m", "%f:%l:%c: %tote: %m" },
-}
-
-if O.lang.sh.linter == "shellcheck" then
-  table.insert(sh_arguments, shellcheck)
-end
-
-if not require("lv-utils").check_lsp_client_active "efm" then
-  require("lspconfig").efm.setup {
-    -- init_options = {initializationOptions},
-    cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
-    init_options = { documentFormatting = true, codeAction = false },
-    filetypes = { "sh" },
-    settings = {
-      rootMarkers = { ".git/" },
-      languages = {
-        sh = sh_arguments,
-      },
-    },
-  }
+if O.lang.sh.efm.active == true then
+  require("lsp.efm-ls").generic_setup(ft)
 end

--- a/ftplugin/typescript.lua
+++ b/ftplugin/typescript.lua
@@ -1,3 +1,6 @@
 require "lsp.tsserver-ls"
 
+if O.lang.typescript.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"typescript"})
+end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/typescriptreact.lua
+++ b/ftplugin/typescriptreact.lua
@@ -1,3 +1,6 @@
 require "lsp.tsserver-ls"
 
+if O.lang.typescriptreact.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"typescriptreact"})
+end
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/vue.lua
+++ b/ftplugin/vue.lua
@@ -8,3 +8,8 @@ require("lspconfig").vuels.setup {
   on_attach = require("lsp").common_on_attach,
   root_dir = require("lspconfig").util.root_pattern(".git", "vue.config.js", "package.json", "yarn.lock"),
 }
+
+if O.lang.vue.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"vue"})
+end
+

--- a/ftplugin/yaml.lua
+++ b/ftplugin/yaml.lua
@@ -8,3 +8,7 @@ require("lspconfig").yamlls.setup {
   on_attach = require("lsp").common_on_attach,
 }
 vim.cmd "setl ts=2 sw=2 ts=2 ai et"
+
+if O.lang.yaml.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"yaml"})
+end

--- a/ftplugin/zsh.lua
+++ b/ftplugin/zsh.lua
@@ -1,35 +1,10 @@
-if not require("lv-utils").check_lsp_client_active "bashls" then
-  -- npm i -g bash-language-server
-  require("lspconfig").bashls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server", "start" },
-    on_attach = require("lsp").common_on_attach,
-    filetypes = { "sh", "zsh" },
-  }
-end
-
--- sh
-local sh_arguments = {}
-
-local shellcheck = {
-  LintCommand = "shellcheck -f gcc -x",
-  lintFormats = { "%f:%l:%c: %trror: %m", "%f:%l:%c: %tarning: %m", "%f:%l:%c: %tote: %m" },
+-- npm i -g bash-language-server
+require'lspconfig'.bashls.setup {
+    cmd = {DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server", "start"},
+    on_attach = require'lsp'.common_on_attach,
+    filetypes = { "zsh" }
 }
 
-if O.lang.sh.linter == "shellcheck" then
-  table.insert(sh_arguments, shellcheck)
-end
-
-if not require("lv-utils").check_lsp_client_active "efm" then
-  require("lspconfig").efm.setup {
-    -- init_options = {initializationOptions},
-    cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
-    init_options = { documentFormatting = true, codeAction = false },
-    filetypes = { "zsh" },
-    settings = {
-      rootMarkers = { ".git/" },
-      languages = {
-        sh = sh_arguments,
-      },
-    },
-  }
+if O.lang.sh.efm.active == true then
+  require("lsp.efm-ls").generic_setup({"zsh"})
 end

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -4,6 +4,12 @@ CACHE_PATH = vim.fn.stdpath "cache"
 TERMINAL = vim.fn.expand "$TERMINAL"
 USER = vim.fn.expand "$USER"
 
+local EFM_CONF_PATH = os.getenv("HOME") .. "/.config/efm-langserver/config.yaml"
+
+if vim.fn.empty(vim.fn.glob(EFM_CONF_PATH)) > 0 then
+  EFM_CONF_PATH = CONFIG_PATH .. "/utils/efm-config.yaml"
+end
+
 O = {
   leader_key = "space",
   colorscheme = "spacegray",
@@ -64,6 +70,10 @@ O = {
     popup_border = "single",
   },
 
+  efm = {
+    config_path = EFM_CONF_PATH,
+  },
+
   database = { save_location = "~/.config/lunarvim_db", auto_execute = 1 },
 
   plugin = {
@@ -120,7 +130,6 @@ O = {
       },
     },
     docker = {},
-    efm = {},
     elm = {},
     emmet = { active = true },
     elixir = {},
@@ -130,6 +139,7 @@ O = {
         exe = "gofmt",
         args = {},
       },
+      efm = { active = true},
     },
     html = {},
     java = {
@@ -147,12 +157,10 @@ O = {
         exe = "python",
         args = { "-m", "json.tool" },
       },
+      efm = { active = true},
     },
     kotlin = {},
-    latex = {
-      auto_save = false,
-      ignore_errors = { },
-    },
+    latex = {},
     lua = {
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
@@ -161,7 +169,7 @@ O = {
       },
       formatter = {
         exe = "stylua",
-        args = {},
+        args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0) },
         stdin = false,
       },
     },
@@ -204,6 +212,7 @@ O = {
         exe = "yapf",
         args = {},
       },
+      efm = { active = true},
     },
     ruby = {
       diagnostics = {
@@ -226,7 +235,7 @@ O = {
       -- @usage can be clippy
       formatter = {
         exe = "rustfmt",
-        args = { "--emit=stdout", "--edition=2018" },
+        args = { "--emit=stdout" },
       },
       linter = "",
       diagnostics = {
@@ -249,6 +258,7 @@ O = {
         args = { "-w" },
         stdin = false,
       },
+      efm = { active = true},
     },
     svelte = {},
     tailwindcss = {
@@ -264,13 +274,12 @@ O = {
       },
       formatter = {
         exe = "prettier",
-        args = { "--write", "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
-        stdin = false,
+        args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
       },
     },
     terraform = {},
     tsserver = {
-      -- @usage can be 'eslint' or 'eslint_d'
+      -- @usage can be 'eslint'
       linter = "",
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
@@ -279,9 +288,9 @@ O = {
       },
       formatter = {
         exe = "prettier",
-        args = { "--write", "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
-        stdin = false,
+        args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
       },
+      efm = { active = true},
     },
     vim = {},
     yaml = {

--- a/lua/lsp/efm-ls.lua
+++ b/lua/lsp/efm-ls.lua
@@ -1,0 +1,16 @@
+local efm = {}
+
+function efm.generic_setup(ft)
+	require("lspconfig").efm.setup({
+		cmd = {
+			DATA_PATH .. "/lspinstall/efm/efm-langserver",
+			"-c",
+			O.efm.config_path,
+		},
+		init_options = { documentFormatting = true, codeAction = false, completion = false, documentSymbol = false },
+		filetypes = ft,
+    -- rootMarkers = {".git/", "package.json"},
+	})
+end
+
+return efm

--- a/utils/efm-config.yaml
+++ b/utils/efm-config.yaml
@@ -1,0 +1,236 @@
+---
+version: 2
+log-file: /tmp/efm-output.log
+log-level: 1
+tools:
+  yaml-yamllint: &yaml-yamllint
+    lint-command: 'yamllint -f parsable -'
+    lint-stdin: true
+
+  python-flake8: &python-flake8
+    lint-command: 'flake8 --stdin-display-name ${INPUT} -'
+    lint-stdin: true
+    lint-formats:
+      - '%f:%l:%c: %m'
+  python-yapf: &python-yapf
+    format-command: 'yapf --quiet'
+    format-stdin: true
+  python-mypy: &python-mypy
+    lint-command: 'mypy --show-column-numbers'
+    lint-formats:
+      - '%f:%l:%c: %trror: %m'
+      - '%f:%l:%c: %tarning: %m'
+      - '%f:%l:%c: %tote: %m'
+  python-pylint: &python-pylint
+    lint-command: 'pylint --output-format text --score no --msg-template {path}:{line}:{column}:{C}:{msg} ${INPUT}'
+    lint-stdin: false
+    lint-formats:
+      - '%f:%l:%c:%t:%m'
+    lint-offset-columns: 1
+    lint-category-map:
+      I: H
+      R: I
+      C: I
+      W: W
+      E: E
+      F: E
+
+  dockerfile-hadolint: &dockerfile-hadolint
+    lint-command: 'hadolint'
+    lint-formats:
+      - '%f:%l %m'
+
+  sh-shellcheck: &sh-shellcheck
+    lint-command: 'shellcheck -f gcc -x'
+    lint-formats:
+      - '%f:%l:%c: %trror: %m'
+      - '%f:%l:%c: %tarning: %m'
+      - '%f:%l:%c: %tote: %m'
+
+  sh-shfmt: &sh-shfmt
+    format-command: 'shfmt -i 2 -ci'
+    format-stdin: true
+
+  eslint: &eslint
+    lint-command: 'eslint -f visualstudio --stdin --stdin-filename ${INPUT}'
+    lint-ignore-exit-code: true
+    lint-stdin: true
+    lint-formats:
+      - "%f(%l,%c): %tarning %m"
+      - "%f(%l,%c): %rror %m"
+  eslint_d: &eslint_d
+    lint-command: './node_modules/.bin/eslint_d -f visualstudio --stdin --stdin-filename ${INPUT}'
+    lint-ignore-exit-code: true
+    lint-stdin: true
+    lint-formats:
+      - "%f(%l,%c): %tarning %m"
+      - "%f(%l,%c): %rror %m"
+    root-markers:
+      - .eslintrc.js
+      - .eslintrc.yaml
+      - .eslintrc.yml
+      - .eslintrc.json
+      - .eslintrc.cjs
+  local-eslint: &local-eslint
+    lint-command: './node_modules/.bin/eslint -f visualstudio --stdin --stdin-filename ${INPUT}'
+    lint-ignore-exit-code: true
+    lint-stdin: true
+    lint-formats:
+      - "%f(%l,%c): %tarning %m"
+      - "%f(%l,%c): %rror %m"
+    root-markers:
+      - .eslintrc.cjs
+      - package.json
+      - .eslintrc.js
+      - .eslintrc.yaml
+      - .eslintrc.yml
+      - .eslintrc.json
+
+  prettier: &prettier
+    format-command: 'prettier --stdin-filepath ${INPUT}'
+    format-stdin: true
+    root-markers:
+      - '.prettierrc'
+      - '.prettierrc.json'
+  prettier-d: &prettier_d
+    format-command: 'prettierd --stdin-filename ${INPUT}'
+    format-stdin: true
+    root-markers:
+      - '.prettierrc'
+      - '.prettierrc.json'
+  prettier-d-slim: &prettier-d-slim
+    format-command: 'prettier_d_slim --stdin --stdin-filepath ${INPUT}'
+    format-stdin: true
+    root-markers:
+      - '.prettierrc'
+      - '.prettierrc.json'
+  local-prettier: &local-prettier
+    format-command: './node_modules/.bin/prettier --stdin-filepath ${INPUT}'
+    format-stdin: true
+  local-prettier-d-slim: &local-prettier-d-slim
+    format-command: './node_modules/.bin/prettier_d_slim --stdin --stdin-filepath ${INPUT}'
+    format-stdin: true
+    root-markers:
+      - '.prettierrc'
+      - '.prettierrc.json'
+
+  html-prettier: &html-prettier
+    format-command: './node_modules/.bin/prettier --parser html --stdin-filename ${INPUT}'
+    format-stdin: true
+    root-markers:
+      - .prettierrc
+      - .prettierrc.json
+
+  css-prettier: &css-prettier
+    format-command: './node_modules/.bin/prettier --parser css --stdin-filename ${INPUT}'
+    format-stdin: true
+    root-markers: 
+      - .prettierrc
+      - .prettierrc.json
+
+  json-prettier: &json-prettier
+    format-command: './node_modules/.bin/prettier --parser json --stdin-filename ${INPUT}'
+    format-stdin: true
+    root-markers: 
+      - .prettierrc
+      - .prettierrc.json
+
+  json-jq: &json-jq
+    lint-command: 'jq .'
+
+  json-fixjson: &json-fixjson
+    format-command: 'fixjson'
+
+  csv-csvlint: &csv-csvlint
+    lint-command: 'csvlint'
+
+  stylelint-lint: &stylelint-lint
+    lint-command: './node_modules/.bin/stylelint --formatter unix --stdin --stdin-filename ${INPUT}'
+    lint-ignore-exit-code: false
+    lint-stdin: true
+    lint-formats:
+      - '%f:%l:%c: %m [%t%*[a-z]]'
+    root-markers:
+      - .stylelintrc.json
+      - .stylelintrc
+
+  lua-stylua-format: &lua-stylua-format
+    format-command: 'stylua -'
+    format-stdin: true
+    root-markers:
+      - 'stylua.toml'
+
+  luaformat: &luaformat
+    format-command: "lua-format --chop-down-table --indent-width=2 --no-use-tab --in-place --no-keep-simple-function-one-line --column-limit=80"
+    format-stdin: true
+
+  luacheck: &luacheck
+    lint-command: 'luacheck --std lua51 --globals vim --filename ${INPUT} --formatter visual_studio -'
+    lint-stdin: true
+    lint-formats:
+      - '%f:%l:%c: %m'
+
+  any-excitetranslate: &any-excitetranslate
+    hover-command: 'excitetranslate'
+    hover-stdin: true
+
+languages:
+  # yaml:
+  #   - <<: *yaml-yamllint
+
+  python:
+    - <<: *python-yapf
+    - <<: *python-mypy
+    - <<: *python-pylint
+
+  dockerfile:
+    - <<: *dockerfile-hadolint
+
+  sh:
+    - <<: *sh-shellcheck
+    - <<: *sh-shfmt
+
+  javascript:
+    - <<: *prettier
+    - <<: *eslint
+    # - <<: *eslint_d
+    # - <<: *local-prettier-d-slim
+    # - <<: *stylelint-lint
+
+  # javascriptreact:
+    # - <<: *prettier
+    # - <<: *eslint
+    # - <<: *eslint_d
+    # - <<: *local-prettier-d-slim
+    # - <<: *stylelint-lint
+
+  typescript:
+    - <<: *prettier
+    - <<: *eslint
+    # - <<: *local-prettier-d-slim
+    # - <<: *stylelint-lint
+
+  # typescriptreact:
+    # - <<: *eslint_d
+    # - <<: *local-prettier-d-slim
+    # - <<: *stylelint-lint
+
+  html:
+    - <<: *local-prettier-d-slim
+
+  css:
+    - <<: *css-prettier
+    - <<: *stylelint-lint
+
+  json:
+    - <<: *json-jq
+    # - <<: *json-fixjson
+    - <<: *json-prettier
+
+  lua:
+    - <<: *lua-stylua-format
+    # - <<: *luaformat
+    - <<: *luacheck
+
+  _:
+    - <<: *any-excitetranslate


### PR DESCRIPTION
- efm now follows the user-config in "~/.config/efm-langserver/config.yaml".
- Add an optional "efm-config.yaml" with support for a lot of popular
  linters/formmatters that works as a *fallback* in case the user-config
  file is completely missing. This gives the user the ability to copy the provided template
  and override whatever option they'd like.
- Using efm is now opt-in and can be selectively turned on for each
  language separately. For example: "O.lang.lua.efm.active = true"
