### PR TITLE
:tada: telescope supports colorscheme preview

### DIFF
--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -148,6 +148,10 @@ M.config = function()
         t = { "<cmd>Telescope live_grep<cr>", "Text" },
         k = { "<cmd>Telescope keymaps<cr>", "Keymaps" },
         C = { "<cmd>Telescope commands<cr>", "Commands" },
+        p = {
+          "<cmd>lua require('telescope.builtin.internal').colorscheme({enable_preview = true})<cr>",
+          "Colorscheme with Preview",
+        },
       },
       T = {
         name = "Treesitter",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adds support for telsecope theme selection with preview

## How Has This Been Tested?

running `<leader>sp` shows this
<img width="1584" alt="Screen Shot 2021-07-16 at 10 11 19 PM" src="https://user-images.githubusercontent.com/10992695/125987828-f867cc5d-4c87-4dcd-aaf6-725e38d3baa4.png">


