### PR TITLE
[Bugfix] Use error instead of print + prevent shadowing

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,9 +1,8 @@
 require "default-config"
 require "keymappings"
-local status_ok, error = pcall(vim.cmd, "luafile " .. CONFIG_PATH .. "/lv-config.lua")
-if not status_ok then
-  print "something is wrong with your lv-config"
-  print(error)
+local ok, err = pcall(vim.cmd, "luafile " .. CONFIG_PATH .. "/lv-config.lua")
+if not ok then
+  error("Configuration error: " .. err)
 end
 require "plugins"
 vim.g.colors_name = O.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.

--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@ require "default-config"
 require "keymappings"
 local ok, err = pcall(vim.cmd, "luafile " .. CONFIG_PATH .. "/lv-config.lua")
 if not ok then
-  error("Configuration error: " .. err)
+  vim.notify("Configuration error: " .. err, vim.log.levels.ERROR)
 end
 require "plugins"
 vim.g.colors_name = O.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

What's in the title + the error now sticks better instead of disappearing like a print would.

## How Has This Been Tested?

lv-config: O.toto.tata = true, opening / closing
