### PR TITLE
Scrolloff option in lv-config

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -17,6 +17,7 @@ O = {
   cmdheight = 2,
   cursorline = true,
   shell = "bash",
+  scrolloff = 0,
   timeoutlen = 100,
   nvim_tree_disable_netrw = 0,
   ignore_case = true,

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -34,6 +34,7 @@ opt.hlsearch = O.hl_search -- highlight all matches on previous search pattern
 opt.ignorecase = O.ignore_case -- ignore case in search patterns
 opt.mouse = "a" -- allow the mouse to be used in neovim
 opt.pumheight = 10 -- pop up menu height
+opt.scrolloff = O.scrolloff -- minimal number of screen lines to keep above and below the cursor
 opt.showmode = false -- we don't need to see things like -- INSERT -- anymore
 opt.showtabline = 2 -- always show tabs
 opt.smartcase = O.smart_case -- smart case


### PR DESCRIPTION
A neat little feature that I find quite useful

> 	Minimal number of screen lines to keep above and below the cursor.
	This will make some context visible around where you are working.  If
	you set it to a very large value (999) the cursor line will always be
	in the middle of the window (except at the start or end of the file or
	when long lines wrap).