### PR TITLE
User configurable latex lsp#2

### DIFF
--- a/ftplugin/tex.lua
+++ b/ftplugin/tex.lua
@@ -76,6 +76,8 @@ O.plugin.which_key.mappings["L"] = {
   s = { "<cmd>VimtexStop<cr>", "Stop Project Compilation" },
   t = { "<cmd>VimtexTocToggle<cr>", "Toggle Table Of Content" },
   v = { "<cmd>VimtexView<cr>", "View PDF" },
+  b = { "<cmd>TexlabBuild<cr>", "Build with Texlab" },
+  p = { "<cmd>TexlabForward<cr>", "Preview with Texlab" },
 }
 
 -- Compile on initialization, cleanup on quit

--- a/ftplugin/tex.lua
+++ b/ftplugin/tex.lua
@@ -68,7 +68,7 @@ vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_view_method = "zathura"
 vim.g.vimtex_fold_enabled = 0
 
-O.plugin.which_key.mappings["L"] = {
+O.plugin.which_key.mappings["t"] = {
   name = "+Latex",
   c = { "<cmd>VimtexCompile<cr>", "Toggle Compilation Mode" },
   f = { "<cmd>call vimtex#fzf#run()<cr>", "Fzf Find" },

--- a/ftplugin/tex.lua
+++ b/ftplugin/tex.lua
@@ -2,11 +2,68 @@ if require("lv-utils").check_lsp_client_active "texlab" then
   return
 end
 
+local preview_settings = {}
+
+local sumatrapdf_args = { "-reuse-instance", "%p", "-forward-search", "%f", "%l" }
+local evince_args = { "-f", "%l", "%p", "\"code -g %f:%l\"" }
+local okular_args = { "--unique", "file:%p#src:%l%f" }
+local zathura_args = { "--synctex-forward", "%l:1:%f", "%p" }
+local qpdfview_args = { "--unique", "%p#src:%f:%l:1" }
+local skim_args = { "%l", "%p", "%f" }
+
+if O.lang.latex.forward_search.executable == "C:/Users/{User}/AppData/Local/SumatraPDF/SumatraPDF.exe" then
+  preview_settings = sumatrapdf_args
+elseif O.lang.latex.forward_search.executable == "evince-synctex" then
+  preview_settings = evince_args
+elseif O.lang.latex.forward_search.executable == "okular" then
+  preview_settings = okular_args
+elseif O.lang.latex.forward_search.executable == "zathura" then
+  preview_settings = zathura_args
+elseif O.lang.latex.forward_search.executable == "qpdfview" then
+  preview_settings = qpdfview_args
+elseif O.lang.latex.forward_search.executable == "/Applications/Skim.app/Contents/SharedSupport/displayline" then
+  preview_settings = skim_args
+end
+
 require("lspconfig").texlab.setup {
   cmd = { DATA_PATH .. "/lspinstall/latex/texlab" },
   on_attach = require("lsp").common_on_attach,
+  handlers = {
+    ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
+      virtual_text = O.lang.latex.diagnostics.virtual_text,
+      signs = O.lang.latex.diagnostics.signs,
+      underline = O.lang.latex.diagnostics.underline,
+       update_in_insert = true,
+    }),
+  },
+  filetypes = { "tex", "bib" },
+  settings = {
+    texlab = {
+      auxDirectory = O.lang.latex.aux_directory,
+      bibtexFormatter = O.lang.latex.bibtex_formatter,
+      build = {
+        args = O.lang.latex.build.args,
+        executable = O.lang.latex.build.executable,
+        forwardSearchAfter = O.lang.latex.build.forward_search_after,
+        onSave = O.lang.latex.build.on_save,
+      },
+      chktex = {
+        onEdit = O.lang.latex.chktex.on_edit,
+        onOpenAndSave = O.lang.latex.chktex.on_open_and_save,
+      },
+      diagnosticsDelay = O.lang.latex.diagnostics_delay,
+      formatterLineLength = O.lang.latex.formatter_line_length,
+      forwardSearch = {
+        args = preview_settings,
+        executable = O.lang.latex.forward_search.executable,
+      },
+      latexFormatter = O.lang.latex.latex_formatter,
+      latexindent = {
+         modifyLineBreaks = O.lang.latex.latexindent.modify_line_breaks,
+      },
+    },
+  },
 }
-
 vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_view_method = "zathura"
 vim.g.vimtex_fold_enabled = 0

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -149,7 +149,37 @@ O = {
       },
     },
     kotlin = {},
-    latex = {},
+    latex = {
+      filetypes = { "tex", "bib"},
+      aux_directory = nil,
+      bibtex_formatter = "texlab",
+      diagnostics_delay = 300,
+      formatter_line_length = 80,
+      latex_formatter = "latexindent",
+      build = {
+        executable = "latexmk",
+        args = {'-pdf', '-interaction=nonstopmode', '-synctex=1', '%f'},
+        on_save = false,
+        forward_search_after = false,
+      },
+      chktex = {
+        on_open_and_save = false,
+        on_edit = false,
+      },
+      forward_search = {
+        executable = nil,
+        args = {}
+      },
+      latexindent = {
+        ["local"] = nil,
+        modify_line_breaks = false
+      },
+      diagnostics = {
+        virtual_text = {spacing = 0, prefix = ""},
+        signs = true,
+        underline = true,
+      },
+    },
     lua = {
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -46,6 +46,23 @@ O.lang.rust.formatter = {
   args = {"--emit=stdout"},
 }
 
+--LaTeX
+-- Options: https://github.com/latex-lsp/texlab/blob/master/docs/options.md
+O.lang.latex.active = true
+O.lang.latex.aux_directory = "."
+O.lang.latex.bibtex_formatter = "texlab"
+O.lang.latex.build.args = { '-pdf', '-interaction=nonstopmode', '-synctex=1', '%f' }
+O.lang.latex.build.executable = "latexmk"
+O.lang.latex.build.forward_search_after = false
+O.lang.latex.build.on_save = false
+O.lang.latex.chktex.on_edit = false
+O.lang.latex.chktex.on_open_and_save = false
+O.lang.latex.diagnostics_delay = 300
+O.lang.latex.formatter_line_length = 80
+O.lang.latex.forward_search.executable = "zathura"
+O.lang.latex.latex_formatter = "latexindent"
+O.lang.latex.latexindent.modify_line_breaks = false
+
 -- Additional Plugins
 -- O.user_plugins = {
 --     {"folke/tokyonight.nvim"}, {


### PR DESCRIPTION
### Description

This PR makes the latex lsp more flexible and easier to configure. Almost every setting can be made in lv-config.lua. With those the user can choose which build arguments and which preview options are to be used by lunarvim.

My hope is that this is a desired PR in the light of #638.

Disclaimer: This is a copy of #671, which has been closed by me. I've messed up big time I think. The main difference is that this PR is now based on rolling and has a cleaner commit history. I'm still learning sorry for the inconvenience.

#### Type Of Change

Please check the relevant options.

- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality
- Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (maybe)

#### How has this been tested

- I have tested these changes with opening .tex and .bib files and checking for linting and lsp-autocomplete. It's working as expected.
- I built files with the command `:TexlabBuild` successfully.
- I also previewed .tex files with the command `:TexlabForward`. Only tested Zathura.
- I switched the settings for build and preview on save. They work as desired.

#### Checklist:

- [x] I read the contributing guide
- [x] My code follows the style guidelines of the project (at least I hope so)
- [x] I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas (code is pretty straightforward)
- [x] I have made corresponding changes to the documentation (I would but I don't know where)
- [x] My changes generate no warnings