### PR TITLE
[Feature] Add an installer for Stylua

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -16,13 +16,10 @@ jobs:
 
       - name: Prepare dependencies
         run: |
-          sudo apt update
-          sudo apt install -y curl
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          cargo install stylua
-      
+          sudo apt install -y curl unzip --no-install-recommends
+          bash ./utils/installer/install_stylua.sh
+
       - name: Check formatting
         run: |
-          cp ./utils/.stylua.toml .
-          stylua -c .
+          ./utils/stylua --config-path ./utils/.stylua.toml -c .
 

--- a/utils/installer/install_stylua.sh
+++ b/utils/installer/install_stylua.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -eu pipefall
+
+declare -r INSTALL_DIR="$PWD/utils"
+declare -r RELEASE="0.10.0"
+declare -r OS="linux"
+# declare -r OS="$(uname -s)"
+declare -r FILENAME="stylua-$RELEASE-$OS"
+
+declare -a __deps=("curl" "unzip")
+
+function check_deps() {
+	for dep in "${__deps[@]}"; do
+		if ! command -v "$dep" >/dev/null; then
+			echo "Missing depdendecy!"
+			echo "The \"$dep\" command was not found!. Please install and try again."
+		fi
+	done
+}
+
+function download_stylua() {
+	local DOWNLOAD_DIR
+	local URL="https://github.com/JohnnyMorganz/StyLua/releases/download/v$RELEASE/$FILENAME.zip"
+
+	DOWNLOAD_DIR="$(mktemp -d)"
+	echo "Initiating download for Stylua v$RELEASE"
+	if ! curl --progress-bar --fail -L "$URL" -o "$DOWNLOAD_DIR/$FILENAME.zip"; then
+		echo "Download failed.  Check that the release/filename are correct."
+		exit 1
+	fi
+
+	echo "Installtion in progress.."
+	unzip -q "$DOWNLOAD_DIR/$FILENAME.zip" -d "$DOWNLOAD_DIR"
+
+	if [ -f "$DOWNLOAD_DIR/stylua" ]; then
+		mv "$DOWNLOAD_DIR/stylua" "$INSTALL_DIR/stylua"
+	else
+		mv "$DOWNLOAD_DIR/$FILENAME/stylua" "$INSTALL_DIR/."
+	fi
+
+	chmod u+x "$INSTALL_DIR/stylua"
+}
+
+function verify_install() {
+	echo "Verifying installtion.."
+	local DOWNLOADED_VER
+	DOWNLOADED_VER="$("$INSTALL_DIR/stylua" -V | awk '{ print $2 }')"
+	if [ "$DOWNLOADED_VER" != "$RELEASE" ]; then
+		echo "Mismatched version!"
+		echo "Expected: v$RELEASE but got v$DOWNLOADED_VER"
+		exit 1
+	fi
+	echo "Verification complete!"
+}
+
+function main() {
+	check_deps
+	download_stylua
+	verify_install
+}
+
+main "$@"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add an installer for Stylua mainly to be used for the CI as to avoid downloading an entire rust toolchain.

## How Has This Been Tested?

Only tested locally

```bash
bash ./utils/install/install_stylua.sh
```

