### PR TITLE
[Refactor] Make default keybindings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,27 @@ O.completion.autocomplete = true
 O.default_options.relativenumber = true
 O.colorscheme = 'spacegray'
 O.default_options.timeoutlen = 100
-O.leader_key = ' '
+
+-- keymappings 
+O.keys.leader_key = "space"
+-- overwrite the key-mappings provided by LunarVim for any mode, or leave it empty to keep them
+O.keys.normal_mode = {
+    -- Page down/up
+  {'[d', '<PageUp>'},
+  {']d', '<PageDown>'},
+
+  -- Navigate buffers
+  {'<Tab>', ':bnext<CR>'},
+  {'<S-Tab>', ':bprevious<CR>'},
+}
+-- if you just want to augment the existing ones then use the utility function
+require("lv-utils").add_keymap_insert_mode({ silent = true }, {
+  { "<C-s>", ":w<cr>" },
+  { "<C-c>", "<ESC>" }
+})
+
+-- you can also use the native vim way directly
+vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
 
 -- After changing plugin config it is recommended to run :PackerCompile
 O.plugin.dashboard.active = true

--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,10 @@
 require "default-config"
-require "keymappings"
 local status_ok, error = pcall(vim.cmd, "luafile " .. CONFIG_PATH .. "/lv-config.lua")
 if not status_ok then
   print "something is wrong with your lv-config"
   print(error)
 end
+require "keymappings"
 require "plugins"
 vim.g.colors_name = O.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
 require "settings"

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -5,7 +5,9 @@ TERMINAL = vim.fn.expand "$TERMINAL"
 USER = vim.fn.expand "$USER"
 
 O = {
-  leader_key = "space",
+  keys = {
+    leader_key = "space",
+  },
   colorscheme = "spacegray",
   line_wrap_cursor_movement = true,
   transparent_window = false,

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,42 +1,41 @@
-local function register_mappings(mappings, default_options)
-  for mode, mode_mappings in pairs(mappings) do
-    for _, mapping in pairs(mode_mappings) do
-      local options = #mapping == 3 and table.remove(mapping) or default_options
-      local prefix, cmd = unpack(mapping)
-      pcall(vim.api.nvim_set_keymap, mode, prefix, cmd, options)
-    end
-  end
-end
+local lv_utils = require "lv-utils"
 
-local mappings = {
-  i = { -- Insert mode
+local opts = {
+  nnoremap = { noremap = true, silent = true },
+  inoremap = { noremap = true, silent = true },
+  vnoremap = { noremap = true, silent = true },
+  xnoremap = { noremap = true, silent = true },
+  generic = { silent = true },
+}
+
+local default_keys = {
+  insert_mode = {
     -- I hate escape
     { "jk", "<ESC>" },
     { "kj", "<ESC>" },
     { "jj", "<ESC>" },
-
     -- Move current line / block with Alt-j/k ala vscode.
     { "<A-j>", "<Esc>:m .+1<CR>==gi" },
     { "<A-k>", "<Esc>:m .-2<CR>==gi" },
-
-    -- Terminal window navigation
-    { "<C-h>", "<C-\\><C-N><C-w>h" },
-    { "<C-j>", "<C-\\><C-N><C-w>j" },
-    { "<C-k>", "<C-\\><C-N><C-w>k" },
-    { "<C-l>", "<C-\\><C-N><C-w>l" },
+    -- navigation
+    { "<A-Up>", "<C-\\><C-N><C-w>h" },
+    { "<A-Down>", "<C-\\><C-N><C-w>j" },
+    { "<A-Left>", "<C-\\><C-N><C-w>k" },
+    { "<A-Right>", "<C-\\><C-N><C-w>l" },
   },
-  n = { -- Normal mode
+
+  normal_mode = {
     -- Better window movement
-    { "<C-h>", "<C-w>h", { silent = true } },
-    { "<C-j>", "<C-w>j", { silent = true } },
-    { "<C-k>", "<C-w>k", { silent = true } },
-    { "<C-l>", "<C-w>l", { silent = true } },
+    { "<C-h>", "<C-w>h" },
+    { "<C-j>", "<C-w>j" },
+    { "<C-k>", "<C-w>k" },
+    { "<C-l>", "<C-w>l" },
 
     -- Resize with arrows
-    { "<C-Up>", ":resize -2<CR>", { silent = true } },
-    { "<C-Down>", ":resize +2<CR>", { silent = true } },
-    { "<C-Left>", ":vertical resize -2<CR>", { silent = true } },
-    { "<C-Right>", ":vertical resize +2<CR>", { silent = true } },
+    { "<C-Up>", ":resize -2<CR>" },
+    { "<C-Down>", ":resize +2<CR>" },
+    { "<C-Left>", ":vertical resize -2<CR>" },
+    { "<C-Right>", ":vertical resize +2<CR>" },
 
     -- Tab switch buffer
     -- { "<TAB>", ":bnext<CR>" },
@@ -49,17 +48,20 @@ local mappings = {
     -- QuickFix
     { "]q", ":cnext<CR>" },
     { "[q", ":cprev<CR>" },
+    { "<C-q>", ":call QuickFixToggle()<CR>" },
 
     -- {'<C-TAB>', 'compe#complete()', {noremap = true, silent = true, expr = true}},
   },
-  t = { -- Terminal mode
+
+  term_mode = {
     -- Terminal window navigation
     { "<C-h>", "<C-\\><C-N><C-w>h" },
     { "<C-j>", "<C-\\><C-N><C-w>j" },
     { "<C-k>", "<C-\\><C-N><C-w>k" },
     { "<C-l>", "<C-\\><C-N><C-w>l" },
   },
-  v = { -- Visual/Select mode
+
+  visual_mode = {
     -- Better indenting
     { "<", "<gv" },
     { ">", ">gv" },
@@ -67,7 +69,8 @@ local mappings = {
     -- { "p", '"0p', { silent = true } },
     -- { "P", '"0P', { silent = true } },
   },
-  x = { -- Visual mode
+
+  visual_block_mode = {
     -- Move selected line / block of text in visual mode
     { "K", ":move '<-2<CR>gv-gv" },
     { "J", ":move '>+1<CR>gv-gv" },
@@ -76,31 +79,37 @@ local mappings = {
     { "<A-j>", ":m '>+1<CR>gv-gv" },
     { "<A-k>", ":m '<-2<CR>gv-gv" },
   },
-  [""] = {
-    -- Toggle the QuickFix window
-    { "<C-q>", ":call QuickFixToggle()<CR>" },
-  },
 }
 
--- TODO: fix this
 if vim.fn.has "mac" == 1 then
-  mappings["n"][5][1] = "<A-Up>"
-  mappings["n"][6][1] = "<A-Down>"
-  mappings["n"][7][1] = "<A-Left>"
-  mappings["n"][8][1] = "<A-Right>"
+  -- TODO: fix this
+  default_keys.insert_mode["n"][5][1] = "<A-Up>"
+  default_keys.insert_mode["n"][6][1] = "<A-Down>"
+  default_keys.insert_mode["n"][7][1] = "<A-Left>"
+  default_keys.insert_mode["n"][8][1] = "<A-Right>"
 end
 
-register_mappings(mappings, { silent = true, noremap = true })
+if O.keys.leader_key == " " or O.keys.leader_key == "space" then
+  vim.g.mapleader = " "
+else
+  vim.g.mapleader = O.keys.leader_key
+end
 
-vim.cmd 'inoremap <expr> <c-j> ("\\<C-n>")'
-vim.cmd 'inoremap <expr> <c-k> ("\\<C-p>")'
+local function get_user_keys(mode)
+  if O.keys[mode] == nil then
+    return default_keys[mode]
+  else
+    return O.keys[mode]
+  end
+end
 
--- vim.cmd('inoremap <expr> <TAB> (\"\\<C-n>\")')
--- vim.cmd('inoremap <expr> <S-TAB> (\"\\<C-p>\")')
+lv_utils.add_keymap_normal_mode(opts.nnoremap, get_user_keys "normal_mode")
+lv_utils.add_keymap_insert_mode(opts.inoremap, get_user_keys "insert_mode")
+lv_utils.add_keymap_visual_mode(opts.vnoremap, get_user_keys "visual_mode")
+lv_utils.add_keymap_visual_block_mode(opts.xnoremap, get_user_keys "visual_block_mode")
+lv_utils.add_keymap_term_mode(opts.generic, get_user_keys "visual_block_mode")
 
--- vim.cmd([[
--- map p <Plug>(miniyank-autoput)
--- map P <Plug>(miniyank-autoPut)
--- map <leader>n <Plug>(miniyank-cycle)
--- map <leader>N <Plug>(miniyank-cycleback)
--- ]])
+-- navigate tab completion with <c-j> and <c-k>
+-- runs conditionally
+vim.cmd 'inoremap <expr> <C-j> pumvisible() ? "\\<C-n>" : "\\<C-j>"'
+vim.cmd 'inoremap <expr> <C-k> pumvisible() ? "\\<C-p>" : "\\<C-k>"'

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -20,6 +20,32 @@ function lv_utils.check_lsp_client_active(name)
   return false
 end
 
+function lv_utils.add_keymap(mode, opts, keymaps)
+  for _, keymap in ipairs(keymaps) do
+    vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)
+  end
+end
+
+function lv_utils.add_keymap_normal_mode(opts, keymaps)
+  lv_utils.add_keymap("n", opts, keymaps)
+end
+
+function lv_utils.add_keymap_visual_mode(opts, keymaps)
+  lv_utils.add_keymap("v", opts, keymaps)
+end
+
+function lv_utils.add_keymap_visual_block_mode(opts, keymaps)
+  lv_utils.add_keymap("x", opts, keymaps)
+end
+
+function lv_utils.add_keymap_insert_mode(opts, keymaps)
+  lv_utils.add_keymap("i", opts, keymaps)
+end
+
+function lv_utils.add_keymap_term_mode(opts, keymaps)
+  lv_utils.add_keymap("t", opts, keymaps)
+end
+
 function lv_utils.define_augroups(definitions) -- {{{1
   -- Create autocommand groups based on the passed definitions
   --

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -45,12 +45,6 @@ local disabled_built_ins = {
   -- 'matchit', 'matchparen', 'shada_plugin',
 }
 
-if O.leader_key == " " or O.leader_key == "space" then
-  vim.g.mapleader = " "
-else
-  vim.g.mapleader = O.leader_key
-end
-
 for _, plugin in pairs(disabled_built_ins) do
   vim.g["loaded_" .. plugin] = 1
 end

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -16,7 +16,25 @@ O.colorscheme = "spacegray"
 O.auto_close_tree = 0
 O.default_options.wrap = true
 O.default_options.timeoutlen = 100
-O.leader_key = " "
+-- keymappings
+O.keys.leader_key = "space"
+-- overwrite the key-mappings provided by LunarVim for any mode, or leave it empty to keep them
+-- O.keys.normal_mode = {
+--   Page down/up
+--   {'[d', '<PageUp>'},
+--   {']d', '<PageDown>'},
+--
+--   Navigate buffers
+--   {'<Tab>', ':bnext<CR>'},
+--   {'<S-Tab>', ':bprevious<CR>'},
+-- }
+-- if you just want to augment the existing ones then use the utility function
+-- require("lv-utils").add_keymap_insert_mode({ silent = true }, {
+-- { "<C-s>", ":w<cr>" },
+-- { "<C-c>", "<ESC>" },
+-- })
+-- you can also use the native vim way directly
+-- vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
 
 -- TODO: User Config for predefined plugins
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -16,7 +16,25 @@ O.colorscheme = "spacegray"
 O.auto_close_tree = 0
 O.default_options.wrap = true
 O.default_options.timeoutlen = 100
-O.leader_key = " "
+-- keymappings
+O.keys.leader_key = "space"
+-- overwrite the key-mappings provided by LunarVim for any mode, or leave it empty to keep them
+-- O.keys.normal_mode = {
+--   Page down/up
+--   {'[d', '<PageUp>'},
+--   {']d', '<PageDown>'},
+--
+--   Navigate buffers
+--   {'<Tab>', ':bnext<CR>'},
+--   {'<S-Tab>', ':bprevious<CR>'},
+-- }
+-- if you just want to augment the existing ones then use the utility function
+-- require("lv-utils").add_keymap_insert_mode({ silent = true }, {
+-- { "<C-s>", ":w<cr>" },
+-- { "<C-c>", "<ESC>" },
+-- })
+-- you can also use the native vim way directly
+-- vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
 
 -- TODO: User Config for predefined plugins
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile


### PR DESCRIPTION


<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Add the ability to override all the default keymappings that aren't prefixed with `<leader>`
`O.keys.normal_mode = { {'[d', '<PageUp>'}, {']d', '<PageDown>'}, }`
- Add the ability to augment the existing keymappings
`require("lv-utils").add_keymap_insert_mode({ silent = true }, { { "<C-s>", ":w<cr>" } })`

Fixes #(issue)

#960

## How Has This Been Tested?

All the keybindings are still working, and overrides from `lv-config` seem to be working as expected.

