### PR TITLE
[Feature] Enable emmet-ls on vue filetype

### DIFF
--- a/lua/lsp/emmet-ls.lua
+++ b/lua/lsp/emmet-ls.lua
@@ -10,7 +10,7 @@ capabilities.textDocument.completion.completionItem.snippetSupport = true
 configs.emmet_ls = {
   default_config = {
     cmd = { "emmet-ls", "--stdio" },
-    filetypes = { "html", "css", "javascript", "typescript" },
+    filetypes = { "html", "css", "javascript", "typescript", "vue" },
     root_dir = function()
       return vim.loop.cwd()
     end,


### PR DESCRIPTION
# Description

Enables emmet-ls support for vue filetype.

## Type Of Change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

By using emmet-ls successfully on a Vue project.

## Checklist:

- [x] I read the [contributing](https://github.com/ChristianChiarulli/LunarVim/blob/rolling/CONTRIBUTING.md) guide
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
