### PR TITLE
[Bugfix] Update nvim-tree to the latest version without the dasboard issue

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -81,7 +81,7 @@ M.toggle_tree = function()
       -- require'bufferline.state'.set_offset(31, 'File Explorer')
       require("bufferline.state").set_offset(31, "")
     end
-    require("nvim-tree").find_file(true)
+    require("nvim-tree").toggle()
   end
 end
 --

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -74,7 +74,7 @@ return {
     "kyazdani42/nvim-tree.lua",
     -- event = "BufWinOpen",
     -- cmd = "NvimTreeToggle",
-    commit = "fd7f60e242205ea9efc9649101c81a07d5f458bb",
+    -- commit = "fd7f60e242205ea9efc9649101c81a07d5f458bb",
     config = function()
       require("core.nvimtree").setup()
     end,


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

as @williamgoulois mentioned the latest `nvim-tree` toggle doesn't work on dashboard

Fixes #1018

## How Has This Been Tested?

open nvim without any files
while on dashboard run `<leader>e`

## The reason behind it

run the following while on dashboard:
```vim
:lua print(vim.inspect(vim.loop.fs_stat(vim.fn.fnamemodify(vim.fn.bufname(), ':p'))))
```
as the [code](https://github.com/kyazdani42/nvim-tree.lua/blob/0a13676f30230f4f049b2efaccc5e0936067b475/lua/nvim-tree.lua) shows, because the `stat.type == directory` the `M.find_file` function returns without actually showing the `nvim-tree`

but since we have `follow=1` the `M.toggle()` function already follows a file and if not a file then shows a directory: 
```lua
function M.toggle()
  if view.win_open() then
    view.close()
  else
    if vim.g.nvim_tree_follow == 1 then
      M.find_file(true)
    end
    if not view.win_open() then
      lib.open()
    end
  end
end
```