### PR TITLE
Split plugin loading logic from the configuration

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -4,9 +4,14 @@ if not status_ok then
   print "something is wrong with your lv-config"
   print(error)
 end
+
 require "keymappings"
-require "plugins"
+
+local plugins = require "plugins"
+local plugin_loader = require("plugin-loader").init()
+plugin_loader:load { plugins, O.user_plugins }
 vim.g.colors_name = O.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
+
 require "settings"
 require "lv-utils"
 

--- a/lua/plugin-loader.lua
+++ b/lua/plugin-loader.lua
@@ -1,0 +1,46 @@
+local plugin_loader = {}
+
+function plugin_loader:init()
+  local execute = vim.api.nvim_command
+  local fn = vim.fn
+
+  local install_path = fn.stdpath "data" .. "/site/pack/packer/start/packer.nvim"
+  if fn.empty(fn.glob(install_path)) > 0 then
+    execute("!git clone https://github.com/wbthomason/packer.nvim " .. install_path)
+    execute "packadd packer.nvim"
+  end
+
+  local packer_ok, packer = pcall(require, "packer")
+  if not packer_ok then
+    return
+  end
+
+  packer.init {
+    -- package_root = require("packer.util").join_paths(vim.fn.stdpath "data", "lvim", "pack"),
+    git = { clone_timeout = 300 },
+    display = {
+      open_fn = function()
+        return require("packer.util").float { border = "single" }
+      end,
+    },
+  }
+
+  self.packer = packer
+  return self
+end
+
+function plugin_loader:load(configurations)
+  return self.packer.startup(function(use)
+    for _, plugins in ipairs(configurations) do
+      for _, plugin in ipairs(plugins) do
+        use(plugin)
+      end
+    end
+  end)
+end
+
+return {
+  init = function()
+    return plugin_loader:init()
+  end,
+}

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,101 +1,76 @@
-local execute = vim.api.nvim_command
-local fn = vim.fn
-
-local install_path = fn.stdpath "data" .. "/site/pack/packer/start/packer.nvim"
-
-if fn.empty(fn.glob(install_path)) > 0 then
-  execute("!git clone https://github.com/wbthomason/packer.nvim " .. install_path)
-  execute "packadd packer.nvim"
-end
-
-local packer_ok, packer = pcall(require, "packer")
-if not packer_ok then
-  return
-end
-
-packer.init {
-  -- package_root = require("packer.util").join_paths(vim.fn.stdpath "data", "lvim", "pack"),
-  git = { clone_timeout = 300 },
-  display = {
-    open_fn = function()
-      return require("packer.util").float { border = "single" }
-    end,
-  },
-}
-
-return require("packer").startup(function(use)
+return {
   -- Packer can manage itself as an optional plugin
-  use "wbthomason/packer.nvim"
+  { "wbthomason/packer.nvim" },
 
   -- TODO: refactor all of this (for now it works, but yes I know it could be wrapped in a simpler function)
-  use { "neovim/nvim-lspconfig" }
-  use {
+  { "neovim/nvim-lspconfig" },
+  {
     "kabouzeid/nvim-lspinstall",
     event = "VimEnter",
     config = function()
       require("lspinstall").setup()
     end,
-  }
+  },
 
-  use { "nvim-lua/popup.nvim" }
-  use { "nvim-lua/plenary.nvim" }
-  use { "tjdevries/astronauta.nvim" }
+  { "nvim-lua/popup.nvim" },
+  { "nvim-lua/plenary.nvim" },
+  { "tjdevries/astronauta.nvim" },
 
   -- Telescope
-  use {
+  {
     "nvim-telescope/telescope.nvim",
     config = [[require('core.telescope').setup()]],
-  }
+  },
 
   -- Autocomplete
-  use {
+  {
     "hrsh7th/nvim-compe",
     -- event = "InsertEnter",
     config = function()
       require("core.compe").setup()
     end,
-  }
+  },
 
   -- Autopairs
-  use {
+  {
     "windwp/nvim-autopairs",
     -- event = "InsertEnter",
     config = function()
       require "core.autopairs"
     end,
-  }
+  },
 
   -- Snippets
 
-  use { "hrsh7th/vim-vsnip", event = "InsertEnter" }
-  use { "rafamadriz/friendly-snippets", event = "InsertEnter" }
+  { "hrsh7th/vim-vsnip", event = "InsertEnter" },
+  { "rafamadriz/friendly-snippets", event = "InsertEnter" },
 
   -- Treesitter
-  use {
+  {
     "nvim-treesitter/nvim-treesitter",
     config = function()
       require("core.treesitter").setup()
     end,
-  }
+  },
 
   -- Formatter.nvim
-  use {
+  {
     "mhartington/formatter.nvim",
     config = function()
       require "core.formatter"
     end,
-  }
+  },
 
   -- Linter
-  use {
+  {
     "mfussenegger/nvim-lint",
     config = function()
       require("core.linter").setup()
     end,
-  }
+  },
 
   -- NvimTree
-  use {
+  {
     "kyazdani42/nvim-tree.lua",
     -- event = "BufWinOpen",
     -- cmd = "NvimTreeToggle",
@@ -103,28 +78,28 @@ return require("packer").startup(function(use)
     config = function()
       require("core.nvimtree").setup()
     end,
-  }
+  },
 
-  use {
+  {
     "lewis6991/gitsigns.nvim",
 
     config = function()
       require("core.gitsigns").setup()
     end,
     event = "BufRead",
-  }
+  },
 
   -- whichkey
-  use {
+  {
     "folke/which-key.nvim",
     config = function()
       require("core.which-key").setup()
     end,
     event = "BufWinEnter",
-  }
+  },
 
   -- Comments
-  use {
+  {
     "terrortylor/nvim-comment",
     event = "BufRead",
     config = function()
@@ -134,89 +109,89 @@ return require("packer").startup(function(use)
       end
       nvim_comment.setup()
     end,
-  }
+  },
 
   -- vim-rooter
-  use {
+  {
     "airblade/vim-rooter",
     config = function()
       vim.g.rooter_silent_chdir = 1
     end,
-  }
+  },
 
   -- Icons
-  use { "kyazdani42/nvim-web-devicons" }
+  { "kyazdani42/nvim-web-devicons" },
 
   -- Status Line and Bufferline
-  use {
+  {
     "glepnir/galaxyline.nvim",
     config = function()
       require "core.galaxyline"
     end,
     event = "BufWinEnter",
     disable = not O.plugin.galaxyline.active,
-  }
+  },
 
-  use {
+  {
     "romgrk/barbar.nvim",
     config = function()
       require "core.bufferline"
     end,
     event = "BufWinEnter",
-  }
+  },
 
   -- Debugging
-  use {
+  {
     "mfussenegger/nvim-dap",
     -- event = "BufWinEnter",
     config = function()
       require("core.dap").setup()
     end,
     disable = not O.plugin.dap.active,
-  }
+  },
 
   -- Debugger management
-  use {
+  {
     "Pocco81/DAPInstall.nvim",
     -- event = "BufWinEnter",
     -- event = "BufRead",
     disable = not O.plugin.dap.active,
-  }
+  },
 
   -- Builtins, these do not load by default
 
   -- Dashboard
-  use {
+  {
     "ChristianChiarulli/dashboard-nvim",
     event = "BufWinEnter",
     config = function()
       require("core.dashboard").setup()
     end,
     disable = not O.plugin.dashboard.active,
-  }
+  },
 
   -- TODO: remove in favor of akinsho/nvim-toggleterm.lua
   -- Floating terminal
-  -- use {
+  -- {
   --   "numToStr/FTerm.nvim",
   --   event = "BufWinEnter",
   --   config = function()
   --     require("core.floatterm").setup()
   --   end,
   --   disable = not O.plugin.floatterm.active,
-  -- }
+  -- },
 
-  use {
+  {
     "akinsho/nvim-toggleterm.lua",
     event = "BufWinEnter",
     config = function()
       require("core.terminal").setup()
     end,
     disable = not O.plugin.terminal.active,
-  }
+  },
 
   -- Zen Mode
-  use {
+  {
     "folke/zen-mode.nvim",
     cmd = "ZenMode",
     event = "BufRead",
@@ -224,28 +199,28 @@ return require("packer").startup(function(use)
       require("core.zen").setup()
     end,
     disable = not O.plugin.zen.active,
-  }
+  },
 
   ---------------------------------------------------------------------------------
 
   -- LANGUAGE SPECIFIC GOES HERE
-  use {
+  {
     "lervag/vimtex",
     ft = "tex",
-  }
+  },
 
   -- Rust tools
   -- TODO: use lazy loading maybe?
-  use {
+  {
     "simrat39/rust-tools.nvim",
     disable = not O.lang.rust.rust_tools.active,
-  }
+  },
 
   -- Elixir
-  use { "elixir-editors/vim-elixir", ft = { "elixir", "eelixir", "euphoria3" } }
+  { "elixir-editors/vim-elixir", ft = { "elixir", "eelixir", "euphoria3" } },
 
   -- Javascript / Typescript
-  use {
+  {
     "jose-elias-alvarez/nvim-lsp-ts-utils",
     ft = {
       "javascript",
@@ -255,23 +230,18 @@ return require("packer").startup(function(use)
       "typescriptreact",
       "typescript.tsx",
     },
-  }
+  },
 
   -- Java
-  use {
+  {
     "mfussenegger/nvim-jdtls",
     -- ft = { "java" },
     disable = not O.lang.java.java_tools.active,
-  }
+  },
 
   -- Scala
-  use {
+  {
     "scalameta/nvim-metals",
     disable = not O.lang.scala.metals.active,
-  }
-
-  -- Install user plugins
-  for _, plugin in pairs(O.user_plugins) do
-    packer.use(plugin)
-  end
-end)
+  },
+}


### PR DESCRIPTION
This splits the plugin configuration from the loading logic.
The plugins.lua file would now contain only the plugin's configurations.
The plugin-loader.lua file contains the logic for loading plugins + handling packer's initialization.

I went for an object-oriented approach for the package-loader as it provides a clear interface.
I think it's better to have an object with clear responsibilities that can be injected as a dependency instead of doing require("mymodule").myfunction everywhere in the code. IMO the code would be more structured and easier to maintain in the future.
Also, it will be possible to have a state and pass the package-loader to other parts of the application (as I said dependency injection). For example, we could inject it into the which-key module (probably at the cost of not lazy loading it though) to fetch registered modules with a lv-config file and retrieve the plugin's mapping from there.

Let's keep things simple for now and changes incremental, let me hear what you think of it.