### PR TITLE
[Bugfix] Set root_dir for efm-langserver configuration

### DIFF
--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -25,6 +25,7 @@ if not require("lv-utils").check_lsp_client_active "efm" then
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
+    root_dir = require("lspconfig").util.root_pattern(".git/", "requirements.txt"),
     filetypes = { "python" },
     settings = {
       rootMarkers = { ".git/", "requirements.txt" },

--- a/ftplugin/sh.lua
+++ b/ftplugin/sh.lua
@@ -26,6 +26,7 @@ if not require("lv-utils").check_lsp_client_active "efm" then
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
+    root_dir = require("lspconfig").util.root_pattern(".git/"),
     filetypes = { "sh" },
     settings = {
       rootMarkers = { ".git/" },

--- a/ftplugin/zsh.lua
+++ b/ftplugin/zsh.lua
@@ -24,6 +24,7 @@ if not require("lv-utils").check_lsp_client_active "efm" then
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
+    root_dir = require("lspconfig").util.root_pattern(".git/"),
     filetypes = { "zsh" },
     settings = {
       rootMarkers = { ".git/" },

--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -21,6 +21,7 @@ M.setup = function()
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
+    root_dir = require("lspconfig").util.root_pattern(".git/", "package.json"),
     filetypes = {
       "vue",
       "javascript",


### PR DESCRIPTION
# Description

efm-langserver configuration(s) need to have root_dir configured. If root_dir is not configured, relative linters and formatters are not found, e.g. `./node_modules/.bin/prettier`
