### PR TITLE
Prevent duplicate LSP clients from appearing in galaxyline

### DIFF
--- a/lua/lv-galaxyline/init.lua
+++ b/lua/lv-galaxyline/init.lua
@@ -212,7 +212,9 @@ local get_lsp_client = function(msg)
         -- print("first", lsps)
         lsps = client.name
       else
-        lsps = lsps .. ", " .. client.name
+        if not string.find(lsps, client.name) then
+          lsps = lsps .. ", " .. client.name
+        end
         -- print("more", lsps)
       end
     end

--- a/lua/lv-galaxyline/init.lua
+++ b/lua/lv-galaxyline/init.lua
@@ -206,7 +206,7 @@ local get_lsp_client = function(msg)
   local lsps = ""
   for _, client in ipairs(clients) do
     local filetypes = client.config.filetypes
-    if filetypes and vim.fn.index(filetypes, buf_ft) ~= 1 then
+    if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
       -- print(client.name)
       if lsps == "" then
         -- print("first", lsps)


### PR DESCRIPTION
This PR prevents this from appearing when having multiple buffers with lua files open.
![image](https://user-images.githubusercontent.com/39450656/125204787-f45c1780-e24c-11eb-8fa4-d75fa69bf4b8.png)

Also fixed the filetypes index check.