### PR TITLE
[Bugfix] Use user defined value when setting showtabline on BufLeave

### DIFF
--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -92,7 +92,7 @@ M.setup = function()
       {
         "FileType",
         "dashboard",
-        "set showtabline=0 | autocmd BufLeave <buffer> set showtabline=2",
+        "set showtabline=0 | autocmd BufLeave <buffer> set showtabline=" .. O.default_options.showtabline,
       },
       { "FileType", "dashboard", "nnoremap <silent> <buffer> q :q<CR>" },
     },


### PR DESCRIPTION
# Description

There is a hard coded `showtabline` value in the `dashboard.lua`, which overrides the user defined (`lv-config.lua`) `O.default_options.showtabline` value. This PR fixes the issue.

## How Has This Been Tested?

Set e.g. `O.default_options.showtabline = 0` in your `lv-config.lua`. Before fix the Dashboard overrides the value, but after the fix the user defined value is honored.
