### PR TITLE
Fix Clang integration

### DIFF
--- a/ftplugin/c.lua
+++ b/ftplugin/c.lua
@@ -1,4 +1,4 @@
-require("lang.clang").format()
-require("lang.clang").lint()
-require("lang.clang").lsp()
-require("lang.clang").dap()
+require("lang.cpp").format()
+require("lang.cpp").lint()
+require("lang.cpp").lsp()
+require("lang.cpp").dap()

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -118,6 +118,7 @@ M.config = function()
           "Workspace Diagnostics",
         },
         f = { "<cmd>silent FormatWrite<cr>", "Format" },
+        F = { "<cmd>lua vim.lsp.buf.formatting()<CR>", "Format (native-lsp)" },
         i = { "<cmd>LspInfo<cr>", "Info" },
         j = {
           "<cmd>lua vim.lsp.diagnostic.goto_next({popup_opts = {border = O.lsp.popup_border}})<cr>",

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -161,7 +161,7 @@ require("core.treesitter").config()
 require("core.which-key").config()
 require("core.nvimtree").config()
 
-require("lang.clang").config()
+require("lang.cpp").config()
 require("lang.cmake").config()
 require("lang.css").config()
 require("lang.dart").config()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix Clang integration

- Rename `O.lang.clang` to `O.lang.cpp`
- Use built-in support of `clangd` for `clang-tidy` and `clang-format`
- User can use `<leader>lF` which is mapped to `vim.lsp.buf.formatting`
to perform formatting using the `clangd`.
- Allow the user to override all the options for `clangd`
- Allow the user to specify an external linter and formatter By explcitly
setting `O.lang.cpp.linter` and `O.lang.cpp.formatter` respectively.

Fixes #(issue)

Clang is not a language 😄 

## How Has This Been Tested?

Open any *.c or *.cc file and test formatting with `<leader>lF` and try to trigger clang-tidy, if it's not already complaining about something.

