### PR TITLE
[SETTINGS] Ensure <Leader> is mapped before plugin configs are sourced.

### DIFF
--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -8,15 +8,6 @@ end
 
 which_key.setup(O.plugin.which_key.setup)
 
--- Set leader
-if O.leader_key == " " or O.leader_key == "space" then
-  vim.api.nvim_set_keymap("n", "<Space>", "<NOP>", { noremap = true, silent = true })
-  vim.g.mapleader = " "
-else
-  vim.api.nvim_set_keymap("n", O.leader_key, "<NOP>", { noremap = true, silent = true })
-  vim.g.mapleader = O.leader_key
-end
-
 local opts = O.plugin.which_key.opts
 
 -- Comments

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -39,6 +39,11 @@ local disabled_built_ins = {
   "spellfile_plugin",
   -- 'matchit', 'matchparen', 'shada_plugin',
 }
+
+if O.leader_key == " " or O.leader_key == "space" then
+  vim.g.mapleader = ' '
+end
+
 for _, plugin in pairs(disabled_built_ins) do
   vim.g["loaded_" .. plugin] = 1
 end

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -42,6 +42,8 @@ local disabled_built_ins = {
 
 if O.leader_key == " " or O.leader_key == "space" then
   vim.g.mapleader = ' '
+else
+  vim.g.mapleader = O.leader_key
 end
 
 for _, plugin in pairs(disabled_built_ins) do


### PR DESCRIPTION
# Description

Fix for leader key not being mapped before some plugins are configured.

Fixes #(issue)
#853 




