### PR TITLE
Add css (and pre-processors) support

### DIFF
--- a/ftplugin/css.lua
+++ b/ftplugin/css.lua
@@ -1,3 +1,36 @@
+vim.cmd "let proj = FindRootDirectory()"
+local root_dir = vim.api.nvim_get_var "proj"
+
+-- use the global prettier if you didn't find the local one
+local prettier_instance = root_dir .. "/node_modules/.bin/prettier"
+if vim.fn.executable(prettier_instance) ~= 1 then
+  prettier_instance = O.lang.tsserver.formatter.exe
+end
+
+local ft = vim.bo.filetype
+O.formatters.filetype[ft]= {
+  function()
+    local args = { "--stdin-filepath", vim.fn.fnameescape(vim.api.nvim_buf_get_name(0)) }
+    -- TODO: O.lang.[ft].formatter.args
+    local extend_args = O.lang.css.formatter.args
+
+    for i = 1, #extend_args do
+      table.insert(args, extend_args[i])
+    end
+
+    return {
+      exe = prettier_instance,
+      args = args,
+      stdin = true
+    }
+  end,
+}
+
+require("formatter.config").set_defaults {
+  logging = false,
+  filetype = O.formatters.filetype,
+}
+
 if not require("lv-utils").check_lsp_client_active "cssls" then
   local capabilities = vim.lsp.protocol.make_client_capabilities()
   capabilities.textDocument.completion.completionItem.snippetSupport = true

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -107,6 +107,10 @@ O = {
     },
     css = {
       virtual_text = true,
+      formatter = {
+        exe = "prettier",
+        args = {},
+      },
     },
     dart = {
       sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adds formatter for css and any filetype symlinked to that filetype, eg. scss and less. I would like to continue add more formatters, specifically via prettier. I noticed there is now a decent amount of duplicated code between formatters so any suggestion on improving that pattern would be appreciated :)

## How Has This Been Tested?

Formatted both `.css` and `.scss` files.

