### PR TITLE
remove tilde from EndOfBuffer in transparent mode

### DIFF
--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -17,6 +17,7 @@ end
 if O.transparent_window then
   cmd "au ColorScheme * hi Normal ctermbg=none guibg=none"
   cmd "au ColorScheme * hi SignColumn ctermbg=none guibg=none"
+  cmd "let &fcs='eob: '"
 end
 
 ---  SETTINGS  ---


### PR DESCRIPTION
the tildes are not transparent and are shown for example in nvimtree.
you cant make them transparent, but we can remove them.
no trailing whitespaces are generated.