### PR TITLE
[Feature]: Add setting to enable/disable the default lsp keybinds

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -70,6 +70,7 @@ O = {
     },
     document_highlight = true,
     popup_border = "single",
+    default_keybinds = true,
   },
 
   disabled_built_ins = {

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -37,25 +37,27 @@ vim.fn.sign_define(
 --   { noremap = true, silent = true }
 -- )
 
-vim.cmd "nnoremap <silent> gd <cmd>lua vim.lsp.buf.definition()<CR>"
-vim.cmd "nnoremap <silent> gD <cmd>lua vim.lsp.buf.declaration()<CR>"
-vim.cmd "nnoremap <silent> gr <cmd>lua vim.lsp.buf.references()<CR>"
-vim.cmd "nnoremap <silent> gi <cmd>lua vim.lsp.buf.implementation()<CR>"
-vim.api.nvim_set_keymap(
-  "n",
-  "gl",
-  '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = "single" })<CR>',
-  { noremap = true, silent = true }
-)
+if O.lsp.default_keybinds then
+  vim.cmd "nnoremap <silent> gd <cmd>lua vim.lsp.buf.definition()<CR>"
+  vim.cmd "nnoremap <silent> gD <cmd>lua vim.lsp.buf.declaration()<CR>"
+  vim.cmd "nnoremap <silent> gr <cmd>lua vim.lsp.buf.references()<CR>"
+  vim.cmd "nnoremap <silent> gi <cmd>lua vim.lsp.buf.implementation()<CR>"
+  vim.api.nvim_set_keymap(
+    "n",
+    "gl",
+    '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = "single" })<CR>',
+    { noremap = true, silent = true }
+  )
 
-vim.cmd "nnoremap <silent> gp <cmd>lua require'lsp'.PeekDefinition()<CR>"
-vim.cmd "nnoremap <silent> K :lua vim.lsp.buf.hover()<CR>"
-vim.cmd "nnoremap <silent> <C-p> :lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = O.lsp.popup_border}})<CR>"
-vim.cmd "nnoremap <silent> <C-n> :lua vim.lsp.diagnostic.goto_next({popup_opts = {border = O.lsp.popup_border}})<CR>"
-vim.cmd "nnoremap <silent> <tab> <cmd>lua vim.lsp.buf.signature_help()<CR>"
--- scroll down hover doc or scroll in definition preview
--- scroll up hover doc
-vim.cmd 'command! -nargs=0 LspVirtualTextToggle lua require("lsp/virtual_text").toggle()'
+  vim.cmd "nnoremap <silent> gp <cmd>lua require'lsp'.PeekDefinition()<CR>"
+  vim.cmd "nnoremap <silent> K :lua vim.lsp.buf.hover()<CR>"
+  vim.cmd "nnoremap <silent> <C-p> :lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = O.lsp.popup_border}})<CR>"
+  vim.cmd "nnoremap <silent> <C-n> :lua vim.lsp.diagnostic.goto_next({popup_opts = {border = O.lsp.popup_border}})<CR>"
+  vim.cmd "nnoremap <silent> <tab> <cmd>lua vim.lsp.buf.signature_help()<CR>"
+  -- scroll down hover doc or scroll in definition preview
+  -- scroll up hover doc
+  vim.cmd 'command! -nargs=0 LspVirtualTextToggle lua require("lsp/virtual_text").toggle()'
+end
 
 -- Set Default Prefix.
 -- Note: You can set a prefix per lsp server in the lv-globals.lua file


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

# Description
This PR addresses issue #895 it the simplest way possible. It may be
preferable to implement a more complex solution to disable individual
keybinds or allow the user to override them in some other way.

I decided to submit this as a PR first because I didn't want to try
making larger changes without feedback.

## How Has This Been Tested?

I toggle the config option and it does enable and disable the default keybinds.
