### PR TITLE
Bugfix: Fixed edition issue with rustfmt.

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -226,7 +226,7 @@ O = {
       -- @usage can be clippy
       formatter = {
         exe = "rustfmt",
-        args = { "--emit=stdout --edition=2018" },
+        args = { "--emit=stdout", "--edition=2018" },
       },
       linter = "",
       diagnostics = {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -223,7 +223,7 @@ O = {
       -- @usage can be clippy
       formatter = {
         exe = "rustfmt",
-        args = { "--emit=stdout" },
+        args = { "--emit=stdout --edition=2018" },
       },
       linter = "",
       diagnostics = {

--- a/lua/lv-which-key/config.lua
+++ b/lua/lv-which-key/config.lua
@@ -116,7 +116,7 @@ O.plugin.which_key = {
         "<cmd>Telescope lsp_workspace_diagnostics<cr>",
         "Workspace Diagnostics",
       },
-      f = { "<cmd>FormatWrite<cr>", "Format" },
+      f = { "<cmd>silent FormatWrite<cr>", "Format" },
       i = { "<cmd>LspInfo<cr>", "Info" },
       j = { "<cmd>lua vim.lsp.diagnostic.goto_next({popup_opts = {border = O.lsp.popup_border}})<cr>", "Next Diagnostic" },
       k = { "<cmd>lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = O.lsp.popup_border}})<cr>", "Prev Diagnostic" },


### PR DESCRIPTION
# Description

This PR attempts to solve an issue with rustfmt not working. Tested on my own machine(MacBook Pro) on a rust crate created with `cargo init --bin`, 
I think it's a sensible assumption to assume that people will write code for the 2018 edition of rust.

Example output when running on a repository with async: 
![image](https://user-images.githubusercontent.com/48220549/125204852-8bda5e00-e27f-11eb-813a-e38f669eaf14.png)


## How Has This Been Tested?

- Created a repo with: `cargo init --bin`
- Indented a line too much.
- Run command `:FormatWrite` or `:w`

