### PR TITLE
[Feature] Support multiple formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ O.treesitter.highlight.enabled = true
 
 -- lua
 O.lang.lua.autoformat = false
-O.lang.lua.formatter = 'lua-format'
+O.lang.lua.formatters = { 'stylua' }
 
 -- javascript
 O.lang.tsserver.formatter = 'prettier'
@@ -130,16 +130,21 @@ O.lang.tsserver.autoformat = true
 -- python
 O.lang.python.diagnostics.virtual_text = true
 O.lang.python.analysis.use_library_code_types = true
--- to change default formatter from yapf to black
--- O.lang.python.formatter.exe = "black"
--- O.lang.python.formatter.args = {"-"}
+-- To configure multiple formatters with an existing profile
+-- O.lang.python.formatters = { "black", "yapf", "isort" }
+-- To configure a new formatter
+-- O.lang.python.formatters.my_new_formatter = {
+--   exe = "my_formatter",
+--   args = {},
+--   stdin = true,
+-- }
 -- To change enabled linters
 -- https://github.com/mfussenegger/nvim-lint#available-linters
 -- O.lang.python.linters = { "flake8", "pylint", "mypy", ... }
 
 -- go
 -- to change default formatter from gofmt to goimports
--- O.lang.formatter.go.exe = "goimports"
+-- O.lang.go.formatters = { "goimports" }
 
 -- Additional Plugins
 -- O.user_plugins = {

--- a/lua/lang/clang.lua
+++ b/lua/lang/clang.lua
@@ -10,10 +10,15 @@ M.config = function()
     cross_file_rename = true,
     header_insertion = "never",
     filetypes = { "c", "cpp", "objc" },
-    formatter = {
-      exe = "clang-format",
-      args = {},
-      stdin = true,
+    formatters = {
+      {
+        exe = "clang-format",
+        args = {},
+        stdin = true,
+        cwd = function()
+          return vim.fn.expand "%:h:p"
+        end,
+      },
     },
     linters = {
       "cppcheck",
@@ -32,19 +37,10 @@ M.config = function()
 end
 
 M.format = function()
-  local shared_config = {
-    function()
-      return {
-        exe = O.lang.clang.formatter.exe,
-        args = O.lang.clang.formatter.args,
-        stdin = O.lang.clang.formatter.stdin,
-        cwd = vim.fn.expand "%:h:p",
-      }
-    end,
-  }
-  O.formatters.filetype["c"] = shared_config
-  O.formatters.filetype["cpp"] = shared_config
-  O.formatters.filetype["objc"] = shared_config
+  local formatters = require("lv-utils").wrap_formatters(O.lang.clang.formatters)
+  O.formatters.filetype["c"] = formatters
+  O.formatters.filetype["cpp"] = formatters
+  O.formatters.filetype["objc"] = formatters
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/clang.lua
+++ b/lua/lang/clang.lua
@@ -1,5 +1,16 @@
 local M = {}
 
+local formatter_profiles = {
+  ["clang-format"] = {
+    exe = "clang-format",
+    args = {},
+    stdin = true,
+    cwd = function()
+      return vim.fn.expand "%:h:p"
+    end,
+  },
+}
+
 M.config = function()
   O.lang.clang = {
     diagnostics = {
@@ -11,14 +22,7 @@ M.config = function()
     header_insertion = "never",
     filetypes = { "c", "cpp", "objc" },
     formatters = {
-      {
-        exe = "clang-format",
-        args = {},
-        stdin = true,
-        cwd = function()
-          return vim.fn.expand "%:h:p"
-        end,
-      },
+      "clang-format",
     },
     linters = {
       "cppcheck",
@@ -37,7 +41,7 @@ M.config = function()
 end
 
 M.format = function()
-  local formatters = require("lv-utils").wrap_formatters(O.lang.clang.formatters)
+  local formatters = require("lv-utils").wrap_formatters(O.lang.clang.formatters, formatter_profiles)
   O.formatters.filetype["c"] = formatters
   O.formatters.filetype["cpp"] = formatters
   O.formatters.filetype["objc"] = formatters

--- a/lua/lang/cmake.lua
+++ b/lua/lang/cmake.lua
@@ -1,10 +1,18 @@
 local M = {}
 
+local formatter_profiles = {
+  ["cmake-format"] = {
+    exe = "cmake-format",
+    args = { "-i" },
+    stdin = false,
+    tempfile_prefix = ".formatter",
+  },
+}
+
 M.config = function()
   O.lang.cmake = {
-    formatter = {
-      exe = "clang-format",
-      args = {},
+    formatters = {
+      "cmake-format",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/cmake/venv/bin/cmake-language-server",
@@ -13,8 +21,11 @@ M.config = function()
 end
 
 M.format = function()
-  -- TODO: implement formatters (if applicable)
-  return "No formatters configured!"
+  O.formatters.filetype["cmake"] = require("lv-utils").wrap_formatters(O.lang.cmake.formatters, formatter_profiles)
+  require("formatter.config").set_defaults {
+    logging = false,
+    filetype = O.formatters.filetype,
+  }
 end
 
 M.lint = function()

--- a/lua/lang/css.lua
+++ b/lua/lang/css.lua
@@ -12,16 +12,20 @@ local function find_local_prettier()
   return prettier_instance
 end
 
+local formatter_profiles = {
+  prettier = {
+    exe = find_local_prettier,
+    args = function()
+      return { "--stdin-filepath", vim.fn.fnameescape(vim.api.nvim_buf_get_name(0)) }
+    end,
+  },
+}
+
 M.config = function()
   O.lang.css = {
     virtual_text = true,
     formatters = {
-      {
-        exe = find_local_prettier,
-        args = function()
-          return { "--stdin-filepath", vim.fn.fnameescape(vim.api.nvim_buf_get_name(0)) }
-        end,
-      },
+      "prettier",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/css/vscode-css/css-language-features/server/dist/node/cssServerMain.js",
@@ -31,7 +35,7 @@ end
 
 M.format = function()
   local ft = vim.bo.filetype
-  O.formatters.filetype[ft] = require("lv-utils").wrap_formatters(O.lang.css.formatters)
+  O.formatters.filetype[ft] = require("lv-utils").wrap_formatters(O.lang.css.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/dart.lua
+++ b/lua/lang/dart.lua
@@ -1,20 +1,24 @@
 local M = {}
 
+local formatter_profiles = {
+  dart = {
+    exe = "dart",
+    args = { "format" },
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.dart = {
     sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
     formatters = {
-      {
-        exe = "dart",
-        args = { "format" },
-        stdin = true,
-      },
+      "dart",
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["dart"] = require("lv-utils").wrap_formatters(O.lang.dart.formatters)
+  O.formatters.filetype["dart"] = require("lv-utils").wrap_formatters(O.lang.dart.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/dart.lua
+++ b/lua/lang/dart.lua
@@ -3,24 +3,18 @@ local M = {}
 M.config = function()
   O.lang.dart = {
     sdk_path = "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
-    formatter = {
-      exe = "dart",
-      args = { "format" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "dart",
+        args = { "format" },
+        stdin = true,
+      },
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["dart"] = {
-    function()
-      return {
-        exe = O.lang.dart.formatter.exe,
-        args = O.lang.dart.formatter.args,
-        stdin = O.lang.dart.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["dart"] = require("lv-utils").wrap_formatters(O.lang.dart.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/elixir.lua
+++ b/lua/lang/elixir.lua
@@ -2,10 +2,12 @@ local M = {}
 
 M.config = function()
   O.lang.elixir = {
-    formatter = {
-      exe = "mix",
-      args = { "format" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "mix",
+        args = { "format" },
+        stdin = true,
+      },
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/elixir/elixir-ls/language_server.sh",
@@ -14,15 +16,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["elixir"] = {
-    function()
-      return {
-        exe = O.lang.elixir.formatter.exe,
-        args = O.lang.elixir.formatter.args,
-        stdin = O.lang.elixir.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["elixir"] = require("lv-utils").wrap_formatters(O.lang.elixir.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/elixir.lua
+++ b/lua/lang/elixir.lua
@@ -1,13 +1,17 @@
 local M = {}
 
+local formatter_profiles = {
+  mix = {
+    exe = "mix",
+    args = { "format" },
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.elixir = {
     formatters = {
-      {
-        exe = "mix",
-        args = { "format" },
-        stdin = true,
-      },
+      "mix",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/elixir/elixir-ls/language_server.sh",
@@ -16,7 +20,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["elixir"] = require("lv-utils").wrap_formatters(O.lang.elixir.formatters)
+  O.formatters.filetype["elixir"] = require("lv-utils").wrap_formatters(O.lang.elixir.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/go.lua
+++ b/lua/lang/go.lua
@@ -2,10 +2,12 @@ local M = {}
 
 M.config = function()
   O.lang.go = {
-    formatter = {
-      exe = "gofmt",
-      args = {},
-      stdin = true,
+    formatters = {
+      {
+        exe = "gofmt",
+        args = {},
+        stdin = true,
+      },
     },
     linters = {
       "golangcilint",
@@ -18,15 +20,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["go"] = {
-    function()
-      return {
-        exe = O.lang.go.formatter.exe,
-        args = O.lang.go.formatter.args,
-        stdin = O.lang.go.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["go"] = require("lv-utils").wrap_formatters(O.lang.go.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/go.lua
+++ b/lua/lang/go.lua
@@ -6,6 +6,11 @@ local formatter_profiles = {
     args = {},
     stdin = true,
   },
+  goimports = {
+    exe = "goimports",
+    args = {},
+    stdin = true,
+  },
 }
 
 M.config = function()

--- a/lua/lang/go.lua
+++ b/lua/lang/go.lua
@@ -1,13 +1,17 @@
 local M = {}
 
+local formatter_profiles = {
+  gofmt = {
+    exe = "gofmt",
+    args = {},
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.go = {
     formatters = {
-      {
-        exe = "gofmt",
-        args = {},
-        stdin = true,
-      },
+      "gofmt",
     },
     linters = {
       "golangcilint",
@@ -20,7 +24,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["go"] = require("lv-utils").wrap_formatters(O.lang.go.formatters)
+  O.formatters.filetype["go"] = require("lv-utils").wrap_formatters(O.lang.go.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/java.lua
+++ b/lua/lang/java.lua
@@ -12,23 +12,29 @@ local function find_local_prettier()
   return prettier_instance
 end
 
+local formatter_profiles = {
+  prettier = {
+    exe = find_local_prettier,
+    args = function()
+      return { "--stdin-filepath", vim.api.nvim_buf_get_name(0) }
+    end,
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.java = {
     java_tools = {
       active = false,
     },
     formatters = {
-      {
-        exe = find_local_prettier,
-        args = function() { "--stdin-filepath", vim.api.nvim_buf_get_name(0) } end,
-        stdin = true,
-      },
+      "prettier",
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["java"] = require("lv-utils").wrap_formatters(O.lang.java.formatters)
+  O.formatters.filetype["java"] = require("lv-utils").wrap_formatters(O.lang.java.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/json.lua
+++ b/lua/lang/json.lua
@@ -7,10 +7,12 @@ M.config = function()
       signs = true,
       underline = true,
     },
-    formatter = {
-      exe = "python",
-      args = { "-m", "json.tool" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "python",
+        args = { "-m", "json.tool" },
+        stdin = true,
+      },
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/json/vscode-json/json-language-features/server/dist/node/jsonServerMain.js",
@@ -19,15 +21,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["json"] = {
-    function()
-      return {
-        exe = O.lang.json.formatter.exe,
-        args = O.lang.json.formatter.args,
-        stdin = O.lang.json.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["json"] = require("lv-utils").wrap_formatters(O.lang.json.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/json.lua
+++ b/lua/lang/json.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+local formatter_profiles = {
+  python = {
+    exe = "python",
+    args = { "-m", "json.tool" },
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.json = {
     diagnostics = {
@@ -8,11 +16,7 @@ M.config = function()
       underline = true,
     },
     formatters = {
-      {
-        exe = "python",
-        args = { "-m", "json.tool" },
-        stdin = true,
-      },
+      "python",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/json/vscode-json/json-language-features/server/dist/node/jsonServerMain.js",
@@ -21,7 +25,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["json"] = require("lv-utils").wrap_formatters(O.lang.json.formatters)
+  O.formatters.filetype["json"] = require("lv-utils").wrap_formatters(O.lang.json.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/lua.lua
+++ b/lua/lang/lua.lua
@@ -7,10 +7,13 @@ M.config = function()
       signs = true,
       underline = true,
     },
-    formatter = {
-      exe = "stylua",
-      args = {},
-      stdin = false,
+    formatters = {
+      {
+        exe = "stylua",
+        args = {},
+        stdin = false,
+        tempfile_prefix = ".formatter",
+      },
     },
     linters = { "luacheck" },
     lsp = {
@@ -20,16 +23,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["lua"] = {
-    function()
-      return {
-        exe = O.lang.lua.formatter.exe,
-        args = O.lang.lua.formatter.args,
-        stdin = O.lang.lua.formatter.stdin,
-        tempfile_prefix = ".formatter",
-      }
-    end,
-  }
+  O.formatters.filetype["lua"] = require("lv-utils").wrap_formatters(O.lang.lua.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/lua.lua
+++ b/lua/lang/lua.lua
@@ -1,5 +1,14 @@
 local M = {}
 
+local formatter_profiles = {
+  stylua = {
+    exe = "stylua",
+    args = {},
+    stdin = false,
+    tempfile_prefix = ".formatter",
+  },
+}
+
 M.config = function()
   O.lang.lua = {
     diagnostics = {
@@ -8,12 +17,7 @@ M.config = function()
       underline = true,
     },
     formatters = {
-      {
-        exe = "stylua",
-        args = {},
-        stdin = false,
-        tempfile_prefix = ".formatter",
-      },
+      "stylua",
     },
     linters = { "luacheck" },
     lsp = {
@@ -23,7 +27,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["lua"] = require("lv-utils").wrap_formatters(O.lang.lua.formatters)
+  O.formatters.filetype["lua"] = require("lv-utils").wrap_formatters(O.lang.lua.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/php.lua
+++ b/lua/lang/php.lua
@@ -1,5 +1,16 @@
 local M = {}
 
+local formatter_profiles = {
+  phcbf = {
+    exe = "phpcbf",
+    args = function()
+      return { "--standard=PSR12", vim.api.nvim_buf_get_name(0) }
+    end,
+    stdin = false,
+    tempfile_prefix = ".formatter",
+  },
+}
+
 M.config = function()
   O.lang.php = {
     format = {
@@ -17,14 +28,7 @@ M.config = function()
     },
     filetypes = { "php", "phtml" },
     formatters = {
-      {
-        exe = "phpcbf",
-        args = function()
-          return { "--standard=PSR12", vim.api.nvim_buf_get_name(0) }
-        end,
-        stdin = false,
-        tempfile_prefix = ".formatter",
-      },
+      "phcbf",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/php/node_modules/.bin/intelephense",
@@ -33,7 +37,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["php"] = require("lv-utils").wrap_formatters(O.lang.php.formatters)
+  O.formatters.filetype["php"] = require("lv-utils").wrap_formatters(O.lang.php.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/php.lua
+++ b/lua/lang/php.lua
@@ -16,10 +16,15 @@ M.config = function()
       underline = true,
     },
     filetypes = { "php", "phtml" },
-    formatter = {
-      exe = "phpcbf",
-      args = { "--standard=PSR12", vim.api.nvim_buf_get_name(0) },
-      stdin = false,
+    formatters = {
+      {
+        exe = "phpcbf",
+        args = function()
+          return { "--standard=PSR12", vim.api.nvim_buf_get_name(0) }
+        end,
+        stdin = false,
+        tempfile_prefix = ".formatter",
+      },
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/php/node_modules/.bin/intelephense",
@@ -28,16 +33,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["php"] = {
-    function()
-      return {
-        exe = O.lang.php.formatter.exe,
-        args = O.lang.php.formatter.args,
-        stdin = O.lang.php.formatter.stdin,
-        tempfile_prefix = ".formatter",
-      }
-    end,
-  }
+  O.formatters.filetype["php"] = require("lv-utils").wrap_formatters(O.lang.php.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/python.lua
+++ b/lua/lang/python.lua
@@ -4,7 +4,6 @@ M.config = function()
   O.lang.python = {
     -- @usage can be flake8 or yapf
     linter = "",
-    isort = false,
     diagnostics = {
       virtual_text = { spacing = 0, prefix = "" },
       signs = true,
@@ -15,10 +14,17 @@ M.config = function()
       auto_search_paths = true,
       use_library_code_types = true,
     },
-    formatter = {
-      exe = "yapf",
-      args = {},
-      stdin = true,
+    formatters = {
+      {
+        exe = "black",
+        args = { "-" },
+        stdin = true,
+      },
+      {
+        exe = "isort",
+        args = { "-" },
+        stdin = true,
+      },
     },
     linters = {
       "flake8",
@@ -32,16 +38,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["python"] = {
-    function()
-      return {
-        exe = O.lang.python.formatter.exe,
-        args = O.lang.python.formatter.args,
-        stdin = O.lang.python.formatter.stdin,
-      }
-    end,
-  }
-
+  O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters)
   require("formatter.config").set_defaults {
     logging = false,
     filetype = O.formatters.filetype,

--- a/lua/lang/python.lua
+++ b/lua/lang/python.lua
@@ -1,5 +1,23 @@
 local M = {}
 
+local formatter_profiles = {
+  black = {
+    exe = "black",
+    args = { "-" },
+    stdin = true,
+  },
+  isort = {
+    exe = "isort",
+    args = { "-" },
+    stdin = true,
+  },
+  yapf = {
+    exe = "yapf",
+    args = {},
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.python = {
     -- @usage can be flake8 or yapf
@@ -15,16 +33,8 @@ M.config = function()
       use_library_code_types = true,
     },
     formatters = {
-      {
-        exe = "black",
-        args = { "-" },
-        stdin = true,
-      },
-      {
-        exe = "isort",
-        args = { "-" },
-        stdin = true,
-      },
+      "black",
+      "isort",
     },
     linters = {
       "flake8",
@@ -38,7 +48,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters)
+  O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters, formatter_profiles)
   require("formatter.config").set_defaults {
     logging = false,
     filetype = O.formatters.filetype,

--- a/lua/lang/python.lua
+++ b/lua/lang/python.lua
@@ -38,7 +38,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters)
+  -- O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters)
   require("formatter.config").set_defaults {
     logging = false,
     filetype = O.formatters.filetype,

--- a/lua/lang/python.lua
+++ b/lua/lang/python.lua
@@ -38,7 +38,7 @@ M.config = function()
 end
 
 M.format = function()
-  -- O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters)
+  O.formatters.filetype["python"] = require("lv-utils").wrap_formatters(O.lang.python.formatters)
   require("formatter.config").set_defaults {
     logging = false,
     filetype = O.formatters.filetype,

--- a/lua/lang/r.lua
+++ b/lua/lang/r.lua
@@ -4,29 +4,23 @@ M.config = function()
   -- R -e 'install.packages("formatR",repos = "http://cran.us.r-project.org")'
   -- R -e 'install.packages("readr",repos = "http://cran.us.r-project.org")'
   O.lang.r = {
-    formatter = {
-      exe = "R",
-      args = {
-        "--slave",
-        "--no-restore",
-        "--no-save",
-        '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
+    formatters = {
+      {
+        exe = "R",
+        args = {
+          "--slave",
+          "--no-restore",
+          "--no-save",
+          '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
+        },
+        stdin = true,
       },
-      stdin = true,
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["r"] = {
-    function()
-      return {
-        exe = O.lang.r.formatter.exe,
-        args = O.lang.r.formatter.args,
-        stdin = O.lang.r.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["r"] = require("lv-utils").wrap_formatters(O.lang.r.formatters)
   O.formatters.filetype["rmd"] = O.formatters.filetype["r"]
 
   require("formatter.config").set_defaults {

--- a/lua/lang/r.lua
+++ b/lua/lang/r.lua
@@ -1,26 +1,30 @@
 local M = {}
 
+local formatter_profiles = {
+  R = {
+    exe = "R",
+    args = {
+      "--slave",
+      "--no-restore",
+      "--no-save",
+      '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
+    },
+    stdin = true,
+  },
+}
+
 M.config = function()
   -- R -e 'install.packages("formatR",repos = "http://cran.us.r-project.org")'
   -- R -e 'install.packages("readr",repos = "http://cran.us.r-project.org")'
   O.lang.r = {
     formatters = {
-      {
-        exe = "R",
-        args = {
-          "--slave",
-          "--no-restore",
-          "--no-save",
-          '-e "formatR::tidy_source(text=readr::read_file(file(\\"stdin\\")), arrow=FALSE)"',
-        },
-        stdin = true,
-      },
+      "R",
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["r"] = require("lv-utils").wrap_formatters(O.lang.r.formatters)
+  O.formatters.filetype["r"] = require("lv-utils").wrap_formatters(O.lang.r.formatters, formatter_profiles)
   O.formatters.filetype["rmd"] = O.formatters.filetype["r"]
 
   require("formatter.config").set_defaults {

--- a/lua/lang/ruby.lua
+++ b/lua/lang/ruby.lua
@@ -8,10 +8,12 @@ M.config = function()
       underline = true,
     },
     filetypes = { "rb", "erb", "rakefile", "ruby" },
-    formatter = {
-      exe = "rufo",
-      args = { "-x" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "rufo",
+        args = { "-x" },
+        stdin = true,
+      },
     },
     linters = { "ruby" },
     lsp = {
@@ -21,15 +23,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["ruby"] = {
-    function()
-      return {
-        exe = O.lang.ruby.formatter.exe,
-        args = O.lang.ruby.formatter.args,
-        stdin = O.lang.ruby.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["ruby"] = require("lv-utils").wrap_formatters(O.lang.ruby.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/ruby.lua
+++ b/lua/lang/ruby.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+local formatter_profiles = {
+  rufo = {
+    exe = "rufo",
+    args = { "-x" },
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.ruby = {
     diagnostics = {
@@ -9,11 +17,7 @@ M.config = function()
     },
     filetypes = { "rb", "erb", "rakefile", "ruby" },
     formatters = {
-      {
-        exe = "rufo",
-        args = { "-x" },
-        stdin = true,
-      },
+      "rufo",
     },
     linters = { "ruby" },
     lsp = {
@@ -23,7 +27,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["ruby"] = require("lv-utils").wrap_formatters(O.lang.ruby.formatters)
+  O.formatters.filetype["ruby"] = require("lv-utils").wrap_formatters(O.lang.ruby.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+local formatter_profiles = {
+  rustfmt = {
+    exe = "rustfmt",
+    args = { "--emit=stdout", "--edition=2018" },
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.rust = {
     rust_tools = {
@@ -9,11 +17,7 @@ M.config = function()
     },
     -- @usage can be clippy
     formatters = {
-      {
-        exe = "rustfmt",
-        args = { "--emit=stdout", "--edition=2018" },
-        stdin = true,
-      },
+      "rustfmt",
     },
     linter = "",
     diagnostics = {
@@ -28,7 +32,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["rust"] = require("lv-utils").wrap_formatters(O.lang.rust.formatters)
+  O.formatters.filetype["rust"] = require("lv-utils").wrap_formatters(O.lang.rust.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/rust.lua
+++ b/lua/lang/rust.lua
@@ -8,10 +8,12 @@ M.config = function()
       other_hints_prefix = "=>", -- prefix for all the other hints (type, chaining)
     },
     -- @usage can be clippy
-    formatter = {
-      exe = "rustfmt",
-      args = { "--emit=stdout", "--edition=2018" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "rustfmt",
+        args = { "--emit=stdout", "--edition=2018" },
+        stdin = true,
+      },
     },
     linter = "",
     diagnostics = {
@@ -26,15 +28,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["rust"] = {
-    function()
-      return {
-        exe = O.lang.rust.formatter.exe,
-        args = O.lang.rust.formatter.args,
-        stdin = O.lang.rust.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["rust"] = require("lv-utils").wrap_formatters(O.lang.rust.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/scala.lua
+++ b/lua/lang/scala.lua
@@ -10,24 +10,18 @@ M.config = function()
       show_inferred_type = true,
       status_bar_provider = false,
     },
-    formatter = {
-      exe = "scalafmt",
-      args = { "--stdin" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "scalafmt",
+        args = { "--stdin" },
+        stdin = true,
+      },
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["scala"] = {
-    function()
-      return {
-        exe = O.lang.scala.formatter.exe,
-        args = O.lang.scala.formatter.args,
-        stdin = O.lang.scala.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["scala"] = require("lv-utils").wrap_formatters(O.lang.scala.formatters)
   O.formatters.filetype["sbt"] = O.formatters.filetype["scala"]
   --  To understand sbt files on stdin, scalafmt needs to assume any old filename
   --  that ends in .sbt.  Using a dummy filename instead of the actual one is

--- a/lua/lang/scala.lua
+++ b/lua/lang/scala.lua
@@ -1,5 +1,13 @@
 local M = {}
 
+local formatter_profiles = {
+  scalafmt = {
+    exe = "scalafmt",
+    args = { "--stdin" },
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.scala = {
     metals = {
@@ -11,17 +19,13 @@ M.config = function()
       status_bar_provider = false,
     },
     formatters = {
-      {
-        exe = "scalafmt",
-        args = { "--stdin" },
-        stdin = true,
-      },
+      "scalafmt",
     },
   }
 end
 
 M.format = function()
-  O.formatters.filetype["scala"] = require("lv-utils").wrap_formatters(O.lang.scala.formatters)
+  O.formatters.filetype["scala"] = require("lv-utils").wrap_formatters(O.lang.scala.formatters, formatter_profiles)
   O.formatters.filetype["sbt"] = O.formatters.filetype["scala"]
   --  To understand sbt files on stdin, scalafmt needs to assume any old filename
   --  that ends in .sbt.  Using a dummy filename instead of the actual one is

--- a/lua/lang/sh.lua
+++ b/lua/lang/sh.lua
@@ -10,10 +10,13 @@ M.config = function()
       signs = true,
       underline = true,
     },
-    formatter = {
-      exe = "shfmt",
-      args = { "-w" },
-      stdin = false,
+    formatters = {
+      {
+        exe = "shfmt",
+        args = { "-w" },
+        stdin = false,
+        tempfile_prefix = ".formatter",
+      },
     },
     linters = { "shellcheck" },
     lsp = {
@@ -23,16 +26,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["sh"] = {
-    function()
-      return {
-        exe = O.lang.sh.formatter.exe,
-        args = O.lang.sh.formatter.args,
-        stdin = O.lang.sh.formatter.stdin,
-        tempfile_prefix = ".formatter",
-      }
-    end,
-  }
+  O.formatters.filetype["sh"] = require("lv-utils").wrap_formatters(O.lang.sh.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/sh.lua
+++ b/lua/lang/sh.lua
@@ -1,5 +1,14 @@
 local M = {}
 
+local formatter_profiles = {
+  shfmt = {
+    exe = "shfmt",
+    args = { "-w" },
+    stdin = false,
+    tempfile_prefix = ".formatter",
+  },
+}
+
 M.config = function()
   O.lang.sh = {
     -- @usage can be 'shellcheck'
@@ -11,12 +20,7 @@ M.config = function()
       underline = true,
     },
     formatters = {
-      {
-        exe = "shfmt",
-        args = { "-w" },
-        stdin = false,
-        tempfile_prefix = ".formatter",
-      },
+      "shfmt",
     },
     linters = { "shellcheck" },
     lsp = {
@@ -26,7 +30,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["sh"] = require("lv-utils").wrap_formatters(O.lang.sh.formatters)
+  O.formatters.filetype["sh"] = require("lv-utils").wrap_formatters(O.lang.sh.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/swift.lua
+++ b/lua/lang/swift.lua
@@ -2,10 +2,12 @@ local M = {}
 
 M.config = function()
   O.lang.swift = {
-    formatter = {
-      exe = "swiftformat",
-      args = {},
-      stdin = true,
+    formatters = {
+      {
+        exe = "swiftformat",
+        args = {},
+        stdin = true,
+      },
     },
     lsp = {
       path = "sourcekit-lsp",
@@ -14,25 +16,17 @@ M.config = function()
 end
 
 M.format = function()
-  -- TODO: implement formatter (if applicable)
-  return "No formatter configured!"
-end
-
-M.lint = function()
-  O.formatters.filetype["swift"] = {
-    function()
-      return {
-        exe = O.lang.swift.formatter.exe,
-        args = O.lang.swift.formatter.args,
-        stdin = O.lang.swift.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["swift"] = require("lv-utils").wrap_formatters(O.lang.swift.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,
     filetype = O.formatters.filetype,
   }
+end
+
+M.lint = function()
+  -- TODO: implement linter (if applicable)
+  return "No linter configured!"
 end
 
 M.lsp = function()

--- a/lua/lang/swift.lua
+++ b/lua/lang/swift.lua
@@ -1,13 +1,17 @@
 local M = {}
 
+local formatter_profiles = {
+  siftformat = {
+    exe = "swiftformat",
+    args = {},
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.swift = {
     formatters = {
-      {
-        exe = "swiftformat",
-        args = {},
-        stdin = true,
-      },
+      "swiftformat",
     },
     lsp = {
       path = "sourcekit-lsp",
@@ -16,7 +20,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["swift"] = require("lv-utils").wrap_formatters(O.lang.swift.formatters)
+  O.formatters.filetype["swift"] = require("lv-utils").wrap_formatters(O.lang.swift.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/terraform.lua
+++ b/lua/lang/terraform.lua
@@ -2,10 +2,13 @@ local M = {}
 
 M.config = function()
   O.lang.terraform = {
-    formatter = {
-      exe = "terraform",
-      args = { "fmt" },
-      stdin = false,
+    formatters = {
+      {
+        exe = "terraform",
+        args = { "fmt" },
+        stdin = false,
+        tempfile_prefix = ".formatter",
+      },
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/terraform/terraform-ls",
@@ -14,16 +17,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["hcl"] = {
-    function()
-      return {
-        exe = O.lang.terraform.formatter.exe,
-        args = O.lang.terraform.formatter.args,
-        stdin = O.lang.terraform.formatter.stdin,
-        tempfile_prefix = ".formatter",
-      }
-    end,
-  }
+  O.formatters.filetype["hcl"] = require("lv-utils").wrap_formatters(O.lang.terraform.formatters)
   O.formatters.filetype["tf"] = O.formatters.filetype["hcl"]
 
   require("formatter.config").set_defaults {

--- a/lua/lang/terraform.lua
+++ b/lua/lang/terraform.lua
@@ -1,14 +1,18 @@
 local M = {}
 
+local formatter_profiles = {
+  terraform = {
+    exe = "terraform",
+    args = { "fmt" },
+    stdin = false,
+    tempfile_prefix = ".formatter",
+  },
+}
+
 M.config = function()
   O.lang.terraform = {
     formatters = {
-      {
-        exe = "terraform",
-        args = { "fmt" },
-        stdin = false,
-        tempfile_prefix = ".formatter",
-      },
+      "terraform",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/terraform/terraform-ls",
@@ -17,7 +21,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["hcl"] = require("lv-utils").wrap_formatters(O.lang.terraform.formatters)
+  O.formatters.filetype["hcl"] = require("lv-utils").wrap_formatters(O.lang.terraform.formatters, formatter_profiles)
   O.formatters.filetype["tf"] = O.formatters.filetype["hcl"]
 
   require("formatter.config").set_defaults {

--- a/lua/lang/vue.lua
+++ b/lua/lang/vue.lua
@@ -12,19 +12,23 @@ local function find_local_prettier()
   return formatter_instance
 end
 
+local formatter_profiles = {
+  prettier = {
+    exe = find_local_prettier,
+    args = function()
+      return require("lv-utils").gsub_args {
+        "--stdin-filepath",
+        "${FILEPATH}",
+      }
+    end,
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.vue = {
     formatters = {
-      {
-        exe = "prettier",
-        args = function()
-          return require("lv-utils").gsub_args {
-            "--stdin-filepath",
-            "${FILEPATH}",
-          }
-        end,
-        stdin = true,
-      },
+      "prettier",
     },
     auto_import = true,
     lsp = {
@@ -35,7 +39,7 @@ end
 
 M.format = function()
   local ft = vim.bo.filetype
-  O.formatters.filetype[ft] = require("lv-utils").wrap_formatters(O.lang.vue.formatters)
+  O.formatters.filetype[ft] = require("lv-utils").wrap_formatters(O.lang.vue.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/yaml.lua
+++ b/lua/lang/yaml.lua
@@ -2,10 +2,14 @@ local M = {}
 
 M.config = function()
   O.lang.yaml = {
-    formatter = {
-      exe = "prettier",
-      args = { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" },
-      stdin = true,
+    formatters = {
+      {
+        exe = "prettier",
+        args = function()
+          return { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" }
+        end,
+        stdin = true,
+      },
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/yaml/node_modules/.bin/yaml-language-server",
@@ -14,15 +18,8 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["yaml"] = {
-    function()
-      return {
-        exe = O.lang.yaml.formatter.exe,
-        args = O.lang.yaml.formatter.args,
-        stdin = O.lang.yaml.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["yaml"] = require("lv-utils").wrap_formatters(O.lang.yaml.formatters)
+
   require("formatter.config").set_defaults {
     logging = false,
     filetype = O.formatters.filetype,

--- a/lua/lang/yaml.lua
+++ b/lua/lang/yaml.lua
@@ -1,15 +1,19 @@
 local M = {}
 
+local formatter_profiles = {
+  prettier = {
+    exe = "prettier",
+    args = function()
+      return { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" }
+    end,
+    stdin = true,
+  },
+}
+
 M.config = function()
   O.lang.yaml = {
     formatters = {
-      {
-        exe = "prettier",
-        args = function()
-          return { "--stdin-filepath", vim.api.nvim_buf_get_name(0), "--single-quote" }
-        end,
-        stdin = true,
-      },
+      "prettier",
     },
     lsp = {
       path = DATA_PATH .. "/lspinstall/yaml/node_modules/.bin/yaml-language-server",
@@ -18,7 +22,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["yaml"] = require("lv-utils").wrap_formatters(O.lang.yaml.formatters)
+  O.formatters.filetype["yaml"] = require("lv-utils").wrap_formatters(O.lang.yaml.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/zig.lua
+++ b/lua/lang/zig.lua
@@ -2,10 +2,12 @@ local M = {}
 
 M.config = function()
   O.lang.zig = {
-    formatter = {
-      exe = "zig",
-      args = { "fmt" },
-      stdin = false,
+    formatters = {
+      {
+        exe = "zig",
+        args = { "fmt" },
+        stdin = false,
+      },
     },
     lsp = {
       path = "zls",
@@ -14,15 +16,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["zig"] = {
-    function()
-      return {
-        exe = O.lang.zig.formatter.exe,
-        args = O.lang.zig.formatter.args,
-        stdin = O.lang.zig.formatter.stdin,
-      }
-    end,
-  }
+  O.formatters.filetype["zig"] = require("lv-utils").wrap_formatters(O.lang.zig.formatters)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lang/zig.lua
+++ b/lua/lang/zig.lua
@@ -1,13 +1,16 @@
 local M = {}
 
+local formatter_profiles = {
+  zig = {
+    exe = "zig",
+    args = { "fmt" },
+    stdin = false,
+  },
+}
 M.config = function()
   O.lang.zig = {
     formatters = {
-      {
-        exe = "zig",
-        args = { "fmt" },
-        stdin = false,
-      },
+      "zig",
     },
     lsp = {
       path = "zls",
@@ -16,7 +19,7 @@ M.config = function()
 end
 
 M.format = function()
-  O.formatters.filetype["zig"] = require("lv-utils").wrap_formatters(O.lang.zig.formatters)
+  O.formatters.filetype["zig"] = require("lv-utils").wrap_formatters(O.lang.zig.formatters, formatter_profiles)
 
   require("formatter.config").set_defaults {
     logging = false,

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -79,21 +79,32 @@ function lv_utils.check_lsp_client_active(name)
   return false
 end
 
-function lv_utils.wrap_formatters(formatters)
+function lv_utils.wrap_formatters(formatters, formatter_profiles)
   local wrapped = {}
 
   for _, formatter in ipairs(formatters) do
-    table.insert(wrapped, function()
-      -- Make a copy to not overwrite formatter function parameters
-      local instance = formatter
-      for k, v in pairs(instance) do
-        if type(v) == "function" then
-          instance[k] = v()
-        end
+    if type(formatter) == "string" then
+      if formatter_profiles[formatter] == nil then
+        print("Formatter '" .. formatter .. "' doesn't have a preconfigured profile")
+        formatter = nil
+      else
+        formatter = formatter_profiles[formatter]
       end
+    end
 
-      return instance
-    end)
+    if formatter then
+      table.insert(wrapped, function()
+        -- Make a copy to not overwrite formatter function parameters
+        local instance = formatter
+        for k, v in pairs(instance) do
+          if type(v) == "function" then
+            instance[k] = v()
+          end
+        end
+
+        return instance
+      end)
+    end
   end
 
   return wrapped

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -79,6 +79,18 @@ function lv_utils.check_lsp_client_active(name)
   return false
 end
 
+function lv_utils.wrap_formatters(formatters)
+  local wrapped = {}
+
+  for _, formatter in ipairs(formatters) do
+    table.insert(wrapped, function()
+      return formatter
+    end)
+  end
+
+  return wrapped
+end
+
 function lv_utils.add_keymap(mode, opts, keymaps)
   for _, keymap in ipairs(keymaps) do
     vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -84,7 +84,15 @@ function lv_utils.wrap_formatters(formatters)
 
   for _, formatter in ipairs(formatters) do
     table.insert(wrapped, function()
-      return formatter
+      -- Make a copy to not overwrite formatter function parameters
+      local instance = formatter
+      for k, v in pairs(instance) do
+        if type(v) == "function" then
+          instance[k] = v()
+        end
+      end
+
+      return instance
     end)
   end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This provides support for running multiple formatters.
I also define formatter profiles, so that the interface for configuring formatters and linters is the same.
Finally, I made sure that formatter parameters are interpreted at formatting time by wrapping them into lambdas.

Fixes #[933](https://github.com/ChristianChiarulli/LunarVim/issues/933)

## How Has This Been Tested?

Using `:Format` you can see the formatter's logs.
I tested with some languages (not all of them), more testing is required before merging this.
With python files, we can see that both black and isort run.
I checked that the arguments defined within a lambda are indeed evaluated at formatting time (not when configuring lvim or its formatters)
