### PR TITLE
[Bugfix] Fix document highlight bug for javascript,typescript...

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -196,8 +196,8 @@ function lsp_config.PeekImplementation()
   end
 end
 
-if O.lsp.document_highlight then
-  function lsp_config.common_on_attach(client, bufnr)
+function lsp_config.common_on_attach(client, bufnr)
+  if O.lsp.document_highlight then
     documentHighlight(client, bufnr)
   end
 end

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -47,6 +47,13 @@ end
 -- require'completion'.on_attach(client)
 -- require'illuminate'.on_attach(client)
 -- end
+
+local on_attach = function(client, bufnr)
+  local lsp = require "lsp"
+  lsp.common_on_attach(client, bufnr)
+  lsp.tsserver_on_attach(client, bufnr)
+end
+
 require("lspconfig").tsserver.setup {
   cmd = {
     DATA_PATH .. "/lspinstall/typescript/node_modules/.bin/typescript-language-server",
@@ -60,8 +67,7 @@ require("lspconfig").tsserver.setup {
     "typescriptreact",
     "typescript.tsx",
   },
-  on_attach = require("lsp").tsserver_on_attach,
-  -- on_attach = require'lsp'.common_on_attach,
+  on_attach = on_attach,
   -- This makes sure tsserver is not used for formatting (I prefer prettier)
   settings = { documentFormatting = false },
   handlers = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- lsp_config.common_on_attach function defines regardless of
  O.lsp.document_highlight value
- creates local on_attach function in lsp/tsserver-ls.lua and assign in
  tsserver.setup argument table

# Fixes
Document highlight doesn't work on javascript and typescript files.

## How Has This Been Tested?

You can test it on javascript or typescript files. 

