### PR TITLE
[Bugfix] Remove OmniSharp LSP root_dir config after nvim-lspconfig PR #1084

### DIFF
--- a/lua/lang/cs.lua
+++ b/lua/lang/cs.lua
@@ -23,7 +23,6 @@ M.lsp = function()
   -- C# language server (csharp/OmniSharp) setup
   require("lspconfig").omnisharp.setup {
     on_attach = require("lsp").common_on_attach,
-    root_dir = require("lspconfig").util.root_pattern(".sln", ".git"),
     cmd = { DATA_PATH .. "/lspinstall/csharp/omnisharp/run", "--languageserver", "--hostPID", tostring(vim.fn.getpid()) },
   }
 end


### PR DESCRIPTION
# Description

nvim-lspconfig has fixed the OmniSharp (csharp) LPS root_dir default configuration. See PR #1084
https://github.com/neovim/nvim-lspconfig/pull/1084

The corresponding configuration can now be removed from LunarVim.

Note! Requires updated nvim-lspconfig, i.e. `:PackerUpdate` or similar is mandatory.

## How Has This Been Tested?

Change has been tested on few .NET Core projects with and without solution (.sln) file.
