### PR TITLE
Fix tsserver formatter not working

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -309,7 +309,7 @@ O = {
       },
       formatter = {
         exe = "prettier",
-        args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
+        args = {},
       },
     },
     vim = {},

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -9,9 +9,14 @@ end
 
 O.formatters.filetype["javascriptreact"] = {
   function()
+    local args = { "--stdin-filepath", vim.fn.fnameescape(vim.api.nvim_buf_get_name(0)) }
+    local extend_args = O.lang.tsserver.formatter.args
+    for i = 1, #extend_args do
+      table.insert(args, extend_args[i])
+    end
     return {
       exe = prettier_instance,
-      args = O.lang.tsserver.formatter.args,
+      args = args,
       stdin = true,
     }
   end,


### PR DESCRIPTION
Sorry, https://github.com/ChristianChiarulli/LunarVim/pull/921 is broken.

`vim.api.nvim_buf_get_name(0)` should call on every format. I think any `vim.api.nvim_buf_get_name(0)` for formatter put in config files(default-config or lv-config) should be careful, as it's only run once on config file loaded.

Also fixed filename should be escaped with `vim.fn.fnameescape`.