### PR TITLE
[Bugfix] Add root_dir configuration to pyright

### DIFF
--- a/lua/lsp/python.lua
+++ b/lua/lsp/python.lua
@@ -74,6 +74,7 @@ M.lsp = function()
         update_in_insert = true,
       }),
     },
+    root_dir = require("lspconfig").util.root_pattern(".git/", "requirements.txt"),
     settings = {
       python = {
         analysis = {


### PR DESCRIPTION
# Description

Adds `root_dir` configuration to `pyright` language server config.

Fixes #(issue)

## How Has This Been Tested?

Opened a Python project, which had a requirements.txt file in the root directory -> pyright recognized project root correctly.