### PR TITLE
Fix rust root pattern

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -95,7 +95,7 @@ else
     cmd = { DATA_PATH .. "/lspinstall/rust/rust-analyzer" },
     on_attach = require("lsp").common_on_attach,
     filetypes = { "rust" },
-    root_dir = require("lspconfig.util").root_pattern("Carrust.toml", "rust-project.json"),
+    root_dir = require("lspconfig.util").root_pattern("Cargo.toml", "rust-project.json"),
   }
 end
 


### PR DESCRIPTION
rust projects don't have a `Carrust.toml` file at the root. it's `Cargo.toml`

Edit:

Maybe this should go straight to `master` branch as rust projects are simply broken due to this ?