### PR TITLE
Vimtex/Latex : Added autosave on focus loss option and list of errors to be ignored.

### DIFF
--- a/ftplugin/tex.lua
+++ b/ftplugin/tex.lua
@@ -10,6 +10,7 @@ require("lspconfig").texlab.setup {
 vim.g.vimtex_compiler_method = "latexmk"
 vim.g.vimtex_view_method = "zathura"
 vim.g.vimtex_fold_enabled = 0
+vim.g.vimtex_quickfix_ignore_filters = O.lang.latex.ignore_errors
 
 O.plugin.which_key.mappings["L"] = {
   name = "+Latex",
@@ -32,3 +33,7 @@ vim.api.nvim_exec(
     ]],
   false
 )
+if (O.lang.latex.auto_save)
+then
+  vim.api.nvim_exec([[au FocusLost * :wa]],false)
+end

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -149,7 +149,10 @@ O = {
       },
     },
     kotlin = {},
-    latex = {},
+    latex = {
+      auto_save = false,
+      ignore_errors = { },
+    },
     lua = {
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -40,6 +40,11 @@ O.lang.python.analysis.use_library_code_types = true
 -- javascript
 O.lang.tsserver.linter = nil
 
+-- latex
+-- O.lang.latex.auto_save = false
+-- O.lang.latex.ignore_errors = { }
+
+
 -- Additional Plugins
 -- O.user_plugins = {
 --     {"folke/tokyonight.nvim"}, {

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -46,6 +46,10 @@ O.lang.rust.formatter = {
   args = {"--emit=stdout"},
 }
 
+-- latex
+-- O.lang.latex.auto_save = false
+-- O.lang.latex.ignore_errors = { }
+
 -- Additional Plugins
 -- O.user_plugins = {
 --     {"folke/tokyonight.nvim"}, {


### PR DESCRIPTION
# Description
This is a repeat PR of #840 but in the new rolling set out.

I find myself using autosave (save &compile on focus change) on latex a lot as it compiles stuff in the background as I do something else, a lot of people i know have something similar within their IDEs, I believe it is an option that gets used by a lot of people, some hate it though so I thought it might be a good idea to give the option.

For ignore errors, sometimes latex gives errors the user may not care about and this results in them being bothered every time they compile.

There is another latex PR #861 , this doesn't interfere with it so no problem there.

## Type Of Change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I ran it with my configs and with default configs.

## Checklist:

- [x] I read the [contributing](https://github.com/ChristianChiarulli/LunarVim/blob/rolling/CONTRIBUTING.md) guide
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - (I would, but I don't know where)
- [x] My changes generate no new warnings
