### PR TITLE
Option to rename rust parameter hints & cleanup

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -28,11 +28,11 @@ if O.lang.rust.rust_tools.active then
 
         -- prefix for parameter hints
         -- default: "<-"
-        parameter_hints_prefix = "<-",
+        parameter_hints_prefix = O.lang.rust.parameter_hints_prefix,
 
         -- prefix for all the other hints (type, chaining)
         -- default: "=>"
-        other_hints_prefix = "=>",
+        other_hints_prefix = O.lang.rust.other_hints_prefix,
 
         -- whether to align to the lenght of the longest line in the file
         max_len_align = false,

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -99,68 +99,7 @@ O = {
   },
 
   lang = {
-    python = {
-      linter = "",
-      isort = false,
-      diagnostics = {
-        virtual_text = { spacing = 0, prefix = "" },
-        signs = true,
-        underline = true,
-      },
-      analysis = {
-        type_checking = "basic",
-        auto_search_paths = true,
-        use_library_code_types = true,
-      },
-    },
-    dart = {
-      sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
-    },
-    lua = {
-      diagnostics = {
-        virtual_text = { spacing = 0, prefix = "" },
-        signs = true,
-        underline = true,
-      },
-    },
-    sh = {
-      -- @usage can be 'shellcheck'
-      linter = "",
-      -- @usage can be 'shfmt'
-      diagnostics = {
-        virtual_text = { spacing = 0, prefix = "" },
-        signs = true,
-        underline = true,
-      },
-    },
-    tsserver = {
-      -- @usage can be 'eslint'
-      linter = "",
-      diagnostics = {
-        virtual_text = { spacing = 0, prefix = "" },
-        signs = true,
-        underline = true,
-      },
-    },
-    json = {
-      diagnostics = {
-        virtual_text = { spacing = 0, prefix = "" },
-        signs = true,
-        underline = true,
-      },
-    },
-    tailwindcss = {
-      active = false,
-      filetypes = {
-        "html",
-        "css",
-        "scss",
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact",
-      },
-    },
+    cmake = {},
     clang = {
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
@@ -170,34 +109,37 @@ O = {
       cross_file_rename = true,
       header_insertion = "never",
     },
-    ruby = {
-      diagnostics = {
-        virtualtext = { spacing = 0, prefix = "" },
-        signs = true,
-        underline = true,
-      },
-      filetypes = { "rb", "erb", "rakefile", "ruby" },
+    css = {
+      virtual_text = true,
     },
-    go = {},
+    dart = {
+      sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
+    },
+    docker = {},
+    efm = {},
+    elm = {},
+    emmet = { active = true },
     elixir = {},
-    vim = {},
-    yaml = {},
-    terraform = {},
-    rust = {
-      rust_tools = {
-        active = false,
-        parameter_hints_prefix = "<-",
-        other_hints_prefix = "=>", -- prefix for all the other hints (type, chaining)
-      },
-      linter = "",
+    graphql = {},
+    go = {},
+    html = {},
+    java = {},
+    json = {
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },
         signs = true,
         underline = true,
       },
     },
-    svelte = {},
-
+    kotlin = {},
+    latex = {},
+    lua = {
+      diagnostics = {
+        virtual_text = { spacing = 0, prefix = "" },
+        signs = true,
+        underline = true,
+      },
+    },
     php = {
       format = {
         format = {
@@ -214,19 +156,76 @@ O = {
       },
       filetypes = { "php", "phtml" },
     },
-    latex = {},
-    kotlin = {},
-    html = {},
-    elm = {},
-    emmet = { active = true },
-    graphql = {},
-    efm = {},
-    docker = {},
-    cmake = {},
-    java = {},
-    css = {
-      virtual_text = true,
+    python = {
+      linter = "",
+      isort = false,
+      diagnostics = {
+        virtual_text = { spacing = 0, prefix = "" },
+        signs = true,
+        underline = true,
+      },
+      analysis = {
+        type_checking = "basic",
+        auto_search_paths = true,
+        use_library_code_types = true,
+      },
     },
+    ruby = {
+      diagnostics = {
+        virtualtext = { spacing = 0, prefix = "" },
+        signs = true,
+        underline = true,
+      },
+      filetypes = { "rb", "erb", "rakefile", "ruby" },
+    },
+    rust = {
+      rust_tools = {
+        active = false,
+        parameter_hints_prefix = "<-",
+        other_hints_prefix = "=>", -- prefix for all the other hints (type, chaining)
+      },
+      linter = "",
+      diagnostics = {
+        virtual_text = { spacing = 0, prefix = "" },
+        signs = true,
+        underline = true,
+      },
+    },
+    sh = {
+      -- @usage can be 'shellcheck'
+      linter = "",
+      -- @usage can be 'shfmt'
+      diagnostics = {
+        virtual_text = { spacing = 0, prefix = "" },
+        signs = true,
+        underline = true,
+      },
+    },
+    svelte = {},
+    tailwindcss = {
+      active = false,
+      filetypes = {
+        "html",
+        "css",
+        "scss",
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+      },
+    },
+    terraform = {},
+    tsserver = {
+      -- @usage can be 'eslint'
+      linter = "",
+      diagnostics = {
+        virtual_text = { spacing = 0, prefix = "" },
+        signs = true,
+        underline = true,
+      },
+    },
+    vim = {},
+    yaml = {},
   },
 
   dashboard = {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -186,6 +186,8 @@ O = {
     rust = {
       rust_tools = {
         active = false,
+        parameter_hints_prefix = "<-",
+        other_hints_prefix = "=>", -- prefix for all the other hints (type, chaining)
       },
       linter = "",
       diagnostics = {


### PR DESCRIPTION
- Added the ability to change parameter hint prefix for Rust in the user config file
- Reordered the language list to be in alphabetical order