### PR TITLE
[Feature] Allow using custom paths for language servers

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -1,4 +1,4 @@
-require("lang.clang").format()
-require("lang.clang").lint()
-require("lang.clang").lsp()
-require("lang.clang").dap()
+require("lang.cpp").format()
+require("lang.cpp").lint()
+require("lang.cpp").lsp()
+require("lang.cpp").dap()

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -128,7 +128,7 @@ require("core.telescope").config()
 require("core.treesitter").config()
 require("core.which-key").config()
 
-require("lang.clang").config()
+require("lang.cpp").config()
 require("lang.cmake").config()
 require("lang.css").config()
 require("lang.dart").config()

--- a/lua/lang/cmake.lua
+++ b/lua/lang/cmake.lua
@@ -25,7 +25,7 @@ M.lsp = function()
   end
 
   require("lspconfig").cmake.setup {
-    cmd = { DATA_PATH .. "/lspinstall/cmake/venv/bin/cmake-language-server" },
+    cmd = { require("lsp.installer").get_langserver_path "cmake" },
     on_attach = require("lsp").common_on_attach,
     filetypes = { "cmake" },
   }

--- a/lua/lang/cpp.lua
+++ b/lua/lang/cpp.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 M.config = function()
-  O.lang.clang = {
+  O.lang.cpp = {
     diagnostics = {
       virtual_text = { spacing = 0, prefix = "" },
       signs = true,
@@ -27,9 +27,9 @@ M.format = function()
   local shared_config = {
     function()
       return {
-        exe = O.lang.clang.formatter.exe,
-        args = O.lang.clang.formatter.args,
-        stdin = not (O.lang.clang.formatter.stdin ~= nil),
+        exe = O.lang.cpp.formatter.exe,
+        args = O.lang.cpp.formatter.args,
+        stdin = not (O.lang.cpp.formatter.stdin ~= nil),
         cwd = vim.fn.expand "%:h:p",
       }
     end,
@@ -55,20 +55,20 @@ M.lsp = function()
   end
   local clangd_flags = { "--background-index" }
 
-  if O.lang.clang.cross_file_rename then
+  if O.lang.cpp.cross_file_rename then
     table.insert(clangd_flags, "--cross-file-rename")
   end
 
-  table.insert(clangd_flags, "--header-insertion=" .. O.lang.clang.header_insertion)
+  table.insert(clangd_flags, "--header-insertion=" .. O.lang.cpp.header_insertion)
 
   require("lspconfig").clangd.setup {
-    cmd = { DATA_PATH .. "/lspinstall/cpp/clangd/bin/clangd", unpack(clangd_flags) },
+    cmd = { require("lsp.installer").get_langserver_path "cpp", unpack(clangd_flags) },
     on_attach = require("lsp").common_on_attach,
     handlers = {
       ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
-        virtual_text = O.lang.clang.diagnostics.virtual_text,
-        signs = O.lang.clang.diagnostics.signs,
-        underline = O.lang.clang.diagnostics.underline,
+        virtual_text = O.lang.cpp.diagnostics.virtual_text,
+        signs = O.lang.cpp.diagnostics.signs,
+        underline = O.lang.cpp.diagnostics.underline,
         update_in_insert = true,
       }),
     },
@@ -82,7 +82,7 @@ M.dap = function()
     dap_install.config("ccppr_vsc_dbg", {})
     dap.adapters.lldb = {
       type = "executable",
-      command = O.lang.clang.debug.adapter.command,
+      command = O.lang.cpp.debug.adapter.command,
       name = "lldb",
     }
     local shared_dap_config = {
@@ -94,7 +94,7 @@ M.dap = function()
           return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
         end,
         cwd = "${workspaceFolder}",
-        stopOnEntry = O.lang.clang.debug.stop_on_entry,
+        stopOnEntry = O.lang.cpp.debug.stop_on_entry,
         args = {},
         env = function()
           local variables = {}

--- a/lua/lang/cs.lua
+++ b/lua/lang/cs.lua
@@ -24,7 +24,7 @@ M.lsp = function()
   require("lspconfig").omnisharp.setup {
     on_attach = require("lsp").common_on_attach,
     root_dir = require("lspconfig").util.root_pattern(".sln", ".git"),
-    cmd = { DATA_PATH .. "/lspinstall/csharp/omnisharp/run", "--languageserver", "--hostPID", tostring(vim.fn.getpid()) },
+    cmd = { require("lsp.installer").get_langserver_path "csharp", tostring(vim.fn.getpid()) },
   }
 end
 

--- a/lua/lang/css.lua
+++ b/lua/lang/css.lua
@@ -57,7 +57,7 @@ M.lsp = function()
     require("lspconfig").cssls.setup {
       cmd = {
         "node",
-        DATA_PATH .. "/lspinstall/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
+        require("lsp.installer").get_langserver_path "css",
         "--stdio",
       },
       on_attach = require("lsp").common_on_attach,

--- a/lua/lang/dockerfile.lua
+++ b/lua/lang/dockerfile.lua
@@ -21,7 +21,7 @@ M.lsp = function()
 
   -- npm install -g dockerfile-language-server-nodejs
   require("lspconfig").dockerls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/dockerfile/node_modules/.bin/docker-langserver", "--stdio" },
+    cmd = { require("lsp.installer").get_langserver_path "dockerfile", "--stdio" },
     on_attach = require("lsp").common_on_attach,
     root_dir = vim.loop.cwd,
   }

--- a/lua/lang/elixir.lua
+++ b/lua/lang/elixir.lua
@@ -38,7 +38,7 @@ M.lsp = function()
   end
 
   require("lspconfig").elixirls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/elixir/elixir-ls/language_server.sh" },
+    cmd = { require("lsp.installer").get_langserver_path "elixir" },
   }
 end
 

--- a/lua/lang/elm.lua
+++ b/lua/lang/elm.lua
@@ -20,7 +20,7 @@ M.lsp = function()
   end
 
   require("lspconfig").elmls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/elm/node_modules/.bin/elm-language-server" },
+    cmd = { require("lsp.installer").get_langserver_path "elm" },
     init_options = {
       elmAnalyseTrigger = "change",
       elmFormatPath = DATA_PATH .. "/lspinstall/elm/node_modules/.bin/elm-format",

--- a/lua/lang/euphoria3.lua
+++ b/lua/lang/euphoria3.lua
@@ -22,7 +22,7 @@ M.lsp = function()
 
   -- TODO: Remove this at some point
   require("lspconfig").elixirls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/elixir/elixir-ls/language_server.sh" },
+    cmd = { require("lsp.installer").get_langserver_path "elixir" },
   }
 end
 

--- a/lua/lang/go.lua
+++ b/lua/lang/go.lua
@@ -34,7 +34,7 @@ end
 M.lsp = function()
   if not require("lv-utils").check_lsp_client_active "gopls" then
     require("lspconfig").gopls.setup {
-      cmd = { DATA_PATH .. "/lspinstall/go/gopls" },
+      cmd = { require("lsp.installer").get_langserver_path "go" },
       settings = { gopls = { analyses = { unusedparams = true }, staticcheck = true } },
       root_dir = require("lspconfig").util.root_pattern(".git", "go.mod"),
       init_options = { usePlaceholders = true, completeUnimported = true },

--- a/lua/lang/html.lua
+++ b/lua/lang/html.lua
@@ -23,7 +23,7 @@ M.lsp = function()
     require("lspconfig").html.setup {
       cmd = {
         "node",
-        DATA_PATH .. "/lspinstall/html/vscode-html/html-language-features/server/dist/node/htmlServerMain.js",
+        require("lsp.installer").get_langserver_path "html",
         "--stdio",
       },
       on_attach = require("lsp").common_on_attach,

--- a/lua/lang/json.lua
+++ b/lua/lang/json.lua
@@ -45,7 +45,7 @@ M.lsp = function()
   require("lspconfig").jsonls.setup {
     cmd = {
       "node",
-      DATA_PATH .. "/lspinstall/json/vscode-json/json-language-features/server/dist/node/jsonServerMain.js",
+      require("lsp.installer").get_langserver_path "json",
       "--stdio",
     },
     on_attach = require("lsp").common_on_attach,

--- a/lua/lang/kotlin.lua
+++ b/lua/lang/kotlin.lua
@@ -29,7 +29,7 @@ M.lsp = function()
 
   local util = require "lspconfig/util"
 
-  local bin_name = DATA_PATH .. "/lspinstall/kotlin/server/bin/kotlin-language-server"
+  local bin_name = require("lsp.installer").get_langserver_path "kotlin"
   if vim.fn.has "win32" == 1 then
     bin_name = bin_name .. ".bat"
   end

--- a/lua/lang/lua.lua
+++ b/lua/lang/lua.lua
@@ -40,7 +40,7 @@ end
 M.lsp = function()
   if not require("lv-utils").check_lsp_client_active "sumneko_lua" then
     -- https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)
-    local sumneko_root_path = DATA_PATH .. "/lspinstall/lua"
+    local sumneko_root_path = require("lsp.installer").get_langserver_path "lua"
     local sumneko_binary = sumneko_root_path .. "/sumneko-lua-language-server"
 
     require("lspconfig").sumneko_lua.setup {

--- a/lua/lang/php.lua
+++ b/lua/lang/php.lua
@@ -52,7 +52,7 @@ M.lsp = function()
   end
 
   require("lspconfig").intelephense.setup {
-    cmd = { DATA_PATH .. "/lspinstall/php/node_modules/.bin/intelephense", "--stdio" },
+    cmd = { require("lsp.installer").get_langserver_path "php", "--stdio" },
     on_attach = require("lsp").common_on_attach,
     handlers = {
       ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {

--- a/lua/lang/python.lua
+++ b/lua/lang/python.lua
@@ -63,7 +63,7 @@ M.lint = function()
 
   if not require("lv-utils").check_lsp_client_active "efm" then
     require("lspconfig").efm.setup {
-      cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
+      cmd = { require("lsp.installer").get_langserver_path "efm" },
       init_options = { documentFormatting = true, codeAction = false },
       root_dir = require("lspconfig").util.root_pattern(".git/", "requirements.txt"),
       filetypes = { "python" },
@@ -83,10 +83,7 @@ M.lsp = function()
   end
   -- npm i -g pyright
   require("lspconfig").pyright.setup {
-    cmd = {
-      DATA_PATH .. "/lspinstall/python/node_modules/.bin/pyright-langserver",
-      "--stdio",
-    },
+    cmd = { require("lsp.installer").get_langserver_path "python", "--stdio" },
     on_attach = require("lsp").common_on_attach,
     handlers = {
       ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {

--- a/lua/lang/ruby.lua
+++ b/lua/lang/ruby.lua
@@ -44,7 +44,7 @@ M.lsp = function()
 
   -- If you are using rvm, make sure to change below configuration
   require("lspconfig").solargraph.setup {
-    cmd = { DATA_PATH .. "/lspinstall/ruby/solargraph/solargraph", "stdio" },
+    cmd = { require("lsp.installer").get_langserver_path "ruby", "stdio" },
     on_attach = require("lsp").common_on_attach,
     handlers = {
       ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {

--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -117,14 +117,14 @@ M.lsp = function()
       -- these override the defaults set by rust-tools.nvim
       -- see https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#rust_analyzer
       server = {
-        cmd = { DATA_PATH .. "/lspinstall/rust/rust-analyzer" },
+        cmd = { require("lsp.installer").get_langserver_path "rust" },
         on_attach = require("lsp").common_on_attach,
       }, -- rust-analyser options
     }
     require("rust-tools").setup(opts)
   else
     require("lspconfig").rust_analyzer.setup {
-      cmd = { DATA_PATH .. "/lspinstall/rust/rust-analyzer" },
+      cmd = { require("lsp.installer").get_langserver_path "rust" },
       on_attach = require("lsp").common_on_attach,
       filetypes = { "rust" },
       root_dir = require("lspconfig.util").root_pattern("Cargo.toml", "rust-project.json"),

--- a/lua/lang/sh.lua
+++ b/lua/lang/sh.lua
@@ -53,7 +53,7 @@ M.lint = function()
   if not require("lv-utils").check_lsp_client_active "efm" then
     require("lspconfig").efm.setup {
       -- init_options = {initializationOptions},
-      cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
+      cmd = { require("lsp.installer").get_langserver_path "efm" },
       init_options = { documentFormatting = true, codeAction = false },
       root_dir = require("lspconfig").util.root_pattern ".git/",
       filetypes = { "sh" },
@@ -71,7 +71,7 @@ M.lsp = function()
   if not require("lv-utils").check_lsp_client_active "bashls" then
     -- npm i -g bash-language-server
     require("lspconfig").bashls.setup {
-      cmd = { DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server", "start" },
+      cmd = { require("lsp.installer").get_langserver_path "bash", "start" },
       on_attach = require("lsp").common_on_attach,
       filetypes = { "sh", "zsh" },
     }

--- a/lua/lang/terraform.lua
+++ b/lua/lang/terraform.lua
@@ -39,7 +39,7 @@ M.lsp = function()
   end
 
   require("lspconfig").terraformls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/terraform/terraform-ls", "serve" },
+    cmd = { require("lsp.installer").get_langserver_path "terraform", "serve" },
     on_attach = require("lsp").common_on_attach,
     filetypes = { "tf", "terraform", "hcl" },
   }

--- a/lua/lang/tex.lua
+++ b/lua/lang/tex.lua
@@ -75,7 +75,7 @@ M.lsp = function()
   end
 
   require("lspconfig").texlab.setup {
-    cmd = { DATA_PATH .. "/lspinstall/latex/texlab" },
+    cmd = { require("lsp.installer").get_langserver_path "latex" },
     on_attach = require("lsp").common_on_attach,
     handlers = {
       ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {

--- a/lua/lang/vim.lua
+++ b/lua/lang/vim.lua
@@ -21,7 +21,7 @@ M.lsp = function()
 
   -- npm install -g vim-language-server
   require("lspconfig").vimls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/vim/node_modules/.bin/vim-language-server", "--stdio" },
+    cmd = { require("lsp.installer").get_langserver_path "vim", "--stdio" },
     on_attach = require("lsp").common_on_attach,
   }
 end

--- a/lua/lang/vue.lua
+++ b/lua/lang/vue.lua
@@ -22,7 +22,7 @@ M.lsp = function()
 
   -- Vue language server configuration (vetur)
   require("lspconfig").vuels.setup {
-    cmd = { DATA_PATH .. "/lspinstall/vue/node_modules/.bin/vls", "--stdio" },
+    cmd = { require("lsp.installer").get_langserver_path "vue", "--stdio" },
     on_attach = require("lsp").common_on_attach,
     root_dir = require("lspconfig").util.root_pattern(".git", "vue.config.js", "package.json", "yarn.lock"),
   }

--- a/lua/lang/yaml.lua
+++ b/lua/lang/yaml.lua
@@ -37,7 +37,7 @@ M.lsp = function()
 
   -- npm install -g yaml-language-server
   require("lspconfig").yamlls.setup {
-    cmd = { DATA_PATH .. "/lspinstall/yaml/node_modules/.bin/yaml-language-server", "--stdio" },
+    cmd = { require("lsp.installer").get_langserver_path "yaml", "--stdio" },
     on_attach = require("lsp").common_on_attach,
   }
 end

--- a/lua/lang/zsh.lua
+++ b/lua/lang/zsh.lua
@@ -17,7 +17,7 @@ M.lint = function()
   if not require("lv-utils").check_lsp_client_active "efm" then
     require("lspconfig").efm.setup {
       -- init_options = {initializationOptions},
-      cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
+      cmd = { require("lsp.installer").get_langserver_path "efm" },
       init_options = { documentFormatting = true, codeAction = false },
       root_dir = require("lspconfig").util.root_pattern ".git/",
       filetypes = { "zsh" },
@@ -35,7 +35,7 @@ M.lsp = function()
   if not require("lv-utils").check_lsp_client_active "bashls" then
     -- npm i -g bash-language-server
     require("lspconfig").bashls.setup {
-      cmd = { DATA_PATH .. "/lspinstall/bash/node_modules/.bin/bash-language-server", "start" },
+      cmd = { require("lsp.installer").get_langserver_path "bash", "start" },
       on_attach = require("lsp").common_on_attach,
       filetypes = { "sh", "zsh" },
     }

--- a/lua/lsp/angular-ls.lua
+++ b/lua/lsp/angular-ls.lua
@@ -1,6 +1,6 @@
 -- TODO: find correct root filetype
 -- :LspInstall angular
 require("lspconfig").angularls.setup {
-  cmd = { DATA_PATH .. "/lspinstall/angular/node_modules/@angular/language-server/bin/ngserver", "--stdio" },
+  cmd = { require("lsp.installer").get_langserver_path "angular", "--stdio" },
   on_attach = require("lsp").common_on_attach,
 }

--- a/lua/lsp/installer.lua
+++ b/lua/lsp/installer.lua
@@ -1,0 +1,47 @@
+local installer = {}
+
+local LSP_INSTALL_DIR = DATA_PATH .. "/lspinstall"
+
+installer.default_install_path = {
+  ["sh"] = LSP_INSTALL_DIR .. "/bash/node_modules/.bin/bash-language-server",
+  ["cpp"] = LSP_INSTALL_DIR .. "/cpp/clangd/bin/clangd",
+  ["cmake"] = LSP_INSTALL_DIR .. "/cmake/venv/bin/cmake-language-server",
+  ["csharp"] = LSP_INSTALL_DIR .. "/csharp/omnisharp/run",
+  ["css"] = LSP_INSTALL_DIR .. "/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
+  ["docker"] = LSP_INSTALL_DIR .. "/dockerfile/node_modules/.bin/docker-langserver",
+  ["efm"] = LSP_INSTALL_DIR .. "/efm/efm-langserver",
+  ["elm"] = LSP_INSTALL_DIR .. "/elm/node_modules/.bin/elm-language-server",
+  ["gopls"] = LSP_INSTALL_DIR .. "/go/gopls",
+  ["html"] = LSP_INSTALL_DIR .. "/html/vscode-html/html-language-features/server/dist/node/htmlServerMain.js",
+  ["php"] = LSP_INSTALL_DIR .. "/php/node_modules/.bin/intelephense",
+  ["java"] = LSP_INSTALL_DIR .. "/java/jdtls.sh",
+  ["json"] = LSP_INSTALL_DIR .. "/json/vscode-json/json-language-features/server/dist/node/jsonServerMain.js",
+  ["angular"] = LSP_INSTALL_DIR .. "/angular/node_modules/@angular/language-server/bin/ngserver",
+  ["python"] = LSP_INSTALL_DIR .. "/python/node_modules/.bin/pyright-langserver",
+  ["rust"] = LSP_INSTALL_DIR .. "/rust/rust-analyzer",
+  ["elixir"] = LSP_INSTALL_DIR .. "/elixir/elixir-ls/language_server.sh",
+  ["ruby"] = LSP_INSTALL_DIR .. "/ruby/solargraph/solargraph",
+  ["lua"] = LSP_INSTALL_DIR .. "/lua",
+  ["svelte"] = LSP_INSTALL_DIR .. "/svelte/node_modules/.bin/svelteserver",
+  ["terraform"] = LSP_INSTALL_DIR .. "/terraform/terraform-ls",
+  ["latex"] = LSP_INSTALL_DIR .. "/latex/texlab",
+  ["tsserver"] = LSP_INSTALL_DIR .. "/typescript/node_modules/.bin/typescript-language-server",
+  ["vim"] = LSP_INSTALL_DIR .. "/vim/node_modules/.bin/vim-language-server",
+  ["vue"] = LSP_INSTALL_DIR .. "/vue/node_modules/.bin/vls",
+  ["yaml"] = LSP_INSTALL_DIR .. "/yaml/node_modules/.bin/yaml-language-server",
+}
+
+function installer.get_langserver_path(lang)
+  -- check if it has been defined by the user
+  if O.lang[lang]["custom_languageserver"] ~= nil then
+    return O.lang[lang]["custom_languageserver"]
+  end
+  -- otherwise we use the one provided by LspInstall if it's available
+  if require("lspinstall").is_server_installed(lang) then
+    return installer.default_install_path[lang]
+  else
+    vim.notify("No language server was found! try :LspInstall " .. lang)
+  end
+end
+
+return installer

--- a/lua/lsp/svelte-ls.lua
+++ b/lua/lsp/svelte-ls.lua
@@ -1,5 +1,5 @@
 -- TODO: what is a svelte filetype
 require("lspconfig").svelte.setup {
-  cmd = { DATA_PATH .. "/lspinstall/svelte/node_modules/.bin/svelteserver", "--stdio" },
+  cmd = { require("lsp.installer").get_langserver_path "svelte", "--stdio" },
   on_attach = require("lsp").common_on_attach,
 }

--- a/lua/lsp/tailwindcss-ls.lua
+++ b/lua/lsp/tailwindcss-ls.lua
@@ -4,7 +4,7 @@ local lspconfig = require "lspconfig"
 lspconfig.tailwindcss.setup {
   cmd = {
     "node",
-    DATA_PATH .. "/lspinstall/tailwindcss/tailwindcss-intellisense/extension/dist/server/tailwindServer.js",
+    require("lsp.installer").get_langserver_path "terraform",
     "--stdio",
   },
   filetypes = O.lang.tailwindcss.filetypes,

--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -19,7 +19,7 @@ M.setup = function()
 
   require("lspconfig").efm.setup {
     -- init_options = {initializationOptions},
-    cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
+    cmd = { require("lsp.installer").get_langserver_path "efm" },
     init_options = { documentFormatting = true, codeAction = false },
     root_dir = require("lspconfig").util.root_pattern(".git/", "package.json"),
     filetypes = {

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -45,7 +45,7 @@ end
 -- end
 require("lspconfig").tsserver.setup {
   cmd = {
-    DATA_PATH .. "/lspinstall/typescript/node_modules/.bin/typescript-language-server",
+    require("lsp.installer").get_langserver_path "typescript",
     "--stdio",
   },
   filetypes = {

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -31,7 +31,7 @@ return require("packer").startup(function(use)
   use { "neovim/nvim-lspconfig" }
   use {
     "kabouzeid/nvim-lspinstall",
-    event = "VimEnter",
+    -- event = "VimEnter",
     config = function()
       require("lspinstall").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

**_Breaking change: "O.lang.clang" has been changed to "O.lang.cpp"_**

Added the ability to use manually installed language servers. This can be done using:
`O.lang.rust.custom_languageserver = "/my/custom/path/rust-analyzer"`

## How Has This Been Tested?

Tested with `.lua` and `.c` files.

