### PR TITLE
[Feature] Added Deno Language Server

### DIFF
--- a/ftplugin/javascript.lua
+++ b/ftplugin/javascript.lua
@@ -1,7 +1,7 @@
 if O.lang.tsserver.active then
-  require "lsp.tsserver-ls"
+	require("lsp.tsserver-ls")
 elseif O.lang.deno.active then
-  require "lsp.deno-ls"
+	require("lsp.deno-ls")
 end
 
-vim.cmd "setl ts=2 sw=2"
+vim.cmd("setl ts=2 sw=2")

--- a/ftplugin/javascript.lua
+++ b/ftplugin/javascript.lua
@@ -1,3 +1,7 @@
-require "lsp.tsserver-ls"
+if O.lang.tsserver.active then
+  require "lsp.tsserver-ls"
+elseif O.lang.deno.active then
+  require "lsp.deno-ls"
+end
 
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/javascriptreact.lua
+++ b/ftplugin/javascriptreact.lua
@@ -1,7 +1,7 @@
 if O.lang.tsserver.active then
-  require "lsp.tsserver-ls"
+	require("lsp.tsserver-ls")
 elseif O.lang.deno.active then
-  require "lsp.deno-ls"
+	require("lsp.deno-ls")
 end
 
-vim.cmd "setl ts=2 sw=2"
+vim.cmd("setl ts=2 sw=2")

--- a/ftplugin/javascriptreact.lua
+++ b/ftplugin/javascriptreact.lua
@@ -1,3 +1,7 @@
-require "lsp.tsserver-ls"
+if O.lang.tsserver.active then
+  require "lsp.tsserver-ls"
+elseif O.lang.deno.active then
+  require "lsp.deno-ls"
+end
 
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/typescript.lua
+++ b/ftplugin/typescript.lua
@@ -1,7 +1,7 @@
 if O.lang.tsserver.active then
-  require "lsp.tsserver-ls"
+	require("lsp.tsserver-ls")
 elseif O.lang.deno.active then
-  require "lsp.deno-ls"
+	require("lsp.deno-ls")
 end
 
-vim.cmd "setl ts=2 sw=2"
+vim.cmd("setl ts=2 sw=2")

--- a/ftplugin/typescript.lua
+++ b/ftplugin/typescript.lua
@@ -1,3 +1,7 @@
-require "lsp.tsserver-ls"
+if O.lang.tsserver.active then
+  require "lsp.tsserver-ls"
+elseif O.lang.deno.active then
+  require "lsp.deno-ls"
+end
 
 vim.cmd "setl ts=2 sw=2"

--- a/ftplugin/typescriptreact.lua
+++ b/ftplugin/typescriptreact.lua
@@ -1,8 +1,7 @@
 if O.lang.tsserver.active then
-  require "lsp.tsserver-ls"
+	require("lsp.tsserver-ls")
 elseif O.lang.deno.active then
-  require "lsp.deno-ls"
+	require("lsp.deno-ls")
 end
 
-
-vim.cmd "setl ts=2 sw=2"
+vim.cmd("setl ts=2 sw=2")

--- a/ftplugin/typescriptreact.lua
+++ b/ftplugin/typescriptreact.lua
@@ -1,3 +1,8 @@
-require "lsp.tsserver-ls"
+if O.lang.tsserver.active then
+  require "lsp.tsserver-ls"
+elseif O.lang.deno.active then
+  require "lsp.deno-ls"
+end
+
 
 vim.cmd "setl ts=2 sw=2"

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -119,6 +119,7 @@ O = {
         args = { "format" },
       },
     },
+    deno = {},
     docker = {},
     efm = {},
     elm = {},

--- a/lua/lsp/deno-ls.lua
+++ b/lua/lsp/deno-ls.lua
@@ -1,18 +1,18 @@
-print(require('lv-utils'))
-if require("lv-utils").check_lsp_client_active "denols" then
-  return
+print(require("lv-utils"))
+if require("lv-utils").check_lsp_client_active("denols") then
+	return
 end
 
 -- :LspInstall deno
 print(require("lspconfig"))
-require("lspconfig").denols.setup {
-  cmd = { DATA_PATH .. "/lspinstall/deno/bin/deno", "lsp" },
-  filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
+require("lspconfig").denols.setup({
+	cmd = { DATA_PATH .. "/lspinstall/deno/bin/deno", "lsp" },
+	filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
 
-  init_options = {
-    enable = true,
-    lint = true,
-    unstable = true
-  },
-  root_dir = require("lspconfig").util.root_pattern("package.json", "tsconfig.json", ".git")
-}
+	init_options = {
+		enable = true,
+		lint = true,
+		unstable = true,
+	},
+	root_dir = require("lspconfig").util.root_pattern("package.json", "tsconfig.json", ".git"),
+})

--- a/lua/lsp/deno-ls.lua
+++ b/lua/lsp/deno-ls.lua
@@ -1,0 +1,18 @@
+print(require('lv-utils'))
+if require("lv-utils").check_lsp_client_active "denols" then
+  return
+end
+
+-- :LspInstall deno
+print(require("lspconfig"))
+require("lspconfig").denols.setup {
+  cmd = { DATA_PATH .. "/lspinstall/deno/bin/deno", "lsp" },
+  filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
+
+  init_options = {
+    enable = true,
+    lint = true,
+    unstable = true
+  },
+  root_dir = require("lspconfig").util.root_pattern("package.json", "tsconfig.json", ".git")
+}

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -3,7 +3,7 @@
 -- end
 local status_ok, which_key = pcall(require, "which-key")
 if not status_ok then
-  return
+	return
 end
 
 which_key.setup(O.plugin.which_key.setup)
@@ -12,7 +12,7 @@ local opts = O.plugin.which_key.opts
 local vopts = O.plugin.which_key.vopts
 
 local mappings = O.plugin.which_key.mappings
-local vmappings = O.plugin.which_key.vmappings;
+local vmappings = O.plugin.which_key.vmappings
 
 -- if O.plugin.ts_playground.active then
 --   vim.api.nvim_set_keymap("n", "<leader>Th", ":TSHighlightCapturesUnderCursor<CR>", { noremap = true, silent = true })
@@ -20,39 +20,39 @@ local vmappings = O.plugin.which_key.vmappings;
 -- end
 
 if O.plugin.zen.active then
-  vim.api.nvim_set_keymap("n", "<leader>z", ":ZenMode<CR>", { noremap = true, silent = true })
-  mappings["z"] = "Zen"
+	vim.api.nvim_set_keymap("n", "<leader>z", ":ZenMode<CR>", { noremap = true, silent = true })
+	mappings["z"] = "Zen"
 end
 
 if O.plugin.telescope_project.active then
-  -- open projects
-  vim.api.nvim_set_keymap(
-    "n",
-    "<leader>P",
-    ":lua require'telescope'.extensions.project.project{}<CR>",
-    { noremap = true, silent = true }
-  )
-  mappings["P"] = "Projects"
+	-- open projects
+	vim.api.nvim_set_keymap(
+		"n",
+		"<leader>P",
+		":lua require'telescope'.extensions.project.project{}<CR>",
+		{ noremap = true, silent = true }
+	)
+	mappings["P"] = "Projects"
 end
 
 if O.plugin.lush.active then
-  mappings["L"] = {
-    name = "+Lush",
-    l = { ":Lushify<cr>", "Lushify" },
-    x = { ":lua require('lush').export_to_buffer(require('lush_theme.cool_name'))", "Lush Export" },
-    t = { ":LushRunTutorial<cr>", "Lush Tutorial" },
-    q = { ":LushRunQuickstart<cr>", "Lush Quickstart" },
-  }
+	mappings["L"] = {
+		name = "+Lush",
+		l = { ":Lushify<cr>", "Lushify" },
+		x = { ":lua require('lush').export_to_buffer(require('lush_theme.cool_name'))", "Lush Export" },
+		t = { ":LushRunTutorial<cr>", "Lush Tutorial" },
+		q = { ":LushRunQuickstart<cr>", "Lush Quickstart" },
+	}
 end
 
 if O.lang.deno.active then
-  mappings["l"]["c"] = { "<cmd>DenolsCache<cr>", "Deno Cache" }
+	mappings["l"]["c"] = { "<cmd>DenolsCache<cr>", "Deno Cache" }
 end
 
 for k, v in pairs(O.user_which_key) do
-  mappings[k] = v
+	mappings[k] = v
 end
 
-local wk = require "which-key"
+local wk = require("which-key")
 wk.register(mappings, opts)
 wk.register(vmappings, vopts)

--- a/lua/lv-which-key/init.lua
+++ b/lua/lv-which-key/init.lua
@@ -45,6 +45,10 @@ if O.plugin.lush.active then
   }
 end
 
+if O.lang.deno.active then
+  mappings["l"]["c"] = { "<cmd>DenolsCache<cr>", "Deno Cache" }
+end
+
 for k, v in pairs(O.user_which_key) do
   mappings[k] = v
 end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add deno to as a language server for javascript/typescript (and their react equivalents) files. 
Add a which-key entry when deno has been activated.

# How to activate

Since deno is an alternative to tsserver, their use should be mutually exclusive.
Add the following to the lv-config.lua
`O.lang.tsserver.active = false`
`O.lang.deno.active = true`

# Notes/Questions for the reviewers

1. The which-key entry will be visible whenever `O.lang.deno.active = true`. I would've liked to have it visible only when the deno-ls is running. Is this possible?
2. The commands that come with the language server (`DenolsDefinition` and `DenolsReferences`) should be used when going to the definition/references of a method/variable. They do work, but the default behaviour when pressing `gd` or `gr` is broken on  deno's files. According to the documentation these handlers can be overridden (see below), but my lack of lua knowledge prevents me from implementing `<function 1>`. How can I implement this function to execute the abovementioned neovim commands?

> handlers = {
      ["textDocument/definition"] = <function 1>,
      ["textDocument/references"] = <function 1>
    }