### PR TITLE
Autopairs event trigger

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -60,7 +60,6 @@ return require("packer").startup(function(use)
   use {
     "windwp/nvim-autopairs",
     -- event = "InsertEnter",
-    after = { "nvim-treesitter" },
     config = function()
       require "core.autopairs"
     end,

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -60,7 +60,7 @@ return require("packer").startup(function(use)
   use {
     "windwp/nvim-autopairs",
     -- event = "InsertEnter",
-    after = { "telescope.nvim" },
+    after = { "nvim-treesitter" },
     config = function()
       require "core.autopairs"
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description



The 'after' keyword has no effect.  Since the dependencies are autoloaded, the 'after' setting is not being applied.  Packer can only manage plugins in the 'opt' folder with the 'after' keyword.

The 'after' keyword was needed when we were lazy loading compe and tree-sitter but now it does nothing.  

As described here https://github.com/wbthomason/packer.nvim/issues/435

The listing in the packer_compiled file shows an empty table for 'after'

```lua
  ["nvim-autopairs"] = {
    config = { "\27LJ\2\n.\0\0\3\0\2\0\0046\0\0\0'\2\1\0B\0\2\1K\0\1\0\19core.autopairs\frequire\0" },
    load_after = {},
    loaded = true,
    needs_bufread = false,
    path = "/home/nelson/.local/share/nvim/site/pack/packer/opt/nvim-autopairs"
  },
```

## How Has This Been Tested?

Opened lua file to make sure autopairs works and that indenting works as well. 

- ...

