### PR TITLE
WIP: Minor comments changes, and proposed refactor/cleanup to lang/rust.lua

### DIFF
--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -7,12 +7,13 @@ M.config = function()
       parameter_hints_prefix = "<-",
       other_hints_prefix = "=>", -- prefix for all the other hints (type, chaining)
     },
-    -- @usage can be clippy
+    -- @usage can be rustfmt
     formatter = {
       exe = "rustfmt",
       args = { "--emit=stdout", "--edition=2018" },
       stdin = true,
     },
+    -- @usage can be clippy
     linter = "",
     diagnostics = {
       virtual_text = { spacing = 0, prefix = "" },

--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -42,7 +42,7 @@ end
 
 M.lint = function()
   -- TODO: implement linters (if applicable)
-  require("lint).linters_by_fit =  {
+  require("lint").linters_by_fit =  {
     rust = O.lang.rust.linters,
   }
   -- return "No linters configured!"

--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -42,7 +42,10 @@ end
 
 M.lint = function()
   -- TODO: implement linters (if applicable)
-  return "No linters configured!"
+  require("lint).linters_by_fit =  {
+    rust = O.lang.rust.linters,
+  }
+  -- return "No linters configured!"
 end
 
 M.lsp = function()

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -68,7 +68,7 @@ O.lang.python.analysis.use_library_code_types = true
 O.lang.tsserver.linter = nil
 
 -- rust
--- O.lang.rust.rust_tools = true
+-- O.lang.rust.rust_tools.active = true
 -- O.lang.rust.formatter = {
 --   exe = "rustfmt",
 --   args = {"--emit=stdout", "--edition=2018"},


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

* Fixed an issue with the lv-config.example.lua rust_tools example.
* Moved the @usage comment for rustfmt down to linter, and created a separate comment for the formatter.
* Proposed changes:
* @abzcoding I am tagging you here since you seem to be the person who has written most of the rust lang config.  I am proposing to remove the values where we are using the default values. This would remove what I consider "unnessecary" code(unless there is a reason behind it that I am not thinking about), and clean up the rust file somewhat. 
* Add propper clippy(or another linter) support for rust files. 

Fixes #(issue)

## How Has This Been Tested?

TBD