### PR TITLE
Overrideable configs for core plugins

### DIFF
--- a/ftplugin/css.lua
+++ b/ftplugin/css.lua
@@ -1,0 +1,4 @@
+require("lang.css").format()
+require("lang.css").lint()
+require("lang.css").lsp()
+require("lang.css").dap()

--- a/ftplugin/css.lua
+++ b/ftplugin/css.lua
@@ -1,4 +1,0 @@
-require("lang.css").format()
-require("lang.css").lint()
-require("lang.css").lsp()
-require("lang.css").dap()

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -5,63 +5,63 @@ local M = {}
 
 M.config = function()
   O.plugin.autopairs = {
-    config = false,
+    config = nil,
   }
 end
 
 M.setup = function()
   if O.plugin.autopairs.config then
-    O.plugin.autopairs.config()
-  else
-    local status_ok, autopairs = pcall(require, "nvim-autopairs")
-    if not status_ok then
-      return false
-    end
-    local npairs = require "nvim-autopairs"
-    local Rule = require "nvim-autopairs.rule"
+    return O.plugin.autopairs.config()
+  end
 
-    -- skip it, if you use another global object
-    _G.MUtils = {}
+  local status_ok, autopairs = pcall(require, "nvim-autopairs")
+  if not status_ok then
+    return false
+  end
+  local npairs = require "nvim-autopairs"
+  local Rule = require "nvim-autopairs.rule"
 
-    vim.g.completion_confirm_key = ""
-    MUtils.completion_confirm = function()
-      if vim.fn.pumvisible() ~= 0 then
-        if vim.fn.complete_info()["selected"] ~= -1 then
-          return vim.fn["compe#confirm"](npairs.esc "<cr>")
-        else
-          return npairs.esc "<cr>"
-        end
+  -- skip it, if you use another global object
+  _G.MUtils = {}
+
+  vim.g.completion_confirm_key = ""
+  MUtils.completion_confirm = function()
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
       else
-        return npairs.autopairs_cr()
+        return npairs.esc "<cr>"
       end
+    else
+      return npairs.autopairs_cr()
     end
+  end
 
-    if package.loaded["compe"] then
-      require("nvim-autopairs.completion.compe").setup {
-        map_cr = true, --  map <CR> on insert mode
-        map_complete = true, -- it will auto insert `(` after select function or method item
-      }
-    end
-
-    npairs.setup {
-      check_ts = true,
-      ts_config = {
-        lua = { "string" }, -- it will not add pair on that treesitter node
-        javascript = { "template_string" },
-        java = false, -- don't check treesitter on java
-      },
-    }
-
-    require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
-
-    local ts_conds = require "nvim-autopairs.ts-conds"
-
-    -- press % => %% is only inside comment or string
-    npairs.add_rules {
-      Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-      Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  if package.loaded["compe"] then
+    require("nvim-autopairs.completion.compe").setup {
+      map_cr = true, --  map <CR> on insert mode
+      map_complete = true, -- it will auto insert `(` after select function or method item
     }
   end
+
+  npairs.setup {
+    check_ts = true,
+    ts_config = {
+      lua = { "string" }, -- it will not add pair on that treesitter node
+      javascript = { "template_string" },
+      java = false, -- don't check treesitter on java
+    },
+  }
+
+  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+  local ts_conds = require "nvim-autopairs.ts-conds"
+
+  -- press % => %% is only inside comment or string
+  npairs.add_rules {
+    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  }
 end
 
 return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -10,7 +10,6 @@ M.config = function()
 end
 
 M.setup = function()
-  -- if not O.plugin.autopairs.config then
   if O.plugin.autopairs.config then
     return O.plugin.autopairs.config
   end

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -10,54 +10,58 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, autopairs = pcall(require, "nvim-autopairs")
-  if not status_ok then
-    return false
-  end
-  local npairs = require "nvim-autopairs"
-  local Rule = require "nvim-autopairs.rule"
-
-  -- skip it, if you use another global object
-  _G.MUtils = {}
-
-  vim.g.completion_confirm_key = ""
-  MUtils.completion_confirm = function()
-    if vim.fn.pumvisible() ~= 0 then
-      if vim.fn.complete_info()["selected"] ~= -1 then
-        return vim.fn["compe#confirm"](npairs.esc "<cr>")
-      else
-        return npairs.esc "<cr>"
-      end
-    else
-      return npairs.autopairs_cr()
+  if O.plugin.autopairs.config then
+    O.plugin.autopairs.config()
+  else
+    local status_ok, autopairs = pcall(require, "nvim-autopairs")
+    if not status_ok then
+      return false
     end
-  end
+    local npairs = require "nvim-autopairs"
+    local Rule = require "nvim-autopairs.rule"
 
-  if package.loaded["compe"] then
-    require("nvim-autopairs.completion.compe").setup {
-      map_cr = true, --  map <CR> on insert mode
-      map_complete = true, -- it will auto insert `(` after select function or method item
+    -- skip it, if you use another global object
+    _G.MUtils = {}
+
+    vim.g.completion_confirm_key = ""
+    MUtils.completion_confirm = function()
+      if vim.fn.pumvisible() ~= 0 then
+        if vim.fn.complete_info()["selected"] ~= -1 then
+          return vim.fn["compe#confirm"](npairs.esc "<cr>")
+        else
+          return npairs.esc "<cr>"
+        end
+      else
+        return npairs.autopairs_cr()
+      end
+    end
+
+    if package.loaded["compe"] then
+      require("nvim-autopairs.completion.compe").setup {
+        map_cr = true, --  map <CR> on insert mode
+        map_complete = true, -- it will auto insert `(` after select function or method item
+      }
+    end
+
+    npairs.setup {
+      check_ts = true,
+      ts_config = {
+        lua = { "string" }, -- it will not add pair on that treesitter node
+        javascript = { "template_string" },
+        java = false, -- don't check treesitter on java
+      },
+    }
+
+    require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+    local ts_conds = require "nvim-autopairs.ts-conds"
+
+    -- press % => %% is only inside comment or string
+    npairs.add_rules {
+      Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+      Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
     }
   end
-
-  npairs.setup {
-    check_ts = true,
-    ts_config = {
-      lua = { "string" }, -- it will not add pair on that treesitter node
-      javascript = { "template_string" },
-      java = false, -- don't check treesitter on java
-    },
-  }
-
-  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
-
-  local ts_conds = require "nvim-autopairs.ts-conds"
-
-  -- press % => %% is only inside comment or string
-  npairs.add_rules {
-    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
-  }
 end
 
 return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -1,51 +1,68 @@
 -- if not package.loaded['nvim-autopairs'] then
 --   return
 -- end
-local status_ok, autopairs = pcall(require, "nvim-autopairs")
-if not status_ok then
-  return
-end
-local npairs = require "nvim-autopairs"
-local Rule = require "nvim-autopairs.rule"
+local M = {}
 
--- skip it, if you use another global object
-_G.MUtils = {}
-
-vim.g.completion_confirm_key = ""
-MUtils.completion_confirm = function()
-  if vim.fn.pumvisible() ~= 0 then
-    if vim.fn.complete_info()["selected"] ~= -1 then
-      return vim.fn["compe#confirm"](npairs.esc "<cr>")
-    else
-      return npairs.esc "<cr>"
-    end
-  else
-    return npairs.autopairs_cr()
-  end
-end
-
-if package.loaded["compe"] then
-  require("nvim-autopairs.completion.compe").setup {
-    map_cr = true, --  map <CR> on insert mode
-    map_complete = true, -- it will auto insert `(` after select function or method item
+M.config = function()
+  O.plugin.autopairs = {
+    config = false,
   }
 end
 
-npairs.setup {
-  check_ts = true,
-  ts_config = {
-    lua = { "string" }, -- it will not add pair on that treesitter node
-    javascript = { "template_string" },
-    java = false, -- don't check treesitter on java
-  },
-}
+M.setup = function()
+  -- if not O.plugin.autopairs.config then
+  if O.plugin.autopairs.config then
+    return O.plugin.autopairs.config
+  end
 
-require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+  local status_ok, autopairs = pcall(require, "nvim-autopairs")
+  if not status_ok then
+    return
+  end
+  local npairs = require "nvim-autopairs"
+  local Rule = require "nvim-autopairs.rule"
 
-local ts_conds = require "nvim-autopairs.ts-conds"
+  -- skip it, if you use another global object
+  _G.MUtils = {}
 
--- press % => %% is only inside comment or string
-npairs.add_rules {
-  Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-  Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
-}
+  vim.g.completion_confirm_key = ""
+  MUtils.completion_confirm = function()
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
+      else
+        return npairs.esc "<cr>"
+      end
+    else
+      return npairs.autopairs_cr()
+    end
+  end
+
+  if package.loaded["compe"] then
+    require("nvim-autopairs.completion.compe").setup {
+      map_cr = true, --  map <CR> on insert mode
+      map_complete = true, -- it will auto insert `(` after select function or method item
+    }
+  end
+
+  npairs.setup {
+    check_ts = true,
+    ts_config = {
+      lua = { "string" }, -- it will not add pair on that treesitter node
+      javascript = { "template_string" },
+      java = false, -- don't check treesitter on java
+    },
+  }
+
+  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+  local ts_conds = require "nvim-autopairs.ts-conds"
+
+  -- press % => %% is only inside comment or string
+  npairs.add_rules {
+    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  }
+end
+
+return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -10,13 +10,9 @@ M.config = function()
 end
 
 M.setup = function()
-  if O.plugin.autopairs.config then
-    return O.plugin.autopairs.config
-  end
-
   local status_ok, autopairs = pcall(require, "nvim-autopairs")
   if not status_ok then
-    return
+    return false
   end
   local npairs = require "nvim-autopairs"
   local Rule = require "nvim-autopairs.rule"

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -11,7 +11,7 @@ end
 
 M.setup = function()
   if O.plugin.autopairs.config then
-    return O.plugin.autopairs.config()
+    return O.plugin.autopairs.config
   end
 
   local status_ok, autopairs = pcall(require, "nvim-autopairs")

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -11,7 +11,7 @@ end
 
 M.setup = function()
   if O.plugin.autopairs.config then
-    return O.plugin.autopairs.config
+    return O.plugin.autopairs.config()
   end
 
   local status_ok, autopairs = pcall(require, "nvim-autopairs")

--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -1,28 +1,44 @@
-vim.api.nvim_set_keymap("n", "<S-x>", ":BufferClose<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<leader>c", ":BufferClose<CR>", { noremap = true, silent = true })
+local M = {}
 
-O.plugin.which_key.mappings["b"] = {
-  name = "Buffers",
-  j = { "<cmd>BufferPick<cr>", "jump to buffer" },
-  f = { "<cmd>Telescope buffers<cr>", "Find buffer" },
-  w = { "<cmd>BufferWipeout<cr>", "wipeout buffer" },
-  e = {
-    "<cmd>BufferCloseAllButCurrent<cr>",
-    "close all but current buffer",
-  },
-  h = { "<cmd>BufferCloseBuffersLeft<cr>", "close all buffers to the left" },
-  l = {
-    "<cmd>BufferCloseBuffersRight<cr>",
-    "close all BufferLines to the right",
-  },
-  D = {
-    "<cmd>BufferOrderByDirectory<cr>",
-    "sort BufferLines automatically by directory",
-  },
-  L = {
-    "<cmd>BufferOrderByLanguage<cr>",
-    "sort BufferLines automatically by language",
-  },
-}
+M.config = function()
+  O.plugin.bufferline = {
+    config = nil,
+  }
+end
+
+M.setup = function()
+  if O.plugin.bufferline.config then
+    return O.plugin.bufferline.config()
+  end
+
+  vim.api.nvim_set_keymap("n", "<S-x>", ":BufferClose<CR>", { noremap = true, silent = true })
+  vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
+  vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
+  vim.api.nvim_set_keymap("n", "<leader>c", ":BufferClose<CR>", { noremap = true, silent = true })
+
+  O.plugin.which_key.mappings["b"] = {
+    name = "Buffers",
+    j = { "<cmd>BufferPick<cr>", "jump to buffer" },
+    f = { "<cmd>Telescope buffers<cr>", "Find buffer" },
+    w = { "<cmd>BufferWipeout<cr>", "wipeout buffer" },
+    e = {
+      "<cmd>BufferCloseAllButCurrent<cr>",
+      "close all but current buffer",
+    },
+    h = { "<cmd>BufferCloseBuffersLeft<cr>", "close all buffers to the left" },
+    l = {
+      "<cmd>BufferCloseBuffersRight<cr>",
+      "close all BufferLines to the right",
+    },
+    D = {
+      "<cmd>BufferOrderByDirectory<cr>",
+      "sort BufferLines automatically by directory",
+    },
+    L = {
+      "<cmd>BufferOrderByLanguage<cr>",
+      "sort BufferLines automatically by language",
+    },
+  }
+end
+
+return M

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -13,6 +13,7 @@ M.config = function()
     max_kind_width = 100,
     max_menu_width = 100,
     documentation = true,
+    config = nil,
 
     source = {
       path = { kind = "   (Path)" },
@@ -34,6 +35,9 @@ M.config = function()
 end
 
 M.setup = function()
+  if O.completion.config then
+    return O.completion.config()
+  end
   vim.g.vsnip_snippet_dir = O.vsnip_dir
 
   local status_ok, compe = pcall(require, "compe")

--- a/lua/core/dap.lua
+++ b/lua/core/dap.lua
@@ -2,6 +2,7 @@ local M = {}
 M.config = function()
   O.plugin.dap = {
     active = false,
+    config = nil,
     breakpoint = {
       text = "",
       texthl = "LspDiagnosticsSignError",
@@ -12,6 +13,10 @@ M.config = function()
 end
 
 M.setup = function()
+  if O.plugin.dap.config then
+    return O.plugin.dap.config()
+  end
+
   local status_ok, dap = pcall(require, "dap")
   if not status_ok then
     return

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -2,6 +2,7 @@ local M = {}
 M.config = function()
   O.plugin.dashboard = {
     active = false,
+    config = nil,
     search_handler = "telescope",
     custom_header = {
       "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⣀⣀⣀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
@@ -52,6 +53,10 @@ M.config = function()
 end
 
 M.setup = function()
+  if O.plugin.dashboard.config then
+    return O.plugin.dashboard.config()
+  end
+
   vim.g.dashboard_disable_at_vimenter = 0
 
   vim.g.dashboard_custom_header = O.plugin.dashboard.custom_header

--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -1,326 +1,333 @@
--- if not package.loaded['galaxyline'] then
---   return
--- end
-local status_ok, gl = pcall(require, "galaxyline")
-if not status_ok then
-  return
-end
+local M = {}
 
--- NOTE: if someone defines colors but doesn't have them then this will break
-local palette_status_ok, colors = pcall(require, O.colorscheme .. ".palette")
-if not palette_status_ok then
-  colors = O.plugin.galaxyline.colors
-end
+M.setup = function()
+  if O.plugin.galaxyline.config then
+    return O.plugin.galaxyline.config()
+  end
 
-local condition = require "galaxyline.condition"
-local gls = gl.section
-gl.short_line_list = { "NvimTree", "vista", "dbui", "packer" }
+  local status_ok, gl = pcall(require, "galaxyline")
+  if not status_ok then
+    return
+  end
 
-table.insert(gls.left, {
-  ViMode = {
-    provider = function()
-      -- auto change color according the vim mode
-      local mode_color = {
-        n = colors.blue,
-        i = colors.green,
-        v = colors.purple,
-        [""] = colors.purple,
-        V = colors.purple,
-        c = colors.magenta,
-        no = colors.blue,
-        s = colors.orange,
-        S = colors.orange,
-        [""] = colors.orange,
-        ic = colors.yellow,
-        R = colors.red,
-        Rv = colors.red,
-        cv = colors.blue,
-        ce = colors.blue,
-        r = colors.cyan,
-        rm = colors.cyan,
-        ["r?"] = colors.cyan,
-        ["!"] = colors.blue,
-        t = colors.blue,
-      }
-      vim.api.nvim_command("hi GalaxyViMode guifg=" .. mode_color[vim.fn.mode()])
-      return "▊"
-    end,
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { "NONE", colors.alt_bg },
-  },
-})
--- print(vim.fn.getbufvar(0, 'ts'))
-vim.fn.getbufvar(0, "ts")
+  -- NOTE: if someone defines colors but doesn't have them then this will break
+  local palette_status_ok, colors = pcall(require, O.colorscheme .. ".palette")
+  if not palette_status_ok then
+    colors = O.plugin.galaxyline.colors
+  end
 
-table.insert(gls.left, {
-  GitIcon = {
-    provider = function()
-      return "  "
-    end,
-    condition = condition.check_git_workspace,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.orange, colors.alt_bg },
-  },
-})
+  local condition = require "galaxyline.condition"
+  local gls = gl.section
+  gl.short_line_list = { "NvimTree", "vista", "dbui", "packer" }
 
-table.insert(gls.left, {
-  GitBranch = {
-    provider = "GitBranch",
-    condition = condition.check_git_workspace,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    ViMode = {
+      provider = function()
+        -- auto change color according the vim mode
+        local mode_color = {
+          n = colors.blue,
+          i = colors.green,
+          v = colors.purple,
+          [""] = colors.purple,
+          V = colors.purple,
+          c = colors.magenta,
+          no = colors.blue,
+          s = colors.orange,
+          S = colors.orange,
+          [""] = colors.orange,
+          ic = colors.yellow,
+          R = colors.red,
+          Rv = colors.red,
+          cv = colors.blue,
+          ce = colors.blue,
+          r = colors.cyan,
+          rm = colors.cyan,
+          ["r?"] = colors.cyan,
+          ["!"] = colors.blue,
+          t = colors.blue,
+        }
+        vim.api.nvim_command("hi GalaxyViMode guifg=" .. mode_color[vim.fn.mode()])
+        return "▊"
+      end,
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { "NONE", colors.alt_bg },
+    },
+  })
+  -- print(vim.fn.getbufvar(0, 'ts'))
+  vim.fn.getbufvar(0, "ts")
 
-table.insert(gls.left, {
-  DiffAdd = {
-    provider = "DiffAdd",
-    condition = condition.hide_in_width,
-    icon = "  ",
-    highlight = { colors.green, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    GitIcon = {
+      provider = function()
+        return "  "
+      end,
+      condition = condition.check_git_workspace,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.orange, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  DiffModified = {
-    provider = "DiffModified",
-    condition = condition.hide_in_width,
-    icon = " 柳",
-    highlight = { colors.blue, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    GitBranch = {
+      provider = "GitBranch",
+      condition = condition.check_git_workspace,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  DiffRemove = {
-    provider = "DiffRemove",
-    condition = condition.hide_in_width,
-    icon = "  ",
-    highlight = { colors.red, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    DiffAdd = {
+      provider = "DiffAdd",
+      condition = condition.hide_in_width,
+      icon = "  ",
+      highlight = { colors.green, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  Filler = {
-    provider = function()
-      return " "
-    end,
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
--- get output from shell command
-function os.capture(cmd, raw)
-  local f = assert(io.popen(cmd, "r"))
-  local s = assert(f:read "*a")
-  f:close()
-  if raw then
+  table.insert(gls.left, {
+    DiffModified = {
+      provider = "DiffModified",
+      condition = condition.hide_in_width,
+      icon = " 柳",
+      highlight = { colors.blue, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.left, {
+    DiffRemove = {
+      provider = "DiffRemove",
+      condition = condition.hide_in_width,
+      icon = "  ",
+      highlight = { colors.red, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.left, {
+    Filler = {
+      provider = function()
+        return " "
+      end,
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+  -- get output from shell command
+  function os.capture(cmd, raw)
+    local f = assert(io.popen(cmd, "r"))
+    local s = assert(f:read "*a")
+    f:close()
+    if raw then
+      return s
+    end
+    s = string.gsub(s, "^%s+", "")
+    s = string.gsub(s, "%s+$", "")
+    s = string.gsub(s, "[\n\r]+", " ")
     return s
   end
-  s = string.gsub(s, "^%s+", "")
-  s = string.gsub(s, "%s+$", "")
-  s = string.gsub(s, "[\n\r]+", " ")
-  return s
-end
--- cleanup virtual env
-local function env_cleanup(venv)
-  if string.find(venv, "/") then
-    local final_venv = venv
-    for w in venv:gmatch "([^/]+)" do
-      final_venv = w
+  -- cleanup virtual env
+  local function env_cleanup(venv)
+    if string.find(venv, "/") then
+      local final_venv = venv
+      for w in venv:gmatch "([^/]+)" do
+        final_venv = w
+      end
+      venv = final_venv
     end
-    venv = final_venv
+    return venv
   end
-  return venv
-end
-local PythonEnv = function()
-  if vim.bo.filetype == "python" then
-    local venv = os.getenv "CONDA_DEFAULT_ENV"
-    if venv ~= nil then
-      return "  (" .. env_cleanup(venv) .. ")"
-    end
-    venv = os.getenv "VIRTUAL_ENV"
-    if venv ~= nil then
-      return "  (" .. env_cleanup(venv) .. ")"
+  local PythonEnv = function()
+    if vim.bo.filetype == "python" then
+      local venv = os.getenv "CONDA_DEFAULT_ENV"
+      if venv ~= nil then
+        return "  (" .. env_cleanup(venv) .. ")"
+      end
+      venv = os.getenv "VIRTUAL_ENV"
+      if venv ~= nil then
+        return "  (" .. env_cleanup(venv) .. ")"
+      end
+      return ""
     end
     return ""
   end
-  return ""
-end
-table.insert(gls.left, {
-  VirtualEnv = {
-    provider = PythonEnv,
-    event = "BufEnter",
-    highlight = { colors.green, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    VirtualEnv = {
+      provider = PythonEnv,
+      event = "BufEnter",
+      highlight = { colors.green, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  DiagnosticError = {
-    provider = "DiagnosticError",
-    icon = "  ",
-    highlight = { colors.red, colors.alt_bg },
-  },
-})
-table.insert(gls.right, {
-  DiagnosticWarn = {
-    provider = "DiagnosticWarn",
-    icon = "  ",
-    highlight = { colors.orange, colors.alt_bg },
-  },
-})
+  table.insert(gls.right, {
+    DiagnosticError = {
+      provider = "DiagnosticError",
+      icon = "  ",
+      highlight = { colors.red, colors.alt_bg },
+    },
+  })
+  table.insert(gls.right, {
+    DiagnosticWarn = {
+      provider = "DiagnosticWarn",
+      icon = "  ",
+      highlight = { colors.orange, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  DiagnosticInfo = {
-    provider = "DiagnosticInfo",
-    icon = "  ",
-    highlight = { colors.yellow, colors.alt_bg },
-  },
-})
+  table.insert(gls.right, {
+    DiagnosticInfo = {
+      provider = "DiagnosticInfo",
+      icon = "  ",
+      highlight = { colors.yellow, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  DiagnosticHint = {
-    provider = "DiagnosticHint",
-    icon = "  ",
-    highlight = { colors.blue, colors.alt_bg },
-  },
-})
+  table.insert(gls.right, {
+    DiagnosticHint = {
+      provider = "DiagnosticHint",
+      icon = "  ",
+      highlight = { colors.blue, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  TreesitterIcon = {
-    provider = function()
-      if next(vim.treesitter.highlighter.active) ~= nil then
-        return "  "
-      end
-      return ""
-    end,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.green, colors.alt_bg },
-  },
-})
-
-local get_lsp_client = function(msg)
-  msg = msg or "LSP Inactive"
-  local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
-  local clients = vim.lsp.get_active_clients()
-  if next(clients) == nil then
-    return msg
-  end
-  local lsps = ""
-  for _, client in ipairs(clients) do
-    local filetypes = client.config.filetypes
-    if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
-      -- print(client.name)
-      if lsps == "" then
-        -- print("first", lsps)
-        lsps = client.name
-      else
-        if not string.find(lsps, client.name) then
-          lsps = lsps .. ", " .. client.name
+  table.insert(gls.right, {
+    TreesitterIcon = {
+      provider = function()
+        if next(vim.treesitter.highlighter.active) ~= nil then
+          return "  "
         end
-        -- print("more", lsps)
+        return ""
+      end,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.green, colors.alt_bg },
+    },
+  })
+
+  local get_lsp_client = function(msg)
+    msg = msg or "LSP Inactive"
+    local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
+    local clients = vim.lsp.get_active_clients()
+    if next(clients) == nil then
+      return msg
+    end
+    local lsps = ""
+    for _, client in ipairs(clients) do
+      local filetypes = client.config.filetypes
+      if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
+        -- print(client.name)
+        if lsps == "" then
+          -- print("first", lsps)
+          lsps = client.name
+        else
+          if not string.find(lsps, client.name) then
+            lsps = lsps .. ", " .. client.name
+          end
+          -- print("more", lsps)
+        end
       end
     end
+    if lsps == "" then
+      return msg
+    else
+      return lsps
+    end
   end
-  if lsps == "" then
-    return msg
-  else
-    return lsps
-  end
+
+  table.insert(gls.right, {
+    ShowLspClient = {
+      provider = get_lsp_client,
+      condition = function()
+        local tbl = { ["dashboard"] = true, [" "] = true }
+        if tbl[vim.bo.filetype] then
+          return false
+        end
+        return true
+      end,
+      icon = " ",
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    LineInfo = {
+      provider = "LineColumn",
+      separator = "  ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    PerCent = {
+      provider = "LinePercent",
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    Tabstop = {
+      provider = function()
+        return "Spaces: " .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
+      end,
+      condition = condition.hide_in_width,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    BufferType = {
+      provider = "FileTypeName",
+      condition = condition.hide_in_width,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.alt_bg, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    FileEncode = {
+      provider = "FileEncode",
+      condition = condition.hide_in_width,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    Space = {
+      provider = function()
+        return " "
+      end,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.short_line_left, {
+    BufferType = {
+      provider = "FileTypeName",
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.alt_bg, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.short_line_left, {
+    SFileName = {
+      provider = "SFileName",
+      condition = condition.buffer_not_empty,
+      highlight = { colors.alt_bg, colors.alt_bg },
+    },
+  })
+
+  --table.insert(gls.short_line_right[1] = {BufferIcon = {provider = 'BufferIcon', highlight = {colors.grey, colors.alt_bg}}})
 end
 
-table.insert(gls.right, {
-  ShowLspClient = {
-    provider = get_lsp_client,
-    condition = function()
-      local tbl = { ["dashboard"] = true, [" "] = true }
-      if tbl[vim.bo.filetype] then
-        return false
-      end
-      return true
-    end,
-    icon = " ",
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  LineInfo = {
-    provider = "LineColumn",
-    separator = "  ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  PerCent = {
-    provider = "LinePercent",
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  Tabstop = {
-    provider = function()
-      return "Spaces: " .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
-    end,
-    condition = condition.hide_in_width,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  BufferType = {
-    provider = "FileTypeName",
-    condition = condition.hide_in_width,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.alt_bg, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  FileEncode = {
-    provider = "FileEncode",
-    condition = condition.hide_in_width,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  Space = {
-    provider = function()
-      return " "
-    end,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.short_line_left, {
-  BufferType = {
-    provider = "FileTypeName",
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.alt_bg, colors.alt_bg },
-  },
-})
-
-table.insert(gls.short_line_left, {
-  SFileName = {
-    provider = "SFileName",
-    condition = condition.buffer_not_empty,
-    highlight = { colors.alt_bg, colors.alt_bg },
-  },
-})
-
---table.insert(gls.short_line_right[1] = {BufferIcon = {provider = 'BufferIcon', highlight = {colors.grey, colors.alt_bg}}})
+return M

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -1,14 +1,21 @@
--- --if not package.loaded['nvim-tree.view'] then
--- --  return
--- --end
---
 local M = {}
 local status_ok, nvim_tree_config = pcall(require, "nvim-tree.config")
 if not status_ok then
   return
 end
 --
+
+M.config = function()
+  O.plugin.nvimtree = {
+    config = nil,
+  }
+end
+
 M.setup = function()
+  if O.plugin.nvimtree.config then
+    return O.plugin.nvimtree.config()
+  end
+
   local g = vim.g
 
   vim.o.termguicolors = true

--- a/lua/core/status_colors.lua
+++ b/lua/core/status_colors.lua
@@ -1,5 +1,6 @@
 O.plugin.galaxyline = {
   active = true,
+  config = nil,
   colors = {
     alt_bg = "#2E2E2E",
     grey = "#858585",

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -81,6 +81,7 @@ M.config = function()
         override_file_sorter = true,
       },
     },
+    config = nil,
   }
 end
 
@@ -89,6 +90,11 @@ M.setup = function()
   if not status_ok then
     return
   end
+
+  if O.plugin.telescope.config then
+    return O.plugin.telescope.config()
+  end
+
   telescope.setup(O.plugin.telescope)
   vim.api.nvim_set_keymap("n", "<Leader>f", ":Telescope find_files<CR>", { noremap = true, silent = true })
 end

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -32,6 +32,7 @@ M.config = function()
         background = "Normal",
       },
     },
+    config = nil,
   }
 end
 
@@ -41,6 +42,11 @@ M.setup = function()
     print(terminal)
     return
   end
+
+  if O.plugin.terminal.config then
+    return O.plugin.terminal.config()
+  end
+
   vim.api.nvim_set_keymap(
     "n",
     "<leader>gg",

--- a/lua/core/treesitter.lua
+++ b/lua/core/treesitter.lua
@@ -58,6 +58,7 @@ M.config = function()
       extended_mode = true, -- Highlight also non-parentheses delimiters, boolean or table: lang -> boolean
       max_file_lines = 1000, -- Do not enable for files with more than 1000 lines, int
     },
+    config = nil,
   }
 
   -- -- TODO refactor treesitter
@@ -179,6 +180,10 @@ M.setup = function()
   local status_ok, treesitter_configs = pcall(require, "nvim-treesitter.configs")
   if not status_ok then
     return
+  end
+
+  if O.treesitter.config then
+    return O.treesitter.config()
   end
 
   treesitter_configs.setup(O.treesitter)

--- a/lua/core/zen.lua
+++ b/lua/core/zen.lua
@@ -20,6 +20,7 @@ M.config = function()
       -- or leave it empty to use the default settings
       -- refer to the configuration section below
     },
+    config = nil,
   }
 end
 
@@ -28,6 +29,11 @@ M.setup = function()
   if not status_ok then
     return
   end
+
+  if O.plugin.zen.config then
+    return O.plugin.zen.config()
+  end
+
   zen_mode.setup(O.plugin.zen)
 end
 

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -139,6 +139,7 @@ require("core.treesitter").config()
 require("core.which-key").config()
 require("core.autopairs").config()
 require("core.bufferline").config()
+require("core.nvimtree").config()
 
 require("lang.clang").config()
 require("lang.cmake").config()

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -127,6 +127,7 @@ require("core.zen").config()
 require("core.telescope").config()
 require("core.treesitter").config()
 require("core.which-key").config()
+require("core.autopairs").config()
 
 require("lang.clang").config()
 require("lang.cmake").config()

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -138,6 +138,7 @@ require("core.telescope").config()
 require("core.treesitter").config()
 require("core.which-key").config()
 require("core.autopairs").config()
+require("core.bufferline").config()
 
 require("lang.clang").config()
 require("lang.cmake").config()

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,9 +59,7 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    config = function()
-      require("core.autopairs").setup()
-    end,
+    config = require("core.autopairs").setup(),
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -60,11 +60,7 @@ return require("packer").startup(function(use)
   use {
     "windwp/nvim-autopairs",
     config = function()
-      if O.plugin.autopairs.config then
-        O.plugin.autopairs.config()
-      else
-        require("core.autopairs").setup()
-      end
+      require("core.autopairs").setup()
     end,
   }
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -151,7 +151,7 @@ return require("packer").startup(function(use)
   use {
     "romgrk/barbar.nvim",
     config = function()
-      require "core.bufferline"
+      require("core.bufferline").setup()
     end,
     event = "BufWinEnter",
   }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -44,7 +44,9 @@ return require("packer").startup(function(use)
   -- Telescope
   use {
     "nvim-telescope/telescope.nvim",
-    config = require("core.telescope").setup(),
+    config = function()
+      require("core.telescope").setup()
+    end,
   }
 
   -- Autocomplete

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -142,7 +142,7 @@ return require("packer").startup(function(use)
   use {
     "glepnir/galaxyline.nvim",
     config = function()
-      require "core.galaxyline"
+      require("core.galaxyline").setup()
     end,
     event = "BufWinEnter",
     disable = not O.plugin.galaxyline.active,

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,7 +59,9 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    config = require("core.autopairs").setup(),
+    config = function()
+      require("core.autopairs").setup()
+    end,
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,7 +59,13 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    config = require("core.autopairs").setup(),
+    config = function()
+      if O.plugin.autopairs.config then
+        O.plugin.autopairs.config()
+      else
+        require("core.autopairs").setup()
+      end
+    end,
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -59,10 +59,7 @@ return require("packer").startup(function(use)
   -- Autopairs
   use {
     "windwp/nvim-autopairs",
-    -- event = "InsertEnter",
-    config = function()
-      require "core.autopairs"
-    end,
+    config = require("core.autopairs").setup(),
   }
 
   -- Snippets

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -44,7 +44,7 @@ return require("packer").startup(function(use)
   -- Telescope
   use {
     "nvim-telescope/telescope.nvim",
-    config = [[require('core.telescope').setup()]],
+    config = require("core.telescope").setup(),
   }
 
   -- Autocomplete

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -91,3 +91,66 @@ O.lang.latex.latexindent.modify_line_breaks = false
 --     b = { "<cmd>echo 'second custom command'<cr>", "Description for b" },
 --   },
 -- }
+
+-- If you want to override settings to the core plugins
+-- AND those settings are not available from the global object 'O'
+-- You can provide your own configuration by placing it in the following format:
+
+-- O.plugin.autopairs.config = function()
+--   print "loading user config for autopairs"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.bufferline.config = function()
+--   print "Loaded user config for bufferline"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.completion.config = function()
+--   print "Loaded user config for compe"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.dap.active = true
+-- O.plugin.dap.config = function()
+--   print "Loaded user config for dap"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.dashboard.active = true
+-- O.plugin.dashboard.config = function()
+--   print "Loaded user config for dashboard"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.galaxyline.config = function()
+--   print "Loaded user config for galaxyline"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.nvimtree.config = function()
+--   print "Loaded user config for nvimtree"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.telescope.config = function()
+--   print "Loaded user config for telescope"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.terminal.active = true
+-- O.plugin.terminal.config = function()
+--   print "Loaded user config for terminal"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.treesitter.config = function()
+--   print "Loaded user config for treesitter"
+--   -- VALID_CONFIG_HERE
+-- end
+--
+-- O.plugin.zen.active = true
+-- O.plugin.zen.config = function()
+--   print "Loaded user config for zen"
+--   -- VALID_CONFIG_HERE
+-- end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Allows users to override default configs for core plugins with their own settings.  This addresses users concerns that they can't modify some settings.  This also means that going forward, if some new obscure setting gets released for a plugin, the user can try it out immediately without waiting for an entry to get added to a table.  


I made the following plugins override-able: autopairs, bufferline, compe, dap, dashboard, galaxyline, nvimtree, telescope, terminal, treesitter, zen

I skipped gitsigns, because I couldn't make it work with this method.

I also skipped formatter because there's nothing user configurable there
And which-key because I think this will have a different solution.  Can't we just expose the default whichkey mappings from the O object and let the user rewrite the default bindings if they wish?  The user_which_key table can stay in case they want the default bindings AND their own as well.  

Fixes #(issue)
https://github.com/ChristianChiarulli/LunarVim/issues/960

## How Has This Been Tested?
```lua
O.plugin.autopairs.config = function()
  print "loading user config for autopairs"
  -- VALID_CONFIG_HERE
end

O.plugin.bufferline.config = function()
  print "Loaded user config for bufferline"
  -- VALID_CONFIG_HERE
end

O.completion.config = function()
  print "Loaded user config for compe"
  -- VALID_CONFIG_HERE
end

O.plugin.dap.active = true
O.plugin.dap.config = function()
  print "Loaded user config for dap"
  -- VALID_CONFIG_HERE
end

O.plugin.dashboard.active = true
O.plugin.dashboard.config = function()
  print "Loaded user config for dashboard"
  -- VALID_CONFIG_HERE
end

O.plugin.galaxyline.config = function()
  print "Loaded user config for galaxyline"
  -- VALID_CONFIG_HERE
end

O.plugin.nvimtree.config = function()
  print "Loaded user config for nvimtree"
  -- VALID_CONFIG_HERE
end

O.plugin.telescope.config = function()
  print "Loaded user config for telescope"
  -- VALID_CONFIG_HERE
end

O.plugin.terminal.active = true
O.plugin.terminal.config = function()
  print "Loaded user config for terminal"
  -- VALID_CONFIG_HERE
end

O.treesitter.config = function()
  print "Loaded user config for treesitter"
  -- VALID_CONFIG_HERE
end

O.plugin.zen.active = true
O.plugin.zen.config = function()
  print "Loaded user config for zen"
  -- VALID_CONFIG_HERE
end
```

Please describe the tests that you ran to verify your changes. \
I added valid configs to make sure each plugin respected modifications


