### PR TITLE
Use which-key for spelling hints

### DIFF
--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -21,6 +21,7 @@ which_key.setup {
       z = true, -- bindings for folds, spelling and others prefixed with z
       g = true, -- bindings for prefixed with g
     },
+    spelling = {enabled = true, suggestions = 20}, -- use which-key for spelling hints
   },
   icons = {
     breadcrumb = "»", -- symbol used in the command line area that shows your active key combo


### PR DESCRIPTION
This is a nice default to have which doesn't require any additional plugins or configuration but simply replaces the built-in extremely basic spelling hint list with the which-key interface.

To test, simply:
```
:PackerCompile
set spell -- enable spell checking
z= -- press this on a misspelled word that is underlined
```

I haven't included the following,  but this is a nice addition to enable spell checking by default for certain filetypes:
```
vim.cmd [[autocmd FileType text,latex,tex,md,markdown setlocal spell]]
```

Alternatively, having a keybinding to toggle spell checking could be an option?