### PR TITLE
Vimtex : Autosave and ignore errors options

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -144,7 +144,10 @@ O = {
       },
     },
     kotlin = {},
-    latex = {},
+    latex = {
+      auto_save = false,
+      ignore_errors = { },
+    },
     lua = {
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },

--- a/lua/lv-vimtex/init.lua
+++ b/lua/lv-vimtex/init.lua
@@ -1,7 +1,7 @@
 vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_view_method = "zathura"
 vim.g.vimtex_fold_enabled = 0
-vim.g.vimtex_quickfix_ignore_filters = O.vimtex_ignore_errors
+vim.g.vimtex_quickfix_ignore_filters = O.lang.latex.ignore_errors
 O.user_which_key["L"] = {
   name = "+Latex",
   c = { "<cmd>VimtexCompile<cr>", "Toggle Compilation Mode" },
@@ -22,7 +22,7 @@ vim.api.nvim_exec(
     ]],
   false
 )
-if (O.vimtex_autosave)
+if (O.lang.latex.auto_save)
 then
   vim.api.nvim_exec([[au FocusLost * :wa]],false)
 end

--- a/lua/lv-vimtex/init.lua
+++ b/lua/lv-vimtex/init.lua
@@ -2,8 +2,16 @@ vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_view_method = "zathura"
 vim.g.vimtex_fold_enabled = 0
 vim.g.vimtex_quickfix_ignore_filters = O.vimtex_ignore_errors
+O.user_which_key["L"] = {
+  name = "+Latex",
+  c = { "<cmd>VimtexCompile<cr>", "Toggle Compilation Mode" },
+  f = { "<cmd>call vimtex#fzf#run()<cr>", "Fzf Find" },
+  i = { "<cmd>VimtexInfo<cr>", "Project Information" },
+  s = { "<cmd>VimtexStop<cr>", "Stop Project Compilation" },
+  t = { "<cmd>VimtexTocToggle<cr>", "Toggle Table Of Content" },
+  v = { "<cmd>VimtexView<cr>", "View PDF" },
+}
 -- Compile on initialization, cleanup on quit
--- O.autosavevimtex = false
 vim.api.nvim_exec(
   [[
         augroup vimtex_event_1

--- a/lua/lv-vimtex/init.lua
+++ b/lua/lv-vimtex/init.lua
@@ -1,18 +1,9 @@
 vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_view_method = "zathura"
 vim.g.vimtex_fold_enabled = 0
-
-O.user_which_key["L"] = {
-  name = "+Latex",
-  c = { "<cmd>VimtexCompile<cr>", "Toggle Compilation Mode" },
-  f = { "<cmd>call vimtex#fzf#run()<cr>", "Fzf Find" },
-  i = { "<cmd>VimtexInfo<cr>", "Project Information" },
-  s = { "<cmd>VimtexStop<cr>", "Stop Project Compilation" },
-  t = { "<cmd>VimtexTocToggle<cr>", "Toggle Table Of Content" },
-  v = { "<cmd>VimtexView<cr>", "View PDF" },
-}
-
+vim.g.vimtex_quickfix_ignore_filters = O.vimtex_ignore_errors
 -- Compile on initialization, cleanup on quit
+-- O.autosavevimtex = false
 vim.api.nvim_exec(
   [[
         augroup vimtex_event_1
@@ -23,3 +14,7 @@ vim.api.nvim_exec(
     ]],
   false
 )
+if (O.vimtex_autosave)
+then
+  vim.api.nvim_exec([[au FocusLost * :wa]],false)
+end

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -45,8 +45,8 @@ O.lang.python.analysis.use_library_code_types = true
 O.lang.tsserver.linter = nil
 
 -- latex 
-O.vimtex_autosave = false -- saves and compiles on focus change
-O.vimtex_ignore_errors = { } -- which errors not to display, i.e adding "hbox" will prevent hbox errors from showing.
+-- O.lang.latex.auto_save = false -- saves and compiles on focus change
+-- O.lang.latex.ignore_errors = { } -- which errors not to display, i.e adding "hbox" will prevent hbox errors from showing.
 
 -- Additional Plugins
 -- O.user_plugins = {

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -44,6 +44,10 @@ O.lang.python.analysis.use_library_code_types = true
 -- javascript
 O.lang.tsserver.linter = nil
 
+-- latex 
+O.vimtex_autosave = false -- saves and compiles on focus change
+O.vimtex_ignore_errors = { } -- which errors not to display, i.e adding "hbox" will prevent hbox errors from showing.
+
 -- Additional Plugins
 -- O.user_plugins = {
 --     {"folke/tokyonight.nvim"}, {

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -45,8 +45,8 @@ O.lang.python.analysis.use_library_code_types = true
 O.lang.tsserver.linter = nil
 
 -- latex 
-O.vimtex_autosave = false -- saves and compiles on focus change
-O.vimtex_ignore_errors = { } -- which errors not to display, i.e adding "hbox" will prevent hbox errors from showing.
+-- O.lang.latex.auto_save = false -- saves and compiles on focus change
+-- O.lang.latex.ignore_errors = { } -- which errors not to display, i.e adding "hbox" will prevent hbox errors from showing.
 
 -- Additional Plugins
 -- O.user_plugins = {

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -44,6 +44,10 @@ O.lang.python.analysis.use_library_code_types = true
 -- javascript
 O.lang.tsserver.linter = nil
 
+-- latex 
+O.vimtex_autosave = false -- saves and compiles on focus change
+O.vimtex_ignore_errors = { } -- which errors not to display, i.e adding "hbox" will prevent hbox errors from showing.
+
 -- Additional Plugins
 -- O.user_plugins = {
 --     {"folke/tokyonight.nvim"}, {


### PR DESCRIPTION
I find myself using autosave (save &compile on focus change) on latex a lot as it compiles stuff in the background as I do something else, a lot of people i know have something similar within their IDEs, I believe it is an option that gets used by a lot of people, some hate it though so I thought it might be a good idea to give the option.

For ignore errors, sometimes latex gives errors the user may not care about and this results in them being bothered every time they compile.

I am unsure if lv-config.lua is the right place for this? I wanted to use `O.vimtex.autosave` and `O.vimtex.ignore_errors` but was getting some weird `lv-utils` error, not sure if this matters.