### PR TITLE
[Refactor] cleanup lv utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ O.keys.normal_mode = {
   {']d', '<PageDown>'},
 }
 -- if you just want to augment the existing ones then use the utility function
-require("lv-utils").add_keymap_insert_mode({ silent = true }, {
+require("utils").add_keymap_insert_mode({ silent = true }, {
   { "<C-s>", ":w<cr>" },
   { "<C-c>", "<ESC>" }
 })
@@ -175,7 +175,7 @@ In case you want to see all the settings inside LunarVim, run the following:
 
 ```bash
 cd /tmp
-lvim --headless +'lua require("lv-utils").generate_settings()' +qa && sort -o lv-settings.lua{,}
+lvim --headless +'lua require("utils").generate_settings()' +qa && sort -o lv-settings.lua{,}
 ```
 and then inspect `/tmp/lv-settings.lua` file
 

--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,9 @@ plugin_loader:load { plugins, O.user_plugins }
 vim.g.colors_name = O.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
 
 require "settings"
-require "utils"
+
+local augroups = require "augroups"
+require("utils.augroups").define_augroups(augroups)
 
 -- TODO: these guys need to be in language files
 -- require "lsp"

--- a/init.lua
+++ b/init.lua
@@ -25,7 +25,7 @@ plugin_loader:load { plugins, O.user_plugins }
 vim.g.colors_name = O.colorscheme -- Colorscheme must get called after plugins are loaded or it will break new installs.
 
 require "settings"
-require "lv-utils"
+require "utils"
 
 -- TODO: these guys need to be in language files
 -- require "lsp"

--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,8 @@ require "settings"
 
 local augroups = require "augroups"
 require("utils.augroups").define_augroups(augroups)
+local commands = require "commands"
+commands.load(commands.defaults)
 
 -- TODO: these guys need to be in language files
 -- require "lsp"

--- a/lua/augroups.lua
+++ b/lua/augroups.lua
@@ -45,20 +45,17 @@ return {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
   },
-  _buffer_bindings = {
-    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
-  },
   _auto_resize = {
-    -- will cause split windows to be resized evenly if main window is resized
+    -- Makes split windows resize evenly if main window is resized
     { "VimResized", "*", "wincmd =" },
   },
   _packer_compile = {
-    -- will cause split windows to be resized evenly if main window is resized
+    -- Runs PackerCompile when plugins.lua is updated
     { "BufWritePost", "plugins.lua", "PackerCompile" },
   },
 
   -- _fterm_lazygit = {
-  --   -- will cause esc key to exit lazy git
+  --   -- Makes esc key exit lazy git
   --   {"TermEnter", "*", "call LazyGitNativation()"}
   -- },
   -- _mode_switching = {

--- a/lua/augroups.lua
+++ b/lua/augroups.lua
@@ -1,0 +1,72 @@
+return {
+  _general_settings = {
+    {
+      "TextYankPost",
+      "*",
+      "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
+    },
+    {
+      "BufWinEnter",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    {
+      "BufWinEnter",
+      "dashboard",
+      "setlocal cursorline signcolumn=yes cursorcolumn number",
+    },
+    {
+      "BufRead",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    {
+      "BufNewFile",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    { "BufWritePost", "lv-config.lua", "lua require('utils').reload_lv_config()" },
+    -- { "VimLeavePre", "*", "set title set titleold=" },
+  },
+  _solidity = {
+    { "BufWinEnter", ".tf", "setlocal filetype=hcl" },
+    { "BufRead", "*.tf", "setlocal filetype=hcl" },
+    { "BufNewFile", "*.tf", "setlocal filetype=hcl" },
+  },
+  -- _solidity = {
+  --     {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
+  --     {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
+  -- },
+  -- _gemini = {
+  --     {'BufWinEnter', '.gmi', 'setlocal filetype=markdown'}, {'BufRead', '*.gmi', 'setlocal filetype=markdown'},
+  --     {'BufNewFile', '*.gmi', 'setlocal filetype=markdown'}
+  -- },
+  _markdown = {
+    { "FileType", "markdown", "setlocal wrap" },
+    { "FileType", "markdown", "setlocal spell" },
+  },
+  _buffer_bindings = {
+    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
+  },
+  _auto_resize = {
+    -- will cause split windows to be resized evenly if main window is resized
+    { "VimResized", "*", "wincmd =" },
+  },
+  _packer_compile = {
+    -- will cause split windows to be resized evenly if main window is resized
+    { "BufWritePost", "plugins.lua", "PackerCompile" },
+  },
+
+  -- _fterm_lazygit = {
+  --   -- will cause esc key to exit lazy git
+  --   {"TermEnter", "*", "call LazyGitNativation()"}
+  -- },
+  -- _mode_switching = {
+  --   -- will switch between absolute and relative line numbers depending on mode
+  --   {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
+  --   {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
+  --   {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
+  --   {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
+  -- },
+  _user_autocommands = O.user_autocommands,
+}

--- a/lua/commands.lua
+++ b/lua/commands.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+M.defaults = {
+  [[
+    function! QuickFixToggle()
+      if empty(filter(getwininfo(), 'v:val.quickfix'))
+        copen
+      else
+        cclose
+      endif
+    endfunction
+  ]],
+}
+
+M.load = function(commands)
+  for _, command in ipairs(commands) do
+    vim.cmd(command)
+  end
+end
+
+return M

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -82,7 +82,7 @@ M.setup = function()
 
   -- vim.g.dashboard_session_directory = CACHE_PATH..'/session'
   -- vim.g.dashboard_custom_footer = O.dashboard.footer
-  require("lv-utils").define_augroups {
+  require("utils").define_augroups {
     _dashboard = {
       -- seems to be nobuflisted that makes my stuff disapear will do more testing
       {

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -82,7 +82,7 @@ M.setup = function()
 
   -- vim.g.dashboard_session_directory = CACHE_PATH..'/session'
   -- vim.g.dashboard_custom_footer = O.dashboard.footer
-  require("utils").define_augroups {
+  require("utils.augroups").define_augroups {
     _dashboard = {
       -- seems to be nobuflisted that makes my stuff disapear will do more testing
       {

--- a/lua/core/formatter.lua
+++ b/lua/core/formatter.lua
@@ -1,6 +1,6 @@
 -- autoformat
 if O.format_on_save then
-  require("utils").define_augroups {
+  require("utils.augroups").define_augroups {
     autoformat = {
       {
         "BufWritePost",

--- a/lua/core/formatter.lua
+++ b/lua/core/formatter.lua
@@ -1,6 +1,6 @@
 -- autoformat
 if O.format_on_save then
-  require("lv-utils").define_augroups {
+  require("utils").define_augroups {
     autoformat = {
       {
         "BufWritePost",

--- a/lua/core/linter.lua
+++ b/lua/core/linter.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.setup = function()
   if O.lint_on_save then
-    require("lv-utils").define_augroups {
+    require("utils").define_augroups {
       autolint = {
         {
           "BufWritePost",

--- a/lua/core/linter.lua
+++ b/lua/core/linter.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.setup = function()
   if O.lint_on_save then
-    require("utils").define_augroups {
+    require("utils.augroups").define_augroups {
       autolint = {
         {
           "BufWritePost",

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -72,7 +72,7 @@ M.config = function()
         name = "Packer",
         c = { "<cmd>PackerCompile<cr>", "Compile" },
         i = { "<cmd>PackerInstall<cr>", "Install" },
-        r = { "<cmd>lua require('lv-utils').reload_lv_config()<cr>", "Reload" },
+        r = { "<cmd>lua require('utils').reload_lv_config()<cr>", "Reload" },
         s = { "<cmd>PackerSync<cr>", "Sync" },
         u = { "<cmd>PackerUpdate<cr>", "Update" },
       },

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,4 +1,4 @@
-local lv_utils = require "lv-utils"
+local utils = require "utils"
 
 local opts = {
   nnoremap = { noremap = true, silent = true },
@@ -103,11 +103,11 @@ local function get_user_keys(mode)
   end
 end
 
-lv_utils.add_keymap_normal_mode(opts.nnoremap, get_user_keys "normal_mode")
-lv_utils.add_keymap_insert_mode(opts.inoremap, get_user_keys "insert_mode")
-lv_utils.add_keymap_visual_mode(opts.vnoremap, get_user_keys "visual_mode")
-lv_utils.add_keymap_visual_block_mode(opts.xnoremap, get_user_keys "visual_block_mode")
-lv_utils.add_keymap_term_mode(opts.generic, get_user_keys "term_mode")
+utils.add_keymap_normal_mode(opts.nnoremap, get_user_keys "normal_mode")
+utils.add_keymap_insert_mode(opts.inoremap, get_user_keys "insert_mode")
+utils.add_keymap_visual_mode(opts.vnoremap, get_user_keys "visual_mode")
+utils.add_keymap_visual_block_mode(opts.xnoremap, get_user_keys "visual_block_mode")
+utils.add_keymap_term_mode(opts.generic, get_user_keys "term_mode")
 
 -- navigate tab completion with <c-j> and <c-k>
 -- runs conditionally

--- a/lua/lang/clang.lua
+++ b/lua/lang/clang.lua
@@ -60,7 +60,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "clangd" then
+  if require("utils").check_lsp_client_active "clangd" then
     return
   end
   local clangd_flags = { "--background-index" }

--- a/lua/lang/clojure.lua
+++ b/lua/lang/clojure.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "clojure_lsp" then
+  if require("utils").check_lsp_client_active "clojure_lsp" then
     return
   end
 

--- a/lua/lang/cmake.lua
+++ b/lua/lang/cmake.lua
@@ -23,7 +23,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "cmake" then
+  if require("utils").check_lsp_client_active "cmake" then
     return
   end
 

--- a/lua/lang/cs.lua
+++ b/lua/lang/cs.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "omnisharp" then
+  if require("utils").check_lsp_client_active "omnisharp" then
     return
   end
 

--- a/lua/lang/css.lua
+++ b/lua/lang/css.lua
@@ -53,7 +53,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "cssls" then
+  if not require("utils").check_lsp_client_active "cssls" then
     local capabilities = vim.lsp.protocol.make_client_capabilities()
     capabilities.textDocument.completion.completionItem.snippetSupport = true
     -- npm install -g vscode-css-languageserver-bin

--- a/lua/lang/dart.lua
+++ b/lua/lang/dart.lua
@@ -34,7 +34,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "dartls" then
+  if require("utils").check_lsp_client_active "dartls" then
     return
   end
 

--- a/lua/lang/dockerfile.lua
+++ b/lua/lang/dockerfile.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "dockerls" then
+  if require("utils").check_lsp_client_active "dockerls" then
     return
   end
 

--- a/lua/lang/elixir.lua
+++ b/lua/lang/elixir.lua
@@ -36,7 +36,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "elixirls" then
+  if require("utils").check_lsp_client_active "elixirls" then
     return
   end
 

--- a/lua/lang/elm.lua
+++ b/lua/lang/elm.lua
@@ -24,7 +24,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "elmls" then
+  if require("utils").check_lsp_client_active "elmls" then
     return
   end
 

--- a/lua/lang/erlang.lua
+++ b/lua/lang/erlang.lua
@@ -15,7 +15,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "erlangls" then
+  if require("utils").check_lsp_client_active "erlangls" then
     return
   end
 

--- a/lua/lang/euphoria3.lua
+++ b/lua/lang/euphoria3.lua
@@ -16,7 +16,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "elixirls" then
+  if require("utils").check_lsp_client_active "elixirls" then
     return
   end
 

--- a/lua/lang/go.lua
+++ b/lua/lang/go.lua
@@ -41,7 +41,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "gopls" then
+  if not require("utils").check_lsp_client_active "gopls" then
     require("lspconfig").gopls.setup {
       cmd = { O.lang.go.lsp.path },
       settings = { gopls = { analyses = { unusedparams = true }, staticcheck = true } },

--- a/lua/lang/graphql.lua
+++ b/lua/lang/graphql.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "graphql" then
+  if require("utils").check_lsp_client_active "graphql" then
     return
   end
 

--- a/lua/lang/html.lua
+++ b/lua/lang/html.lua
@@ -25,7 +25,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "html" then
+  if not require("utils").check_lsp_client_active "html" then
     -- npm install -g vscode-html-languageserver-bin
     local capabilities = vim.lsp.protocol.make_client_capabilities()
     capabilities.textDocument.completion.completionItem.snippetSupport = true

--- a/lua/lang/java.lua
+++ b/lua/lang/java.lua
@@ -45,7 +45,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "jdtls" then
+  if require("utils").check_lsp_client_active "jdtls" then
     return
   end
 

--- a/lua/lang/json.lua
+++ b/lua/lang/json.lua
@@ -41,7 +41,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "jsonls" then
+  if require("utils").check_lsp_client_active "jsonls" then
     return
   end
 

--- a/lua/lang/julia.lua
+++ b/lua/lang/julia.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "julials" then
+  if require("utils").check_lsp_client_active "julials" then
     return
   end
   -- Add the following lines to a new julia file, e.g. install.jl

--- a/lua/lang/kotlin.lua
+++ b/lua/lang/kotlin.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "kotlin_language_server" then
+  if require("utils").check_lsp_client_active "kotlin_language_server" then
     return
   end
 

--- a/lua/lang/lua.lua
+++ b/lua/lang/lua.lua
@@ -44,7 +44,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "sumneko_lua" then
+  if not require("utils").check_lsp_client_active "sumneko_lua" then
     -- https://github.com/sumneko/lua-language-server/wiki/Build-and-Run-(Standalone)
     local sumneko_main = string.gsub(O.lang.lua.lsp.path, "sumneko-lua-language-server", "main.lua")
 

--- a/lua/lang/php.lua
+++ b/lua/lang/php.lua
@@ -51,7 +51,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "intelephense" then
+  if require("utils").check_lsp_client_active "intelephense" then
     return
   end
 

--- a/lua/lang/python.lua
+++ b/lua/lang/python.lua
@@ -55,7 +55,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "pyright" then
+  if require("utils").check_lsp_client_active "pyright" then
     return
   end
   -- npm i -g pyright

--- a/lua/lang/r.lua
+++ b/lua/lang/r.lua
@@ -41,7 +41,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "r_language_server" then
+  if require("utils").check_lsp_client_active "r_language_server" then
     return
   end
   -- R -e 'install.packages("languageserver",repos = "http://cran.us.r-project.org")'

--- a/lua/lang/ruby.lua
+++ b/lua/lang/ruby.lua
@@ -44,11 +44,11 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "sorbet" then
+  if not require("utils").check_lsp_client_active "sorbet" then
     require("lspconfig").sorbet.setup {}
   end
 
-  if not require("lv-utils").check_lsp_client_active "solargraph" then
+  if not require("utils").check_lsp_client_active "solargraph" then
     -- If you are using rvm, make sure to change below configuration
     require("lspconfig").solargraph.setup {
       cmd = { O.lang.ruby.lsp.path, "stdio" },

--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -48,7 +48,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "rust_analyzer" then
+  if require("utils").check_lsp_client_active "rust_analyzer" then
     return
   end
 

--- a/lua/lang/sh.lua
+++ b/lua/lang/sh.lua
@@ -47,7 +47,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "bashls" then
+  if not require("utils").check_lsp_client_active "bashls" then
     -- npm i -g bash-language-server
     require("lspconfig").bashls.setup {
       cmd = { O.lang.sh.lsp.path, "start" },

--- a/lua/lang/svelte.lua
+++ b/lua/lang/svelte.lua
@@ -19,7 +19,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "svelte" then
+  if require("utils").check_lsp_client_active "svelte" then
     return
   end
 

--- a/lua/lang/swift.lua
+++ b/lua/lang/swift.lua
@@ -36,7 +36,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "sourcekit" then
+  if require("utils").check_lsp_client_active "sourcekit" then
     return
   end
 

--- a/lua/lang/terraform.lua
+++ b/lua/lang/terraform.lua
@@ -38,7 +38,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "terraformls" then
+  if require("utils").check_lsp_client_active "terraformls" then
     return
   end
 

--- a/lua/lang/tex.lua
+++ b/lua/lang/tex.lua
@@ -52,7 +52,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "texlab" then
+  if require("utils").check_lsp_client_active "texlab" then
     return
   end
 

--- a/lua/lang/vim.lua
+++ b/lua/lang/vim.lua
@@ -21,7 +21,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "vimls" then
+  if require("utils").check_lsp_client_active "vimls" then
     return
   end
 

--- a/lua/lang/vue.lua
+++ b/lua/lang/vue.lua
@@ -30,10 +30,10 @@ M.format = function()
   local ft = vim.bo.filetype
   O.formatters.filetype[ft] = {
     function()
-      local lv_utils = require "lv-utils"
+      local utils = require "utils"
       return {
         exe = formatter_instance,
-        args = lv_utils.gsub_args(O.lang.vue.formatter.args),
+        args = utils.gsub_args(O.lang.vue.formatter.args),
         stdin = O.lang.vue.formatter.stdin,
       }
     end,
@@ -50,7 +50,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "vuels" then
+  if require("utils").check_lsp_client_active "vuels" then
     return
   end
 

--- a/lua/lang/yaml.lua
+++ b/lua/lang/yaml.lua
@@ -35,7 +35,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "yamlls" then
+  if require("utils").check_lsp_client_active "yamlls" then
     return
   end
 

--- a/lua/lang/zig.lua
+++ b/lua/lang/zig.lua
@@ -36,7 +36,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "zls" then
+  if require("utils").check_lsp_client_active "zls" then
     return
   end
   -- Because lspinstall don't support zig yet,

--- a/lua/lang/zsh.lua
+++ b/lua/lang/zsh.lua
@@ -17,7 +17,7 @@ M.lint = function()
   -- zsh
   local zsh_arguments = {}
 
-  if not require("lv-utils").check_lsp_client_active "efm" then
+  if not require("utils").check_lsp_client_active "efm" then
     require("lspconfig").efm.setup {
       -- init_options = {initializationOptions},
       cmd = { DATA_PATH .. "/lspinstall/efm/efm-langserver" },
@@ -35,7 +35,7 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if not require("lv-utils").check_lsp_client_active "bashls" then
+  if not require("utils").check_lsp_client_active "bashls" then
     -- npm i -g bash-language-server
     require("lspconfig").bashls.setup {
       cmd = { O.lang.zsh.lsp.path, "start" },

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -251,7 +251,7 @@ function lsp_config.tsserver_on_attach(client, _)
   -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", {silent = true})
 end
 
-require("lv-utils").define_augroups {
+require("utils").define_augroups {
   _general_lsp = {
     { "FileType", "lspinfo", "nnoremap <silent> <buffer> q :q<CR>" },
   },

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -251,7 +251,7 @@ function lsp_config.tsserver_on_attach(client, _)
   -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", {silent = true})
 end
 
-require("utils").define_augroups {
+require("utils.augroups").define_augroups {
   _general_lsp = {
     { "FileType", "lspinfo", "nnoremap <silent> <buffer> q :q<CR>" },
   },

--- a/lua/lsp/tsserver-ls.lua
+++ b/lua/lsp/tsserver-ls.lua
@@ -34,7 +34,7 @@ require("formatter.config").set_defaults {
   filetype = O.formatters.filetype,
 }
 
-if require("lv-utils").check_lsp_client_active "tsserver" then
+if require("utils").check_lsp_client_active "tsserver" then
   return
 end
 

--- a/lua/utils/augroups.lua
+++ b/lua/utils/augroups.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+M.define_augroups = function(definitions)
+  -- Create autocommand groups based on the passed definitions
+  --
+  -- The key will be the name of the group, and each definition
+  -- within the group should have:
+  --    1. Trigger
+  --    2. Pattern
+  --    3. Text
+  -- just like how they would normally be defined from Vim itself
+  for group_name, definition in pairs(definitions) do
+    vim.cmd("augroup " .. group_name)
+    vim.cmd "autocmd!"
+
+    for _, def in pairs(definition) do
+      local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")
+      vim.cmd(command)
+    end
+
+    vim.cmd "augroup END"
+  end
+end
+
+return M

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -1,4 +1,4 @@
-local lv_utils = {}
+local utils = {}
 
 -- recursive Print (structure, limit, separator)
 local function r_inspect_settings(structure, limit, separator)
@@ -42,7 +42,7 @@ local function r_inspect_settings(structure, limit, separator)
   return limit - 1
 end
 
-function lv_utils.generate_settings()
+function utils.generate_settings()
   -- Opens a file in append mode
   local file = io.open("lv-settings.lua", "w")
 
@@ -56,7 +56,7 @@ function lv_utils.generate_settings()
   io.close(file)
 end
 
-function lv_utils.reload_lv_config()
+function utils.reload_lv_config()
   vim.cmd "source ~/.config/lvim/lv-config.lua"
   vim.cmd "source ~/.local/share/lunarvim/lvim/lua/plugins.lua"
   local plugins = require "plugins"
@@ -69,7 +69,7 @@ function lv_utils.reload_lv_config()
   -- vim.cmd ":PackerClean"
 end
 
-function lv_utils.check_lsp_client_active(name)
+function utils.check_lsp_client_active(name)
   local clients = vim.lsp.get_active_clients()
   for _, client in pairs(clients) do
     if client.name == name then
@@ -79,33 +79,33 @@ function lv_utils.check_lsp_client_active(name)
   return false
 end
 
-function lv_utils.add_keymap(mode, opts, keymaps)
+function utils.add_keymap(mode, opts, keymaps)
   for _, keymap in ipairs(keymaps) do
     vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)
   end
 end
 
-function lv_utils.add_keymap_normal_mode(opts, keymaps)
-  lv_utils.add_keymap("n", opts, keymaps)
+function utils.add_keymap_normal_mode(opts, keymaps)
+  utils.add_keymap("n", opts, keymaps)
 end
 
-function lv_utils.add_keymap_visual_mode(opts, keymaps)
-  lv_utils.add_keymap("v", opts, keymaps)
+function utils.add_keymap_visual_mode(opts, keymaps)
+  utils.add_keymap("v", opts, keymaps)
 end
 
-function lv_utils.add_keymap_visual_block_mode(opts, keymaps)
-  lv_utils.add_keymap("x", opts, keymaps)
+function utils.add_keymap_visual_block_mode(opts, keymaps)
+  utils.add_keymap("x", opts, keymaps)
 end
 
-function lv_utils.add_keymap_insert_mode(opts, keymaps)
-  lv_utils.add_keymap("i", opts, keymaps)
+function utils.add_keymap_insert_mode(opts, keymaps)
+  utils.add_keymap("i", opts, keymaps)
 end
 
-function lv_utils.add_keymap_term_mode(opts, keymaps)
-  lv_utils.add_keymap("t", opts, keymaps)
+function utils.add_keymap_term_mode(opts, keymaps)
+  utils.add_keymap("t", opts, keymaps)
 end
 
-function lv_utils.define_augroups(definitions) -- {{{1
+function utils.define_augroups(definitions) -- {{{1
   -- Create autocommand groups based on the passed definitions
   --
   -- The key will be the name of the group, and each definition
@@ -127,12 +127,12 @@ function lv_utils.define_augroups(definitions) -- {{{1
   end
 end
 
-function lv_utils.unrequire(m)
+function utils.unrequire(m)
   package.loaded[m] = nil
   _G[m] = nil
 end
 
-lv_utils.define_augroups {
+utils.define_augroups {
 
   _general_settings = {
     {
@@ -160,7 +160,7 @@ lv_utils.define_augroups {
       "*",
       "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
     },
-    { "BufWritePost", "lv-config.lua", "lua require('lv-utils').reload_lv_config()" },
+    { "BufWritePost", "lv-config.lua", "lua require('utils').reload_lv_config()" },
     -- { "VimLeavePre", "*", "set title set titleold=" },
   },
   _solidity = {
@@ -206,7 +206,7 @@ lv_utils.define_augroups {
   _user_autocommands = O.user_autocommands,
 }
 
-function lv_utils.gsub_args(args)
+function utils.gsub_args(args)
   if args == nil or type(args) ~= "table" then
     return args
   end
@@ -227,6 +227,6 @@ vim.cmd [[
 endfunction
 ]]
 
-return lv_utils
+return utils
 
 -- TODO: find a new home for these autocommands

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -121,16 +121,4 @@ function utils.gsub_args(args)
   return args
 end
 
-vim.cmd [[
-  function! QuickFixToggle()
-    if empty(filter(getwininfo(), 'v:val.quickfix'))
-      copen
-    else
-      cclose
-    endif
-endfunction
-]]
-
 return utils
-
--- TODO: find a new home for these autocommands

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -105,106 +105,10 @@ function utils.add_keymap_term_mode(opts, keymaps)
   utils.add_keymap("t", opts, keymaps)
 end
 
-function utils.define_augroups(definitions) -- {{{1
-  -- Create autocommand groups based on the passed definitions
-  --
-  -- The key will be the name of the group, and each definition
-  -- within the group should have:
-  --    1. Trigger
-  --    2. Pattern
-  --    3. Text
-  -- just like how they would normally be defined from Vim itself
-  for group_name, definition in pairs(definitions) do
-    vim.cmd("augroup " .. group_name)
-    vim.cmd "autocmd!"
-
-    for _, def in pairs(definition) do
-      local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")
-      vim.cmd(command)
-    end
-
-    vim.cmd "augroup END"
-  end
-end
-
 function utils.unrequire(m)
   package.loaded[m] = nil
   _G[m] = nil
 end
-
-utils.define_augroups {
-
-  _general_settings = {
-    {
-      "TextYankPost",
-      "*",
-      "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
-    },
-    {
-      "BufWinEnter",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    {
-      "BufWinEnter",
-      "dashboard",
-      "setlocal cursorline signcolumn=yes cursorcolumn number",
-    },
-    {
-      "BufRead",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    {
-      "BufNewFile",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    { "BufWritePost", "lv-config.lua", "lua require('utils').reload_lv_config()" },
-    -- { "VimLeavePre", "*", "set title set titleold=" },
-  },
-  _solidity = {
-    { "BufWinEnter", ".tf", "setlocal filetype=hcl" },
-    { "BufRead", "*.tf", "setlocal filetype=hcl" },
-    { "BufNewFile", "*.tf", "setlocal filetype=hcl" },
-  },
-  -- _solidity = {
-  --     {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
-  --     {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
-  -- },
-  -- _gemini = {
-  --     {'BufWinEnter', '.gmi', 'setlocal filetype=markdown'}, {'BufRead', '*.gmi', 'setlocal filetype=markdown'},
-  --     {'BufNewFile', '*.gmi', 'setlocal filetype=markdown'}
-  -- },
-  _markdown = {
-    { "FileType", "markdown", "setlocal wrap" },
-    { "FileType", "markdown", "setlocal spell" },
-  },
-  _buffer_bindings = {
-    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
-  },
-  _auto_resize = {
-    -- will cause split windows to be resized evenly if main window is resized
-    { "VimResized", "*", "wincmd =" },
-  },
-  _packer_compile = {
-    -- will cause split windows to be resized evenly if main window is resized
-    { "BufWritePost", "plugins.lua", "PackerCompile" },
-  },
-
-  -- _fterm_lazygit = {
-  --   -- will cause esc key to exit lazy git
-  --   {"TermEnter", "*", "call LazyGitNativation()"}
-  -- },
-  -- _mode_switching = {
-  --   -- will switch between absolute and relative line numbers depending on mode
-  --   {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
-  --   {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
-  --   {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
-  --   {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
-  -- },
-  _user_autocommands = O.user_autocommands,
-}
 
 function utils.gsub_args(args)
   if args == nil or type(args) ~= "table" then

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -29,7 +29,7 @@ O.keys.leader_key = "space"
 --   {'<S-Tab>', ':bprevious<CR>'},
 -- }
 -- if you just want to augment the existing ones then use the utility function
--- require("lv-utils").add_keymap_insert_mode({ silent = true }, {
+-- require("utils").add_keymap_insert_mode({ silent = true }, {
 -- { "<C-s>", ":w<cr>" },
 -- { "<C-c>", "<ESC>" },
 -- })

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -29,7 +29,7 @@ O.keys.leader_key = "space"
 --   {'<S-Tab>', ':bprevious<CR>'},
 -- }
 -- if you just want to augment the existing ones then use the utility function
--- require("lv-utils").add_keymap_insert_mode({ silent = true }, {
+-- require("utils").add_keymap_insert_mode({ silent = true }, {
 -- { "<C-s>", ":w<cr>" },
 -- { "<C-c>", "<ESC>" },
 -- })


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

#### Motivation:
I think lv-utils is a big amalgam of code that we don't know where to put and is becoming uglier the bigger it grows.
Additionally, there is code interpreted at load time which makes `require "lv-utils"` from init.lua hard to understand (what does it do and why do I have to switch files to understand).
Finally, since we renamed `lv-plugins` I thought it coherent to rename `lv-utils` to `utils` (do we agree that this lv- prefix should not be there?).

#### What it does:
I always advise to check commit by commit for that :)
