### PR TITLE
[Feature] replace vim-rooter with lsp-rooter

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -111,13 +111,8 @@ return {
     end,
   },
 
-  -- vim-rooter
-  {
-    "airblade/vim-rooter",
-    config = function()
-      vim.g.rooter_silent_chdir = 1
-    end,
-  },
+  -- lsp-rooter
+  { "ahmedkhalf/lsp-rooter.nvim" },
 
   -- Icons
   { "kyazdani42/nvim-web-devicons" },

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -112,7 +112,7 @@ return {
   },
 
   -- lsp-rooter
-  { 
+  {
     "ahmedkhalf/lsp-rooter.nvim",
     event = "BufRead",
   },

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -112,7 +112,10 @@ return {
   },
 
   -- lsp-rooter
-  { "ahmedkhalf/lsp-rooter.nvim" },
+  { 
+    "ahmedkhalf/lsp-rooter.nvim",
+    event = "BufRead",
+  },
 
   -- Icons
   { "kyazdani42/nvim-web-devicons" },


### PR DESCRIPTION
# Description

Currently `vim-rooter` doesn't work, when editing a file the working directory doesn't change, need to `: cd` manually 
`lsp-rooter` fixes that, now when `:e` a file outside of the working directory, the working directory will change automatically, so finding files, sidebar, terminal will all work on that new directory 

## How Has This Been Tested?

- `:e ~/file/outside/working-dir`
- open the sidebar, terminal or finding files, all should work on the new directory 

