### PR TITLE
Add eslint and eslint_d to efm and remove prettier from efm

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -266,7 +266,7 @@ O = {
     },
     terraform = {},
     tsserver = {
-      -- @usage can be 'eslint'
+      -- @usage can be 'eslint' or 'eslint_d'
       linter = "",
       diagnostics = {
         virtual_text = { spacing = 0, prefix = "" },

--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -5,30 +5,41 @@ local M = {}
 M.setup = function()
   local tsserver_args = {}
 
-  local prettier = {
-    formatCommand = "prettier --stdin-filepath ${INPUT}",
-    formatStdin = true,
-  }
-
-  if vim.fn.glob "node_modules/.bin/prettier" ~= "" then
-    prettier = {
-      formatCommand = "./node_modules/.bin/prettier --stdin-filepath ${INPUT}",
+  if O.lang.tsserver.linter == "eslint" or O.lang.tsserver.linter == "eslint_d" then
+    local eslint = {
+      lintCommand = O.lang.tsserver.linter .. " -f unix --stdin --stdin-filename   {INPUT}",
+      lintStdin = true,
+      lintFormats = { "%f:%l:%c: %m" },
+      lintIgnoreExitCode = true,
+      formatCommand = O.lang.tsserver.linter .. " --fix-to-stdout --stdin  --stdin-filename=${INPUT}",
       formatStdin = true,
     }
+    table.insert(tsserver_args, eslint)
   end
 
   require("lspconfig").efm.setup {
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
-    filetypes = { "html", "css", "yaml", "vue", "javascript", "javascriptreact", "typescript", "typescriptreact" },
+    filetypes = {
+      "vue",
+      "javascript",
+      "javascriptreact",
+      "typescript",
+      "typescriptreact",
+      "javascript.jsx",
+      "typescript.tsx",
+    },
     settings = {
       rootMarkers = { ".git/", "package.json" },
       languages = {
-        html = { prettier },
-        css = { prettier },
-        json = { prettier },
-        yaml = { prettier },
+        vue = tsserver_args,
+        javascript = tsserver_args,
+        javascriptreact = tsserver_args,
+        ["javascript.jsx"] = tsserver_args,
+        typescript = tsserver_args,
+        ["typescript.tsx"] = tsserver_args,
+        typescriptreact = tsserver_args,
       },
     },
   }


### PR DESCRIPTION
# Description

Fixes a regression where ESLint was removed. It is now possible to specify in `lv-config` :
```lua
O.lang.tsserver.linter = 'eslint' --or 'eslint_d'
```

Fixes #860 

## Type Of Change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested against javascript like types with `eslint` and `eslint_d` and it respects .eslintrc

## Checklist:

- [X] I read the [contributing](https://github.com/ChristianChiarulli/LunarVim/blob/rolling/CONTRIBUTING.md) guide
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
