### PR TITLE
Fix the installation stuck on Ok to remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ If you help to develop Lunarvim, you can install a specific branch branch direct
 LVBRANCH=rolling bash <(curl -s https://raw.githubusercontent.com/ChristianChiarulli/lunarvim/rolling/utils/installer/install.sh)
 ```
 
+If your installation is stuck on `Ok to remove? [y/N]`, it means there are some leftovers, \
+you can run the script with `--overwrite` but be warned this will remove the following folder:
+- `~/.config/nvim`
+- `~/.cache/nvim`
+- `~/.local/share/nvim/site/pack/packer`
+```bash
+curl -s https://raw.githubusercontent.com/ChristianChiarulli/lunarvim/rolling/utils/installer/install.sh| LVBRANCH=rolling bash -s -- --overwrite
+```
+
 
 ## Installing LSP for your language
 

--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -182,6 +182,13 @@ installextrapackages() {
 # Welcome
 echo 'Installing LunarVim'
 
+if [[ $* == *--overwrite* ]]; then
+  echo '!!Warning!! -> Removing all nvim related config because of the --overwrite flag'
+  rm -rf "$HOME/.config/nvim"
+  rm -rf "$HOME/.cache/nvim"
+  rm -rf "$HOME/.local/share/nvim/site/pack/packer"
+fi
+
 # move old nvim directory if it exists
 [ -d "$HOME/.config/nvim" ] && moveoldnvim
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The installation process is sometimes stuck with 
`Ok to remove[y/N]?` message, this PR attempts to fix that
![unknown](https://user-images.githubusercontent.com/10992695/125468633-9caae56d-20b0-4c3c-90a0-331f296c6808.png)


## How Has This Been Tested?

as described in updated `Readme.md` you can run the installer script with
`--overwrite` flag to remove leftover from previous installations.

