### PR TITLE
Fix vsnip_dir typo

### DIFF
--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -34,7 +34,7 @@ M.config = function()
 end
 
 M.setup = function()
-  vim.g.vsnip_snippet_dir = O.vnsip_dir
+  vim.g.vsnip_snippet_dir = O.vsnip_dir
 
   local status_ok, compe = pcall(require, "compe")
   if not status_ok then

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -10,7 +10,7 @@ O = {
   line_wrap_cursor_movement = true,
   transparent_window = false,
   format_on_save = true,
-  vnsip_dir = vim.fn.stdpath "config" .. "/snippets",
+  vsnip_dir = vim.fn.stdpath "config" .. "/snippets",
 
   default_options = {
     backup = false, -- creates a backup file


### PR DESCRIPTION
This PR fixes a typo in the setting name `vsnip_dir`.