### PR TITLE
configure luacheck to better undersant LV code

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,38 @@
+-- vim: ft=lua tw=80
+
+stds.nvim = {
+	globals = {
+		"O",
+		vim = { fields = { "g" } },
+		"CONFIG_PATH",
+		"CACHE_PATH",
+		"DATA_PATH",
+		"TERMINAL",
+		"USER",
+    "C",
+    "Config",
+    "WORKSPACE_PATH",
+    "JAVA_LS_EXECUTABLE",
+    "MUtils",
+    os = {fields = {"capture"}}
+	},
+	read_globals = {
+		"jit",
+		"os",
+		"vim",
+		-- vim = { fields = { "cmd", "api", "fn", "o" } },
+	},
+}
+std = "lua51+nvim"
+
+
+-- Don't report unused self arguments of methods.
+self = false
+
+-- Rerun tests only if their modification time changed.
+cache = true
+
+ignore = {
+	"631", -- max_line_length
+	"212/_.*", -- unused argument, for vars with "_" prefix
+}


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Lucheck needs to be [configured](https://github.com/neovim/neovim/blob/master/.luacheckrc) to understand LV code


## How Has This Been Tested?

- Run
```bash
luarocks install luacheck
cd ~/.config/nvim
luacheck .
```


