### PR TITLE
[LANG] c/cpp: formatter - run clang-format from CWD of file.

### DIFF
--- a/lua/lang/clang.lua
+++ b/lua/lang/clang.lua
@@ -30,6 +30,7 @@ M.format = function()
         exe = O.lang.clang.formatter.exe,
         args = O.lang.clang.formatter.args,
         stdin = not (O.lang.clang.formatter.stdin ~= nil),
+        cwd = vim.fn.expand "%:h:p",
       }
     end,
   }


### PR DESCRIPTION
clang-format find the nearest .clang-format in the files' parent
directories.

This enables clang-format to choose the correct formatting options in e.g. monolithic projects containing different libraries with different styles.
