### PR TITLE
we should install O.user_plugins

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -247,4 +247,9 @@ return require("packer").startup(function(use)
     -- ft = { "java" },
     disable = not O.lang.java.java_tools.active,
   }
+
+  -- Install user plugins
+  for _, plugin in pairs(O.user_plugins) do
+    packer.use(plugin)
+  end
 end)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

We didn't respect the `O.user_plugins` therefore no extra plugin would be installed


## How Has This Been Tested?

- Add an extra plugin
- Run `:PackerSync`
- Nothing happens

