### PR TITLE
expose floatterm config settings.

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -91,7 +91,29 @@ O = {
     dap_install = { active = false },
     lush = { active = false },
     diffview = { active = false },
-    floatterm = { active = false },
+    floatterm = {
+      active = false,
+      config = {
+        fterm = {
+          border = "single", -- or 'double'
+          dimensions = {
+            height = 0.8,
+            width = 0.8,
+            x = 0.5,
+            y = 0.5,
+          },
+        },
+        lazygit = {
+          cmd = "lazygit",
+          dimensions = {
+            height = 0.9,
+            width = 0.9,
+            x = 0.5,
+            y = 0.3,
+          },
+        },
+      },
+    },
     trouble = { active = false },
     sanegx = { active = false },
   },

--- a/lua/lv-floatterm/init.lua
+++ b/lua/lv-floatterm/init.lua
@@ -6,27 +6,11 @@ M.config = function()
     return
   end
 
-  fterm.setup {
-    dimensions = {
-      height = 0.8,
-      width = 0.8,
-      x = 0.5,
-      y = 0.5,
-    },
-    border = "single", -- or 'double'
-  }
+  fterm.setup(O.plugin.floatterm.config.fterm) 
 
   -- Create LazyGit Terminal
   local term = require "FTerm.terminal"
-  local lazy = term:new():setup {
-    cmd = "lazygit",
-    dimensions = {
-      height = 0.9,
-      width = 0.9,
-      x = 0.5,
-      y = 0.3,
-    },
-  }
+  local lazy = term:new():setup(O.plugin.floatterm.config.lazygit)
 
   local function is_installed(exe)
     return vim.fn.executable(exe) == 1


### PR DESCRIPTION
This exposes plugin `floatterm` configuration settings to allow users to easily customize them in `lv-config.lua`.

E.g.
```
O.plugin.floatterm.config.fterm.dimensions = {
  height = 0.9,
  width = 0.9,
  x = 0.5,
  y = 0.3,
}
```