### PR TITLE
chore: update keybinding for tab navigation

### DIFF
--- a/lua/lv-barbar/init.lua
+++ b/lua/lv-barbar/init.lua
@@ -1,6 +1,8 @@
 vim.api.nvim_set_keymap("n", "<TAB>", ":BufferNext<CR>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("n", "<S-TAB>", ":BufferPrevious<CR>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("n", "<S-x>", ":BufferClose<CR>", { noremap = true, silent = true })
+vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
+vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
 
 O.user_which_key["b"] = {
   name = "Buffers",


### PR DESCRIPTION
Better keybindings for tab/buffer navigation.

This is what I have been using personally since NVcode.
The reasons to merge,

1. Consistency (Vi binding)
<C-h> <C-l> for window navigation
<S-h> <S-l> for tab/buffer navigation

2. Resolve conflicts with VimWiki
Tab and S-Tab would not work for VImWiki users.
By default, VimWiki mapped those to navigate between its wiki-links.

3. S-Tab is like ESC
I can deal with Tab key but no S-Tab