### PR TITLE
Overrideable configs for autopairs

### DIFF
--- a/ftplugin/css.lua
+++ b/ftplugin/css.lua
@@ -1,0 +1,4 @@
+require("lang.css").format()
+require("lang.css").lint()
+require("lang.css").lsp()
+require("lang.css").dap()

--- a/ftplugin/css.lua
+++ b/ftplugin/css.lua
@@ -1,4 +1,0 @@
-require("lang.css").format()
-require("lang.css").lint()
-require("lang.css").lsp()
-require("lang.css").dap()

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -5,63 +5,63 @@ local M = {}
 
 M.config = function()
   O.plugin.autopairs = {
-    config = false,
+    config = nil,
   }
 end
 
 M.setup = function()
   if O.plugin.autopairs.config then
-    O.plugin.autopairs.config()
-  else
-    local status_ok, autopairs = pcall(require, "nvim-autopairs")
-    if not status_ok then
-      return false
-    end
-    local npairs = require "nvim-autopairs"
-    local Rule = require "nvim-autopairs.rule"
+    return O.plugin.autopairs.config()
+  end
 
-    -- skip it, if you use another global object
-    _G.MUtils = {}
+  local status_ok, autopairs = pcall(require, "nvim-autopairs")
+  if not status_ok then
+    return false
+  end
+  local npairs = require "nvim-autopairs"
+  local Rule = require "nvim-autopairs.rule"
 
-    vim.g.completion_confirm_key = ""
-    MUtils.completion_confirm = function()
-      if vim.fn.pumvisible() ~= 0 then
-        if vim.fn.complete_info()["selected"] ~= -1 then
-          return vim.fn["compe#confirm"](npairs.esc "<cr>")
-        else
-          return npairs.esc "<cr>"
-        end
+  -- skip it, if you use another global object
+  _G.MUtils = {}
+
+  vim.g.completion_confirm_key = ""
+  MUtils.completion_confirm = function()
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
       else
-        return npairs.autopairs_cr()
+        return npairs.esc "<cr>"
       end
+    else
+      return npairs.autopairs_cr()
     end
+  end
 
-    if package.loaded["compe"] then
-      require("nvim-autopairs.completion.compe").setup {
-        map_cr = true, --  map <CR> on insert mode
-        map_complete = true, -- it will auto insert `(` after select function or method item
-      }
-    end
-
-    npairs.setup {
-      check_ts = true,
-      ts_config = {
-        lua = { "string" }, -- it will not add pair on that treesitter node
-        javascript = { "template_string" },
-        java = false, -- don't check treesitter on java
-      },
-    }
-
-    require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
-
-    local ts_conds = require "nvim-autopairs.ts-conds"
-
-    -- press % => %% is only inside comment or string
-    npairs.add_rules {
-      Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-      Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  if package.loaded["compe"] then
+    require("nvim-autopairs.completion.compe").setup {
+      map_cr = true, --  map <CR> on insert mode
+      map_complete = true, -- it will auto insert `(` after select function or method item
     }
   end
+
+  npairs.setup {
+    check_ts = true,
+    ts_config = {
+      lua = { "string" }, -- it will not add pair on that treesitter node
+      javascript = { "template_string" },
+      java = false, -- don't check treesitter on java
+    },
+  }
+
+  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+  local ts_conds = require "nvim-autopairs.ts-conds"
+
+  -- press % => %% is only inside comment or string
+  npairs.add_rules {
+    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  }
 end
 
 return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -10,7 +10,6 @@ M.config = function()
 end
 
 M.setup = function()
-  -- if not O.plugin.autopairs.config then
   if O.plugin.autopairs.config then
     return O.plugin.autopairs.config
   end

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -10,54 +10,58 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, autopairs = pcall(require, "nvim-autopairs")
-  if not status_ok then
-    return false
-  end
-  local npairs = require "nvim-autopairs"
-  local Rule = require "nvim-autopairs.rule"
-
-  -- skip it, if you use another global object
-  _G.MUtils = {}
-
-  vim.g.completion_confirm_key = ""
-  MUtils.completion_confirm = function()
-    if vim.fn.pumvisible() ~= 0 then
-      if vim.fn.complete_info()["selected"] ~= -1 then
-        return vim.fn["compe#confirm"](npairs.esc "<cr>")
-      else
-        return npairs.esc "<cr>"
-      end
-    else
-      return npairs.autopairs_cr()
+  if O.plugin.autopairs.config then
+    O.plugin.autopairs.config()
+  else
+    local status_ok, autopairs = pcall(require, "nvim-autopairs")
+    if not status_ok then
+      return false
     end
-  end
+    local npairs = require "nvim-autopairs"
+    local Rule = require "nvim-autopairs.rule"
 
-  if package.loaded["compe"] then
-    require("nvim-autopairs.completion.compe").setup {
-      map_cr = true, --  map <CR> on insert mode
-      map_complete = true, -- it will auto insert `(` after select function or method item
+    -- skip it, if you use another global object
+    _G.MUtils = {}
+
+    vim.g.completion_confirm_key = ""
+    MUtils.completion_confirm = function()
+      if vim.fn.pumvisible() ~= 0 then
+        if vim.fn.complete_info()["selected"] ~= -1 then
+          return vim.fn["compe#confirm"](npairs.esc "<cr>")
+        else
+          return npairs.esc "<cr>"
+        end
+      else
+        return npairs.autopairs_cr()
+      end
+    end
+
+    if package.loaded["compe"] then
+      require("nvim-autopairs.completion.compe").setup {
+        map_cr = true, --  map <CR> on insert mode
+        map_complete = true, -- it will auto insert `(` after select function or method item
+      }
+    end
+
+    npairs.setup {
+      check_ts = true,
+      ts_config = {
+        lua = { "string" }, -- it will not add pair on that treesitter node
+        javascript = { "template_string" },
+        java = false, -- don't check treesitter on java
+      },
+    }
+
+    require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+    local ts_conds = require "nvim-autopairs.ts-conds"
+
+    -- press % => %% is only inside comment or string
+    npairs.add_rules {
+      Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+      Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
     }
   end
-
-  npairs.setup {
-    check_ts = true,
-    ts_config = {
-      lua = { "string" }, -- it will not add pair on that treesitter node
-      javascript = { "template_string" },
-      java = false, -- don't check treesitter on java
-    },
-  }
-
-  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
-
-  local ts_conds = require "nvim-autopairs.ts-conds"
-
-  -- press % => %% is only inside comment or string
-  npairs.add_rules {
-    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
-  }
 end
 
 return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -1,51 +1,68 @@
 -- if not package.loaded['nvim-autopairs'] then
 --   return
 -- end
-local status_ok, autopairs = pcall(require, "nvim-autopairs")
-if not status_ok then
-  return
-end
-local npairs = require "nvim-autopairs"
-local Rule = require "nvim-autopairs.rule"
+local M = {}
 
--- skip it, if you use another global object
-_G.MUtils = {}
-
-vim.g.completion_confirm_key = ""
-MUtils.completion_confirm = function()
-  if vim.fn.pumvisible() ~= 0 then
-    if vim.fn.complete_info()["selected"] ~= -1 then
-      return vim.fn["compe#confirm"](npairs.esc "<cr>")
-    else
-      return npairs.esc "<cr>"
-    end
-  else
-    return npairs.autopairs_cr()
-  end
-end
-
-if package.loaded["compe"] then
-  require("nvim-autopairs.completion.compe").setup {
-    map_cr = true, --  map <CR> on insert mode
-    map_complete = true, -- it will auto insert `(` after select function or method item
+M.config = function()
+  O.plugin.autopairs = {
+    config = false,
   }
 end
 
-npairs.setup {
-  check_ts = true,
-  ts_config = {
-    lua = { "string" }, -- it will not add pair on that treesitter node
-    javascript = { "template_string" },
-    java = false, -- don't check treesitter on java
-  },
-}
+M.setup = function()
+  -- if not O.plugin.autopairs.config then
+  if O.plugin.autopairs.config then
+    return O.plugin.autopairs.config
+  end
 
-require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+  local status_ok, autopairs = pcall(require, "nvim-autopairs")
+  if not status_ok then
+    return
+  end
+  local npairs = require "nvim-autopairs"
+  local Rule = require "nvim-autopairs.rule"
 
-local ts_conds = require "nvim-autopairs.ts-conds"
+  -- skip it, if you use another global object
+  _G.MUtils = {}
 
--- press % => %% is only inside comment or string
-npairs.add_rules {
-  Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-  Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
-}
+  vim.g.completion_confirm_key = ""
+  MUtils.completion_confirm = function()
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
+      else
+        return npairs.esc "<cr>"
+      end
+    else
+      return npairs.autopairs_cr()
+    end
+  end
+
+  if package.loaded["compe"] then
+    require("nvim-autopairs.completion.compe").setup {
+      map_cr = true, --  map <CR> on insert mode
+      map_complete = true, -- it will auto insert `(` after select function or method item
+    }
+  end
+
+  npairs.setup {
+    check_ts = true,
+    ts_config = {
+      lua = { "string" }, -- it will not add pair on that treesitter node
+      javascript = { "template_string" },
+      java = false, -- don't check treesitter on java
+    },
+  }
+
+  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+  local ts_conds = require "nvim-autopairs.ts-conds"
+
+  -- press % => %% is only inside comment or string
+  npairs.add_rules {
+    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  }
+end
+
+return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -10,13 +10,9 @@ M.config = function()
 end
 
 M.setup = function()
-  if O.plugin.autopairs.config then
-    return O.plugin.autopairs.config
-  end
-
   local status_ok, autopairs = pcall(require, "nvim-autopairs")
   if not status_ok then
-    return
+    return false
   end
   local npairs = require "nvim-autopairs"
   local Rule = require "nvim-autopairs.rule"

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -11,7 +11,7 @@ end
 
 M.setup = function()
   if O.plugin.autopairs.config then
-    return O.plugin.autopairs.config()
+    return O.plugin.autopairs.config
   end
 
   local status_ok, autopairs = pcall(require, "nvim-autopairs")

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -11,7 +11,7 @@ end
 
 M.setup = function()
   if O.plugin.autopairs.config then
-    return O.plugin.autopairs.config
+    return O.plugin.autopairs.config()
   end
 
   local status_ok, autopairs = pcall(require, "nvim-autopairs")

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -127,6 +127,7 @@ require("core.zen").config()
 require("core.telescope").config()
 require("core.treesitter").config()
 require("core.which-key").config()
+require("core.autopairs").config()
 
 require("lang.clang").config()
 require("lang.cmake").config()

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,9 +59,7 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    config = function()
-      require("core.autopairs").setup()
-    end,
+    config = require("core.autopairs").setup(),
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -60,11 +60,7 @@ return require("packer").startup(function(use)
   use {
     "windwp/nvim-autopairs",
     config = function()
-      if O.plugin.autopairs.config then
-        O.plugin.autopairs.config()
-      else
-        require("core.autopairs").setup()
-      end
+      require("core.autopairs").setup()
     end,
   }
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,7 +59,9 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    config = require("core.autopairs").setup(),
+    config = function()
+      require("core.autopairs").setup()
+    end,
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,7 +59,13 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    config = require("core.autopairs").setup(),
+    config = function()
+      if O.plugin.autopairs.config then
+        O.plugin.autopairs.config()
+      else
+        require("core.autopairs").setup()
+      end
+    end,
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,10 +59,7 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    -- event = "InsertEnter",
-    config = function()
-      require "core.autopairs"
-    end,
+    config = require("core.autopairs").setup(),
   }
 
   -- Snippets


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Allows full configuration of autopairs by the end-user.  A user can inject their own configuration by adding a declaration in lv-config.lua

```
O.plugin.autopairs.config = function()
      YOUR_CUSTOM_CONFIG_HERE
end
```

Please include a summary of the change and which issue is fixed. \
List any dependencies that are required for this change.

Fixes #(issue)
https://github.com/ChristianChiarulli/LunarVim/issues/960

## How Has This Been Tested?
1. Launching with the default config to make sure autopairs still works
2. Launching with the added config to lv-config to make sure a user can add their configuration


