### PR TITLE
[Bugfix] Fix tsserver lsp setup. Fix ts-fmt-lint setup

### DIFF
--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -2,23 +2,41 @@
 -- You can look for project scope Prettier and Eslint with e.g. vim.fn.glob("node_modules/.bin/prettier") etc. If it is not found revert to global Prettier where needed.
 local M = {}
 
+vim.cmd "let proj = FindRootDirectory()"
+local root_dir = vim.api.nvim_get_var "proj"
+
+local get_linter_instance = function()
+  -- prioritize local instance over global
+  local local_instance = root_dir .. "/node_modules/.bin/" .. O.lang.tsserver.linter
+  if vim.fn.executable(local_instance) == 1 then
+    return local_instance
+  end
+  return O.lang.tsserver.linter
+end
+
 M.setup = function()
   local tsserver_args = {}
 
   if O.lang.tsserver.linter == "eslint" or O.lang.tsserver.linter == "eslint_d" then
     local eslint = {
-      lintCommand = O.lang.tsserver.linter .. " -f visualstudio --stdin --stdin-filename ${INPUT}",
+      lintCommand = get_linter_instance() .. " -f visualstudio --stdin --stdin-filename ${INPUT}",
       lintStdin = true,
       lintFormats = {
         "%f(%l,%c): %tarning %m",
-        "%f(%l,%c): %rror %m",
+        "%f(%l,%c): %trror %m",
       },
       lintSource = O.lang.tsserver.linter,
       lintIgnoreExitCode = true,
-      formatCommand = O.lang.tsserver.linter .. " --fix-to-stdout --stdin  --stdin-filename=${INPUT}",
-      formatStdin = true,
     }
     table.insert(tsserver_args, eslint)
+    -- Only eslint_d supports --fix-to-stdout
+    if string.find(get_linter_instance(), "eslint_d") then
+      local eslint_fix = {
+        formatCommand = get_linter_instance() .. " --fix-to-stdout --stdin --stdin-filename ${INPUT}",
+        formatStdin = true,
+      }
+      table.insert(tsserver_args, eslint_fix)
+    end
   end
 
   require("lspconfig").efm.setup {

--- a/lua/lsp/ts-fmt-lint.lua
+++ b/lua/lsp/ts-fmt-lint.lua
@@ -1,21 +1,21 @@
 -- Example configuations here: https://github.com/mattn/efm-langserver
--- You can look for project scope Prettier and Eslint with e.g. vim.fn.glob("node_modules/.bin/prettier") etc. If it is not found revert to global Prettier where needed.
 local M = {}
 
-vim.cmd "let proj = FindRootDirectory()"
-local root_dir = vim.api.nvim_get_var "proj"
-
-local get_linter_instance = function()
-  -- prioritize local instance over global
-  local local_instance = root_dir .. "/node_modules/.bin/" .. O.lang.tsserver.linter
-  if vim.fn.executable(local_instance) == 1 then
-    return local_instance
-  end
-  return O.lang.tsserver.linter
-end
-
 M.setup = function()
+  vim.cmd "let proj = FindRootDirectory()"
+  local root_dir = vim.api.nvim_get_var "proj"
+
+  local get_linter_instance = function()
+    -- prioritize local instance over global
+    local local_instance = root_dir .. "/node_modules/.bin/" .. O.lang.tsserver.linter
+    if vim.fn.executable(local_instance) == 1 then
+      return local_instance
+    end
+    return O.lang.tsserver.linter
+  end
+
   local tsserver_args = {}
+  local formattingSupported = false
 
   if O.lang.tsserver.linter == "eslint" or O.lang.tsserver.linter == "eslint_d" then
     local eslint = {
@@ -31,6 +31,7 @@ M.setup = function()
     table.insert(tsserver_args, eslint)
     -- Only eslint_d supports --fix-to-stdout
     if string.find(get_linter_instance(), "eslint_d") then
+      formattingSupported = true
       local eslint_fix = {
         formatCommand = get_linter_instance() .. " --fix-to-stdout --stdin --stdin-filename ${INPUT}",
         formatStdin = true,
@@ -42,7 +43,7 @@ M.setup = function()
   require("lspconfig").efm.setup {
     -- init_options = {initializationOptions},
     cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
-    init_options = { documentFormatting = true, codeAction = false },
+    init_options = { documentFormatting = formattingSupported, codeAction = false },
     root_dir = require("lspconfig").util.root_pattern(".git/", "package.json"),
     filetypes = {
       "vue",

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -57,9 +57,8 @@ require("lspconfig").tsserver.setup {
     "typescript.tsx",
   },
   on_attach = require("lsp").tsserver_on_attach,
-  -- This makes sure tsserver is not used for formatting (I prefer prettier)
   -- on_attach = require'lsp'.common_on_attach,
-  root_dir = require("lspconfig/util").root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git"),
+  -- This makes sure tsserver is not used for formatting (I prefer prettier)
   settings = { documentFormatting = false },
   handlers = {
     -- ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
@@ -70,4 +69,5 @@ require("lspconfig").tsserver.setup {
     -- }),
   },
 }
+
 require("lsp.ts-fmt-lint").setup()


### PR DESCRIPTION
# Description

1. Use nvim-lspconfig default root_dir configuration for tsserver
2. Fix ts-fmt-lint setup
   - prioritize local linter over global linter
   - fix `lintFormats` typo
   - only eslint_d supports `--fix-to-stdout`. Set formatter (i.e. "fix") only if eslint_d is used.

## How Has This Been Tested?

With a Typescript project using
- global eslint_d
- local eslint_d
- global eslint
- local eslint