### PR TITLE
[WHICH-KEY] Use wk.register() to handle the overrides.

### DIFF
--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -185,13 +185,11 @@ M.setup = function()
     mappings["z"] = "Zen"
   end
 
-  for k, v in pairs(O.user_which_key) do
-    mappings[k] = v
-  end
-
   local wk = require "which-key"
+
   wk.register(mappings, opts)
   wk.register(vmappings, vopts)
+  wk.register(O.user_which_key, opts)
 end
 
 return M


### PR DESCRIPTION
The current O.user_which_key allows user to add top-level mappings, but its difficult to e.g. change a single item in a sub-menu..
Thats because the for() loop which iterates over each k,v pair replaces the root of each key entirely.

Simply giving the user-defined mappings to wk.register() overrides things which much finer control.

