### PR TITLE
[Bugfix] index field typo in ftplugin/c.lua

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -1,9 +1,9 @@
 O.formatters.filetype["c"] = {
   function()
     return {
-      exe = O.lang.c.formatter.exe,
-      args = O.lang.c.formatter.args,
-      stdin = not (O.lang.c.formatter.stdin ~= nil),
+      exe = O.lang.clang.formatter.exe,
+      args = O.lang.clang.formatter.args,
+      stdin = not (O.lang.clang.formatter.stdin ~= nil),
     }
   end,
 }


### PR DESCRIPTION
fix a typo in ftplugin/c.lua that leads to E5108: Error executing lua /home/qvieth/.config/nvim/ftplugin/cpp.lua:4: attempt to index field 'c' (a nil value)  while using Formatter in C file

