### PR TITLE
FTerm starts on same event as Dashboard

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -230,7 +230,7 @@ return require("packer").startup(function(use)
   -- Floating terminal
   use {
     "numToStr/FTerm.nvim",
-    event = "BufRead",
+    event = "BufWinEnter",
     config = function()
       require("lv-floatterm").config()
     end,


### PR DESCRIPTION
If lazyload event for FTerm is set to `BufRead`, you cannot call terminal or lazygit from the initial dashboard. By setting the lazyload event to the same as Dashboard, this issue is corrected.