### PR TITLE
[Doc]: comment typo

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -125,7 +125,7 @@ return require("packer").startup(function(use)
     end,
   }
 
-  -- whichkey
+  -- vim-rooter
   use {
     "airblade/vim-rooter",
     config = function()


### PR DESCRIPTION
# Description

There was a typo in plugins.lua

Fixes #(issue)

Fixed the typo to reference vim-rooter.

