### PR TITLE
disable ts utils formatter since we're using formatter.nvim

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -196,9 +196,7 @@ function lsp_config.tsserver_on_attach(client, bufnr)
     eslint_enable_diagnostics = true,
 
     -- formatting
-    enable_formatting = O.lang.tsserver.autoformat,
-    formatter = O.lang.tsserver.formatter.exe,
-    formatter_config_fallback = nil,
+    enable_formatting = false, -- handled by formatter.nvim
 
     -- parentheses completion
     complete_parens = false,
@@ -213,11 +211,11 @@ function lsp_config.tsserver_on_attach(client, bufnr)
   -- required to fix code action ranges
   ts_utils.setup_client(client)
 
-  -- TODO: keymap these?
-  -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gs", ":TSLspOrganize<CR>", {silent = true})
-  -- vim.api.nvim_buf_set_keymap(bufnr, "n", "qq", ":TSLspFixCurrent<CR>", {silent = true})
-  -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gr", ":TSLspRenameFile<CR>", {silent = true})
-  -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", {silent = true})
+  -- TODO: ts-utils gives us these commands. Should we use them somwhere?
+  -- :TSLspOrganize
+  -- :TSLspFixCurrent
+  -- :TSLspRenameFile
+  -- :TSLspImportAll
 end
 
 require("lv-utils").define_augroups {


### PR DESCRIPTION
https://github.com/ChristianChiarulli/LunarVim/pull/667 was my PR to make eslint / eslint_d codeActions and autofixes work on JS/TS files. But now, I see that we are using efm instead of null-ls, which will not work properly with the formatter and linter features of [ts-utils](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils). This can also cause some potential conflicts.

So I don't see the point of using ts-utils formatter feature since we are now using formatter.nvim.

Also, if we plan to stay with efm, we should probably disable the linter feature too. Because [the formatter and linter depends on null-ls](https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils#requirements) for this specific plugin.