### PR TITLE
goimports instead of goimport

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ O.lang.python.analysis.use_library_code_types = true
 -- O.lang.python.formatter.args = {"-"}
 
 -- go
--- to change default formatter from gofmt to goimport
--- O.lang.formatter.go.exe = "goimport"
+-- to change default formatter from gofmt to goimports
+-- O.lang.formatter.go.exe = "goimports"
 
 -- Additional Plugins
 -- O.user_plugins = {

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -41,8 +41,8 @@ O.lang.python.analysis.use_library_code_types = true
 -- O.lang.python.formatter.args = {"-"}
 
 -- go
--- to change default formatter from gofmt to goimport
--- O.lang.formatter.go.exe = "goimport"
+-- to change default formatter from gofmt to goimports
+-- O.lang.formatter.go.exe = "goimports"
 
 -- javascript
 O.lang.tsserver.linter = nil

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -41,8 +41,8 @@ O.lang.python.analysis.use_library_code_types = true
 -- O.lang.python.formatter.args = {"-"}
 
 -- go
--- to change default formatter from gofmt to goimport
--- O.lang.formatter.go.exe = "goimport"
+-- to change default formatter from gofmt to goimports
+-- O.lang.formatter.go.exe = "goimports"
 
 -- javascript
 O.lang.tsserver.linter = nil


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

fixing my own mistake
:facepalm: instead of `goimport` it should be `goimports`

Fixes #884

## How Has This Been Tested?


- Read the `README.md`

