### PR TITLE
[Feature] Make common_on_attach configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ O.treesitter.ensure_installed = "all"
 O.treesitter.ignore_install = {"haskell"}
 O.treesitter.highlight.enabled = true
 
+-- you can set a custom on_attach function that will be used for all the language servers
+-- See <https://github.com/neovim/nvim-lspconfig#keybindings-and-completion>
+-- O.lsp.on_attach_callback = function(client, bufnr)
+--   local function buf_set_option(...)
+--     vim.api.nvim_buf_set_option(bufnr, ...)
+--   end
+--   --Enable completion triggered by <c-x><c-o>
+--   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
+-- end
+
 -- lua
 O.lang.lua.autoformat = false
 O.lang.lua.formatter = 'lua-format'

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -73,6 +73,7 @@ O = {
     document_highlight = true,
     popup_border = "single",
     default_keybinds = true,
+    on_attach_callback = nil,
   },
 
   disabled_built_ins = {

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -111,7 +111,10 @@ autocmd BufWritePre *.lua lua vim.lsp.buf.formatting_sync(nil, 100) ]]
 -- Java
 -- autocmd FileType java nnoremap ca <Cmd>lua require('jdtls').code_action()<CR>
 
-local function documentHighlight(client, _)
+local function lsp_highlight_document(client)
+  if O.lsp.document_highlight == false then
+    return -- we don't need further
+  end
   -- Set autocommands conditional on server_capabilities
   if client.resolved_capabilities.document_highlight then
     vim.api.nvim_exec(
@@ -197,9 +200,10 @@ function lsp_config.PeekImplementation()
 end
 
 function lsp_config.common_on_attach(client, bufnr)
-  if O.lsp.document_highlight then
-    documentHighlight(client, bufnr)
+  if O.lsp.on_attach_callback then
+    O.lsp.on_attach_callback(client, bufnr)
   end
+  lsp_highlight_document(client)
 end
 
 function lsp_config.tsserver_on_attach(client, _)

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -50,6 +50,17 @@ O.treesitter.ensure_installed = {}
 O.treesitter.ignore_install = { "haskell" }
 O.treesitter.highlight.enabled = true
 
+-- generic LSP settings
+-- you can set a custom on_attach function that will be used for all the language servers
+-- See <https://github.com/neovim/nvim-lspconfig#keybindings-and-completion>
+-- O.lsp.on_attach_callback = function(client, bufnr)
+--   local function buf_set_option(...)
+--     vim.api.nvim_buf_set_option(bufnr, ...)
+--   end
+--   --Enable completion triggered by <c-x><c-o>
+--   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
+-- end
+
 -- python
 O.lang.python.diagnostics.virtual_text = true
 O.lang.python.analysis.use_library_code_types = true

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -50,6 +50,17 @@ O.treesitter.ensure_installed = "maintained"
 O.treesitter.ignore_install = { "haskell" }
 O.treesitter.highlight.enabled = true
 
+-- generic LSP settings
+-- you can set a custom on_attach function that will be used for all the language servers
+-- See <https://github.com/neovim/nvim-lspconfig#keybindings-and-completion>
+-- O.lsp.on_attach_callback = function(client, bufnr)
+--   local function buf_set_option(...)
+--     vim.api.nvim_buf_set_option(bufnr, ...)
+--   end
+--   --Enable completion triggered by <c-x><c-o>
+--   buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
+-- end
+
 -- python
 O.lang.python.diagnostics.virtual_text = true
 O.lang.python.analysis.use_library_code_types = true


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Allow the user to set a custom on_attach callback for lspconfig. 

This also fixes a bug where `lspconfig.common_on_attach` is undefined when `O.lsp.document_highlight` is set to `false`, but it was still called regardless.

## How Has This Been Tested?

Add this to `lv-config.lua` and verify that it's working
```lua
O.lsp.on_attach_callback = function(client, bufnr)
  -- ref: https://github.com/neovim/nvim-lspconfig#keybindings-and-completion
  local function buf_set_option(...)
    vim.api.nvim_buf_set_option(bufnr, ...)
  end
  --Enable completion triggered by <c-x><c-o>
  buf_set_option("omnifunc", "v:lua.vim.lsp.omnifunc")
end
```

