### PR TITLE
Added default formatters

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -1,17 +1,14 @@
-local clang_formatter = {
+O.formatters.filetype["c"] = {
   function()
     return {
-      exe = "clang-format",
-      --  TODO: append to this for args don't overwrite
-      args = {},
-      stdin = true,
+      exe = O.lang.c.formatter.exe,
+      args = O.lang.c.formatter.args,
+      stdin = not (O.lang.c.formatter.stdin ~= nil),
     }
   end,
 }
+O.formatters.filetype["cpp"] = O.formatters.filetype["c"]
 
-O.formatters.filetype["c"] = clang_formatter
-O.formatters.filetype["cpp"] = clang_formatter
-O.formatters.filetype["obj"] = clang_formatter
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,

--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -4,14 +4,18 @@ local clang_formatter = {
       exe = "clang-format",
       --  TODO: append to this for args don't overwrite
       args = {},
+      stdin = true,
     }
   end,
 }
 
 O.formatters.filetype["c"] = clang_formatter
 O.formatters.filetype["cpp"] = clang_formatter
-O.formatters.filetype["cmake"] = clang_formatter
 O.formatters.filetype["obj"] = clang_formatter
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
 
 if require("lv-utils").check_lsp_client_active "clangd" then
   return

--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -1,3 +1,18 @@
+local clang_formatter = {
+  function()
+    return {
+      exe = "clang-format",
+      --  TODO: append to this for args don't overwrite
+      args = {},
+    }
+  end,
+}
+
+O.formatters.filetype["c"] = clang_formatter
+O.formatters.filetype["cpp"] = clang_formatter
+O.formatters.filetype["cmake"] = clang_formatter
+O.formatters.filetype["obj"] = clang_formatter
+
 if require("lv-utils").check_lsp_client_active "clangd" then
   return
 end

--- a/ftplugin/cmake.lua
+++ b/ftplugin/cmake.lua
@@ -1,18 +1,3 @@
-O.formatters.filetype["cmake"] = {
-  function()
-    return {
-      exe = "cmake-format",
-      --  TODO: append to this for args don't overwrite
-      args = {},
-      stdin = true,
-    }
-  end,
-}
-require("formatter.config").set_defaults {
-  logging = false,
-  filetype = O.formatters.filetype,
-}
-
 if require("lv-utils").check_lsp_client_active "cmake" then
   return
 end

--- a/ftplugin/cmake.lua
+++ b/ftplugin/cmake.lua
@@ -1,3 +1,18 @@
+O.formatters.filetype["cmake"] = {
+  function()
+    return {
+      exe = "cmake-format",
+      --  TODO: append to this for args don't overwrite
+      args = {},
+      stdin = true,
+    }
+  end,
+}
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
+
 if require("lv-utils").check_lsp_client_active "cmake" then
   return
 end

--- a/ftplugin/dart.lua
+++ b/ftplugin/dart.lua
@@ -1,10 +1,9 @@
 O.formatters.filetype["dart"] = {
   function()
     return {
-      exe = "dart",
-      --  TODO: append to this for args don't overwrite
-      args = { "format" },
-      stdin = true,
+      exe = O.lang.dart.formatter.exe,
+      args = O.lang.dart.formatter.args,
+      stdin = not (O.lang.dart.formatter.stdin ~= nil),
     }
   end,
 }

--- a/ftplugin/dart.lua
+++ b/ftplugin/dart.lua
@@ -4,10 +4,15 @@ O.formatters.filetype["dart"] = {
       exe = "dart",
       --  TODO: append to this for args don't overwrite
       args = { "format" },
+      stdin = true,
     }
   end,
 }
 
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
 if require("lv-utils").check_lsp_client_active "dartls" then
   return
 end

--- a/ftplugin/dart.lua
+++ b/ftplugin/dart.lua
@@ -1,3 +1,13 @@
+O.formatters.filetype["dart"] = {
+  function()
+    return {
+      exe = "dart",
+      --  TODO: append to this for args don't overwrite
+      args = { "format" },
+    }
+  end,
+}
+
 if require("lv-utils").check_lsp_client_active "dartls" then
   return
 end

--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -1,13 +1,13 @@
 O.formatters.filetype["go"] = {
   function()
     return {
-      exe = "gofmt",
-      --  TODO: append to this for args don't overwrite
-      args = {},
-      stdin = true,
+      exe = O.lang.go.formatter.exe,
+      args = O.lang.go.formatter.args,
+      stdin = not (O.lang.go.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,

--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -4,8 +4,13 @@ O.formatters.filetype["go"] = {
       exe = "gofmt",
       --  TODO: append to this for args don't overwrite
       args = {},
+      stdin = true,
     }
   end,
+}
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
 }
 
 if not require("lv-utils").check_lsp_client_active "gopls" then

--- a/ftplugin/go.lua
+++ b/ftplugin/go.lua
@@ -1,3 +1,13 @@
+O.formatters.filetype["go"] = {
+  function()
+    return {
+      exe = "gofmt",
+      --  TODO: append to this for args don't overwrite
+      args = {},
+    }
+  end,
+}
+
 if not require("lv-utils").check_lsp_client_active "gopls" then
   require("lspconfig").gopls.setup {
     cmd = { DATA_PATH .. "/lspinstall/go/gopls" },

--- a/ftplugin/json.lua
+++ b/ftplugin/json.lua
@@ -4,8 +4,13 @@ O.formatters.filetype["json"] = {
       exe = "python",
       --  TODO: append to this for args don't overwrite
       args = { "-m", "json.tool" },
+      stdin = true,
     }
   end,
+}
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
 }
 
 if require("lv-utils").check_lsp_client_active "jsonls" then

--- a/ftplugin/json.lua
+++ b/ftplugin/json.lua
@@ -1,3 +1,13 @@
+O.formatters.filetype["json"] = {
+  function()
+    return {
+      exe = "python",
+      --  TODO: append to this for args don't overwrite
+      args = { "-m", "json.tool" },
+    }
+  end,
+}
+
 if require("lv-utils").check_lsp_client_active "jsonls" then
   return
 end

--- a/ftplugin/json.lua
+++ b/ftplugin/json.lua
@@ -1,18 +1,17 @@
 O.formatters.filetype["json"] = {
   function()
     return {
-      exe = "python",
-      --  TODO: append to this for args don't overwrite
-      args = { "-m", "json.tool" },
-      stdin = true,
+      exe = O.lang.json.formatter.exe,
+      args = O.lang.json.formatter.args,
+      stdin = not (O.lang.json.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,
 }
-
 if require("lv-utils").check_lsp_client_active "jsonls" then
   return
 end

--- a/ftplugin/lua.lua
+++ b/ftplugin/lua.lua
@@ -1,10 +1,9 @@
 O.formatters.filetype["lua"] = {
   function()
     return {
-      exe = "stylua",
-      --  TODO: append to this for args don't overwrite
-      args = {},
-      stdin = false,
+      exe = O.lang.lua.formatter.exe,
+      args = O.lang.lua.formatter.args,
+      stdin = not (O.lang.lua.formatter.stdin ~= nil),
     }
   end,
 }

--- a/ftplugin/lua.lua
+++ b/ftplugin/lua.lua
@@ -1,5 +1,4 @@
 O.formatters.filetype["lua"] = {
-  -- prettier
   function()
     return {
       exe = "stylua",

--- a/ftplugin/lua.lua
+++ b/ftplugin/lua.lua
@@ -46,16 +46,4 @@ if not require("lv-utils").check_lsp_client_active "sumneko_lua" then
   }
 end
 
-if O.lang.lua.autoformat then
-  require("lv-utils").define_augroups {
-    _lua_autoformat = {
-      {
-        "BufWritePre",
-        "*.lua",
-        "lua vim.lsp.buf.formatting_sync(nil, 1000)",
-      },
-    },
-  }
-end
-
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,18 +1,17 @@
 O.formatters.filetype["php"] = {
   function()
     return {
-      exe = "phpcbf",
-      --  TODO: append to this for args don't overwrite
-      args = { "--standard=PSR12", vim.api.nvim_buf_get_name(0) },
-      stdin = false,
+      exe = O.lang.php.formatter.exe,
+      args = O.lang.php.formatter.args,
+      stdin = not (O.lang.php.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,
 }
-
 if require("lv-utils").check_lsp_client_active "intelephense" then
   return
 end

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -8,6 +8,10 @@ O.formatters.filetype["php"] = {
     }
   end,
 }
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
 
 if require("lv-utils").check_lsp_client_active "intelephense" then
   return

--- a/ftplugin/php.lua
+++ b/ftplugin/php.lua
@@ -1,3 +1,14 @@
+O.formatters.filetype["php"] = {
+  function()
+    return {
+      exe = "phpcbf",
+      --  TODO: append to this for args don't overwrite
+      args = { "--standard=PSR12", vim.api.nvim_buf_get_name(0) },
+      stdin = false,
+    }
+  end,
+}
+
 if require("lv-utils").check_lsp_client_active "intelephense" then
   return
 end

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -1,3 +1,13 @@
+O.formatters.filetype["python"] = {
+  function()
+    return {
+      exe = "yapf",
+      --  TODO: append to this for args don't overwrite
+      args = {},
+    }
+  end,
+}
+
 local python_arguments = {}
 
 -- TODO: replace with path argument

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -1,13 +1,13 @@
 O.formatters.filetype["python"] = {
   function()
     return {
-      exe = "yapf",
-      --  TODO: append to this for args don't overwrite
-      args = {},
-      stdin = true,
+      exe = O.lang.python.formatter.exe,
+      args = O.lang.python.formatter.args,
+      stdin = not (O.lang.python.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -4,8 +4,13 @@ O.formatters.filetype["python"] = {
       exe = "yapf",
       --  TODO: append to this for args don't overwrite
       args = {},
+      stdin = true,
     }
   end,
+}
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
 }
 
 local python_arguments = {}

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -1,18 +1,17 @@
 O.formatters.filetype["ruby"] = {
   function()
     return {
-      exe = "rufo",
-      --  TODO: append to this for args don't overwrite
-      args = { "-x" },
-      stdin = true,
+      exe = O.lang.ruby.formatter.exe,
+      args = O.lang.ruby.formatter.args,
+      stdin = not (O.lang.ruby.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,
 }
-
 if require("lv-utils").check_lsp_client_active "solargraph" then
   return
 end

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -1,3 +1,13 @@
+O.formatters.filetype["ruby"] = {
+  function()
+    return {
+      exe = "rufo",
+      --  TODO: append to this for args don't overwrite
+      args = { "-x" },
+    }
+  end,
+}
+
 if require("lv-utils").check_lsp_client_active "solargraph" then
   return
 end

--- a/ftplugin/ruby.lua
+++ b/ftplugin/ruby.lua
@@ -4,8 +4,13 @@ O.formatters.filetype["ruby"] = {
       exe = "rufo",
       --  TODO: append to this for args don't overwrite
       args = { "-x" },
+      stdin = true,
     }
   end,
+}
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
 }
 
 if require("lv-utils").check_lsp_client_active "solargraph" then

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -1,3 +1,13 @@
+O.formatters.filetype["rust"] = {
+  function()
+    return {
+      exe = "rustfmt",
+      --  TODO: append to this for args don't overwrite
+      args = { "--emit=stdout", "--edition=2018" },
+    }
+  end,
+}
+
 if require("lv-utils").check_lsp_client_active "rust_analyzer" then
   return
 end

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -1,18 +1,17 @@
 O.formatters.filetype["rust"] = {
   function()
     return {
-      exe = "rustfmt",
-      --  TODO: append to this for args don't overwrite
-      args = { "--emit=stdout", "--edition=2018" },
-      stdin = true,
+      exe = O.lang.rust.formatter.exe,
+      args = O.lang.rust.formatter.args,
+      stdin = not (O.lang.rust.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,
 }
-
 if require("lv-utils").check_lsp_client_active "rust_analyzer" then
   return
 end
@@ -96,7 +95,7 @@ else
     cmd = { DATA_PATH .. "/lspinstall/rust/rust-analyzer" },
     on_attach = require("lsp").common_on_attach,
     filetypes = { "rust" },
-    root_dir = require("lspconfig.util").root_pattern("Cargo.toml", "rust-project.json"),
+    root_dir = require("lspconfig.util").root_pattern("Carrust.toml", "rust-project.json"),
   }
 end
 

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -4,8 +4,13 @@ O.formatters.filetype["rust"] = {
       exe = "rustfmt",
       --  TODO: append to this for args don't overwrite
       args = { "--emit=stdout", "--edition=2018" },
+      stdin = true,
     }
   end,
+}
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
 }
 
 if require("lv-utils").check_lsp_client_active "rust_analyzer" then

--- a/ftplugin/sh.lua
+++ b/ftplugin/sh.lua
@@ -1,18 +1,17 @@
 O.formatters.filetype["sh"] = {
   function()
     return {
-      exe = "shfmt",
-      --  TODO: append to this for args don't overwrite
-      args = { "-w" },
-      stdin = false,
+      exe = O.lang.sh.formatter.exe,
+      args = O.lang.sh.formatter.args,
+      stdin = not (O.lang.sh.formatter.stdin ~= nil),
     }
   end,
 }
+
 require("formatter.config").set_defaults {
   logging = false,
   filetype = O.formatters.filetype,
 }
-
 if not require("lv-utils").check_lsp_client_active "bashls" then
   -- npm i -g bash-language-server
   require("lspconfig").bashls.setup {

--- a/ftplugin/sh.lua
+++ b/ftplugin/sh.lua
@@ -8,6 +8,10 @@ O.formatters.filetype["sh"] = {
     }
   end,
 }
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
 
 if not require("lv-utils").check_lsp_client_active "bashls" then
   -- npm i -g bash-language-server

--- a/ftplugin/sh.lua
+++ b/ftplugin/sh.lua
@@ -1,3 +1,14 @@
+O.formatters.filetype["sh"] = {
+  function()
+    return {
+      exe = "shfmt",
+      --  TODO: append to this for args don't overwrite
+      args = { "-w" },
+      stdin = false,
+    }
+  end,
+}
+
 if not require("lv-utils").check_lsp_client_active "bashls" then
   -- npm i -g bash-language-server
   require("lspconfig").bashls.setup {
@@ -26,7 +37,7 @@ if not require("lv-utils").check_lsp_client_active "efm" then
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
-    root_dir = require("lspconfig").util.root_pattern(".git/"),
+    root_dir = require("lspconfig").util.root_pattern ".git/",
     filetypes = { "sh" },
     settings = {
       rootMarkers = { ".git/" },

--- a/ftplugin/tex.lua
+++ b/ftplugin/tex.lua
@@ -33,7 +33,6 @@ vim.api.nvim_exec(
     ]],
   false
 )
-if (O.lang.latex.auto_save)
-then
-  vim.api.nvim_exec([[au FocusLost * :wa]],false)
+if O.lang.latex.auto_save then
+  vim.api.nvim_exec([[au FocusLost * :wa]], false)
 end

--- a/ftplugin/yaml.lua
+++ b/ftplugin/yaml.lua
@@ -1,3 +1,17 @@
+O.formatters.filetype["yaml"] = {
+  function()
+    return {
+      exe = O.lang.yaml.formatter.exe,
+      args = O.lang.yaml.formatter.args,
+      stdin = not (O.lang.yaml.formatter.stdin ~= nil),
+    }
+  end,
+}
+
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
 if require("lv-utils").check_lsp_client_active "yamlls" then
   return
 end

--- a/ftplugin/zsh.lua
+++ b/ftplugin/zsh.lua
@@ -24,7 +24,7 @@ if not require("lv-utils").check_lsp_client_active "efm" then
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
     init_options = { documentFormatting = true, codeAction = false },
-    root_dir = require("lspconfig").util.root_pattern(".git/"),
+    root_dir = require("lspconfig").util.root_pattern ".git/",
     filetypes = { "zsh" },
     settings = {
       rootMarkers = { ".git/" },

--- a/lua/core/formatter.lua
+++ b/lua/core/formatter.lua
@@ -1,14 +1,14 @@
 -- autoformat
 if O.format_on_save then
-	require("lv-utils").define_augroups({
-		autoformat = {
-			{
-				"BufWritePost",
-				"*",
-				":silent FormatWrite",
-			},
-		},
-	})
+  require("lv-utils").define_augroups {
+    autoformat = {
+      {
+        "BufWritePost",
+        "*",
+        ":silent FormatWrite",
+      },
+    },
+  }
 end
 
 -- -- check if formatter has been defined for the language or not
@@ -50,13 +50,13 @@ end
 -- end
 local status_ok, formatter = pcall(require, "formatter")
 if not status_ok then
-	return
+  return
 end
 
-formatter.setup({ formatter.config })
+formatter.setup { formatter.config }
 
 if not O.format_on_save then
-	vim.cmd([[if exists('#autoformat#BufWritePost')
+  vim.cmd [[if exists('#autoformat#BufWritePost')
 	:autocmd! autoformat
-	endif]])
+	endif]]
 end

--- a/lua/core/formatter.lua
+++ b/lua/core/formatter.lua
@@ -53,8 +53,6 @@ if not status_ok then
   return
 end
 
-formatter.setup { formatter.config }
-
 if not O.format_on_save then
   vim.cmd [[if exists('#autoformat#BufWritePost')
 	:autocmd! autoformat

--- a/lua/core/formatter.lua
+++ b/lua/core/formatter.lua
@@ -1,14 +1,14 @@
 -- autoformat
 if O.format_on_save then
-  require("lv-utils").define_augroups {
-    autoformat = {
-      {
-        "BufWritePost",
-        "*",
-        ":silent FormatWrite",
-      },
-    },
-  }
+	require("lv-utils").define_augroups({
+		autoformat = {
+			{
+				"BufWritePost",
+				"*",
+				":silent FormatWrite",
+			},
+		},
+	})
 end
 
 -- -- check if formatter has been defined for the language or not
@@ -50,13 +50,13 @@ end
 -- end
 local status_ok, formatter = pcall(require, "formatter")
 if not status_ok then
-  return
+	return
 end
 
-formatter.setup { formatter.config }
+formatter.setup({ formatter.config })
 
 if not O.format_on_save then
-  vim.cmd [[if exists('#autoformat#BufWritePost')
+	vim.cmd([[if exists('#autoformat#BufWritePost')
 	:autocmd! autoformat
-	endif]]
+	endif]])
 end

--- a/lua/core/formatter.lua
+++ b/lua/core/formatter.lua
@@ -53,7 +53,7 @@ if not status_ok then
   return
 end
 
-formatter.setup {}
+formatter.setup { formatter.config }
 
 if not O.format_on_save then
   vim.cmd [[if exists('#autoformat#BufWritePost')

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -258,11 +258,6 @@ O = {
         "typescript",
         "typescriptreact",
       },
-      formatter = {
-        exe = "prettier",
-        args = { "--write", "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
-        stdin = false,
-      },
     },
     terraform = {},
     tsserver = {
@@ -275,8 +270,7 @@ O = {
       },
       formatter = {
         exe = "prettier",
-        args = { "--write", "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
-        stdin = false,
+        args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
       },
     },
     vim = {},

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -11,8 +11,9 @@ O.formatters.filetype["javascriptreact"] = {
   function()
     return {
       exe = prettier_instance,
-      args = O.lang.tsserver.formatter.args,
-      stdin = not (O.lang.tsserver.formatter.stdin ~= nil),
+      -- TODO: allow user to override this
+      args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
+      stdin = true
     }
   end,
 }

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -1,18 +1,22 @@
 vim.cmd "let proj = FindRootDirectory()"
-print(vim.api.nvim_get_var "proj")
 local root_dir = vim.api.nvim_get_var "proj"
+
+-- use the global prettier if you didn't find the local one
+local prettier_instance = root_dir .. "/node_modules/.bin/prettier"
+if vim.fn.executable(prettier_instance) ~= 1 then
+  prettier_instance = O.lang.tsserver.formatter.exe
+end
+
 O.formatters.filetype["javascriptreact"] = {
-  -- vim.cmd "let root_dir "
-  -- prettier
   function()
     return {
-      exe = root_dir .. "/node_modules/.bin/prettier",
-      --  TODO: append to this for args don't overwrite
-      args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
-      stdin = true,
+      exe = prettier_instance,
+      args = O.lang.tsserver.formatter.args,
+      stdin = not (O.lang.tsserver.formatter.stdin ~= nil),
     }
   end,
 }
+O.formatters.filetype["javascript"] = O.formatters.filetype["javascriptreact"]
 
 require("formatter.config").set_defaults {
   logging = false,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

We need to have some default formatters for each lang
Also, there was a bug that wouldn't set the formatter config.

## How Has This Been Tested?

- open a lua file
- run `:Format`
- run `:lua print(vim.inspect(O.formatters.filetype['lua']))`


