### PR TITLE
[Doc] fix: clicking made with lua icon opens a deadlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ To update Neovim use your package manager
 > "My minimal config with a good amount less code than LunarVim loads 40ms slower. Time to switch."
 > - @mvllow, Potential LunarVim user.
 
-<div align="center">
+<div align="center" id="madewithlua">
 	
-[![Lua](https://img.shields.io/badge/Made%20with%20Lua-blue.svg?style=for-the-badge&logo=lua)]()
+[![Lua](https://img.shields.io/badge/Made%20with%20Lua-blue.svg?style=for-the-badge&logo=lua)](#madewithlua)
 	
 </div>


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Clicking on `Made with Lua` icon jumps to a 404 link <https://github.com/ChristianChiarulli/LunarVim/blob/rolling> (should at least be tree/rolling).

## How Has This Been Tested?

Click on `Made with Lua` icon.

