### PR TITLE
[Feature]: Add sorbet lsp for ruby

### DIFF
--- a/lua/lang/ruby.lua
+++ b/lua/lang/ruby.lua
@@ -41,24 +41,26 @@ M.lint = function()
 end
 
 M.lsp = function()
-  if require("lv-utils").check_lsp_client_active "solargraph" then
-    return
+  if not require("lv-utils").check_lsp_client_active "sorbet" then
+    require("lspconfig").sorbet.setup {}
   end
 
-  -- If you are using rvm, make sure to change below configuration
-  require("lspconfig").solargraph.setup {
-    cmd = { DATA_PATH .. "/lspinstall/ruby/solargraph/solargraph", "stdio" },
-    on_attach = require("lsp").common_on_attach,
-    handlers = {
-      ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
-        virtual_text = O.lang.ruby.diagnostics.virtual_text,
-        signs = O.lang.ruby.diagnostics.signs,
-        underline = O.lang.ruby.diagnostics.underline,
-        update_in_insert = true,
-      }),
-    },
-    filetypes = O.lang.ruby.filetypes,
-  }
+  if not require("lv-utils").check_lsp_client_active "solargraph" then
+    -- If you are using rvm, make sure to change below configuration
+    require("lspconfig").solargraph.setup {
+      cmd = { DATA_PATH .. "/lspinstall/ruby/solargraph/solargraph", "stdio" },
+      on_attach = require("lsp").common_on_attach,
+      handlers = {
+        ["textDocument/publishDiagnostics"] = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
+          virtual_text = O.lang.ruby.diagnostics.virtual_text,
+          signs = O.lang.ruby.diagnostics.signs,
+          underline = O.lang.ruby.diagnostics.underline,
+          update_in_insert = true,
+        }),
+      },
+      filetypes = O.lang.ruby.filetypes,
+    }
+  end
 end
 
 M.dap = function()


### PR DESCRIPTION
# Description

The [sorbet lsp server is included](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#sorbet) in nvim-lspconfig. This adds support for this in addition to the solargraph support that was already there.

## How Has This Been Tested?

I tested it on my project that uses sorbet, and it worked with no other setup:

<img width="651" alt="image" src="https://user-images.githubusercontent.com/1973/126222210-e2340de7-cfb1-41b7-a793-eeaf0f2b2d74.png">

