### PR TITLE
adding branch support in the installer.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Make sure you have the newest version of Neovim (0.5).
 bash <(curl -s https://raw.githubusercontent.com/ChristianChiarulli/lunarvim/master/utils/installer/install.sh)
 ```
 
+If you help to develop Lunarvim, you can install a specific branch branch directly
+``` bash
+LVBRANCH=rolling bash <(curl -s https://raw.githubusercontent.com/ChristianChiarulli/lunarvim/master/utils/installer/install.sh)
+```
+
+
 ## Installing LSP for your language
 
 Just enter `:LspInstall` followed by `<TAB>` to see your options

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-
+#Set Variable to master is not set differently
+LVBRANCH="${LVBRANCH:-master}"
 set -o nounset # error when referencing undefined variable
 set -o errexit # exit when command fails
 
@@ -100,7 +101,7 @@ installpacker() {
 
 cloneconfig() {
     echo "Cloning LunarVim configuration"
-    git clone --branch master https://github.com/ChristianChiarulli/lunarvim.git ~/.config/nvim
+    git clone --branch $LVBRANCH https://github.com/ChristianChiarulli/lunarvim.git ~/.config/nvim
     cp $HOME/.config/nvim/utils/installer/lv-config.example-no-ts.lua $HOME/.config/nvim/lv-config.lua
     nvim --headless \
         +'autocmd User PackerComplete sleep 100m | qall' \


### PR DESCRIPTION
this make its possible to use a branch other then master while installing lunarvim, good for testing the clean install in rolling
```
LVBRANCH=rolling bash <(curl -s https://raw.githubusercontent.com/ChristianChiarulli/lunarvim/master/utils/installer/install.sh)
```
