### PR TITLE
you can disable clipboard

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -8,6 +8,7 @@ O = {
   auto_close_tree = 0,
   auto_complete = true,
   colorscheme = "lunar",
+  clipboard = "unnamedplus",
   hidden_files = true,
   wrap_lines = false,
   number = true,

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -22,7 +22,7 @@ vim.g.colors_name = O.colorscheme
 ---  SETTINGS  ---
 
 opt.backup = false -- creates a backup file
-opt.clipboard = "unnamedplus" -- allows neovim to access the system clipboard
+opt.clipboard = O.clipboard -- allows neovim to access the system clipboard
 opt.cmdheight = O.cmdheight -- more space in the neovim command line for displaying messages
 opt.colorcolumn = "99999" -- fix indentline for now
 opt.completeopt = { "menuone", "noselect" }


### PR DESCRIPTION
by setting
```lua
O.clipboard = ""
```
inside your `lv-config.lua` you can disable the neovim systemwide clipboard usage
> for context: somebody asked on discord how to disable it