### PR TITLE
[Feature] Hide formatter.nvim tempfiles

### DIFF
--- a/lua/lang/lua.lua
+++ b/lua/lang/lua.lua
@@ -22,6 +22,7 @@ M.format = function()
         exe = O.lang.lua.formatter.exe,
         args = O.lang.lua.formatter.args,
         stdin = not (O.lang.lua.formatter.stdin ~= nil),
+        tempfile_prefix = ".formatter",
       }
     end,
   }

--- a/lua/lang/php.lua
+++ b/lua/lang/php.lua
@@ -31,7 +31,7 @@ M.format = function()
         exe = O.lang.php.formatter.exe,
         args = O.lang.php.formatter.args,
         stdin = not (O.lang.php.formatter.stdin ~= nil),
-        tempfile_prefix = '.formatter',
+        tempfile_prefix = ".formatter",
       }
     end,
   }

--- a/lua/lang/php.lua
+++ b/lua/lang/php.lua
@@ -31,6 +31,7 @@ M.format = function()
         exe = O.lang.php.formatter.exe,
         args = O.lang.php.formatter.args,
         stdin = not (O.lang.php.formatter.stdin ~= nil),
+        tempfile_prefix = '.formatter',
       }
     end,
   }

--- a/lua/lang/sh.lua
+++ b/lua/lang/sh.lua
@@ -25,6 +25,7 @@ M.format = function()
         exe = O.lang.sh.formatter.exe,
         args = O.lang.sh.formatter.args,
         stdin = not (O.lang.sh.formatter.stdin ~= nil),
+        tempfile_prefix = '.formatter',
       }
     end,
   }

--- a/lua/lang/sh.lua
+++ b/lua/lang/sh.lua
@@ -25,7 +25,7 @@ M.format = function()
         exe = O.lang.sh.formatter.exe,
         args = O.lang.sh.formatter.args,
         stdin = not (O.lang.sh.formatter.stdin ~= nil),
-        tempfile_prefix = '.formatter',
+        tempfile_prefix = ".formatter",
       }
     end,
   }

--- a/lua/lang/terraform.lua
+++ b/lua/lang/terraform.lua
@@ -17,6 +17,7 @@ M.format = function()
         exe = O.lang.terraform.formatter.exe,
         args = O.lang.terraform.formatter.args,
         stdin = not (O.lang.terraform.formatter.stdin ~= nil),
+        tempfile_prefix = '.formatter',
       }
     end,
   }

--- a/lua/lang/terraform.lua
+++ b/lua/lang/terraform.lua
@@ -17,7 +17,7 @@ M.format = function()
         exe = O.lang.terraform.formatter.exe,
         args = O.lang.terraform.formatter.args,
         stdin = not (O.lang.terraform.formatter.stdin ~= nil),
-        tempfile_prefix = '.formatter',
+        tempfile_prefix = ".formatter",
       }
     end,
   }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Prefix formatter.nvim's tempfile with ".formatter" so they should be hidden by default. This was added to any lang that mentions `stdin = false`.