### PR TITLE
[Feature] Better path_display default for telescope

### DIFF
--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -33,7 +33,7 @@ M.config = function()
       file_sorter = require("telescope.sorters").get_fzy_sorter,
       file_ignore_patterns = {},
       generic_sorter = require("telescope.sorters").get_generic_fuzzy_sorter,
-      path_display = { "shorten" },
+      path_display = { shorten = 5 },
       winblend = 0,
       border = {},
       borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Until we have a better alternative like [this](https://github.com/caojoshua/telescope.nvim/pull/1) or [this](https://github.com/nvim-telescope/telescope.nvim/pull/914).

Fixes #812

## How Has This Been Tested?

before:

<img width="1289" alt="before" src="https://user-images.githubusercontent.com/10992695/126046289-b96a3e6c-b894-4f8f-840d-9b336c7bccc1.png">


after:

<img width="1317" alt="after" src="https://user-images.githubusercontent.com/10992695/126046297-3dff7d66-2190-4ffe-afbf-231ca6e6fd12.png">

