### PR TITLE
[Feature]: Add possibility to focus nvimtree instead of toggle

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -89,9 +89,9 @@ M.focus_or_close = function()
     end
   else
     view.open()
-    if package.loaded["bufferline.state"] then
-      -- require'bufferline.state'.set_offset(O.plugin.nvimtree.width + 1, 'File Explorer')
-      require("bufferline.state").set_offset(O.plugin.nvimtree.width + 1, "")
+    if package.loaded["bufferline.state"] and lvim.builtin.nvimtree.side == "left" then
+      -- require'bufferline.state'.set_offset(lvim.builtin.nvimtree.width + 1, 'File Explorer')
+      require("bufferline.state").set_offset(lvim.builtin.nvimtree.width + 1, "")
     end
   end
 end
@@ -108,8 +108,8 @@ M.toggle_tree = function()
     end
   else
     if package.loaded["bufferline.state"] and lvim.builtin.nvimtree.side == "left" then
-      -- require'bufferline.state'.set_offset(O.plugin.nvimtree.width + 1, 'File Explorer')
-      require("bufferline.state").set_offset(O.plugin.nvimtree.width + 1, "")
+      -- require'bufferline.state'.set_offset(lvim.builtin.nvimtree.width + 1, 'File Explorer')
+      require("bufferline.state").set_offset(lvim.builtin.nvimtree.width + 1, "")
     end
     require("nvim-tree").toggle()
   end

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -3,6 +3,7 @@ local M = {}
 M.config = function()
   lvim.builtin.nvimtree = {
     side = "left",
+    width = 30,
     show_icons = {
       git = 1,
       folders = 1,
@@ -65,6 +66,35 @@ M.setup = function()
   }
 end
 --
+M.focus_or_close = function()
+  local view_status_ok, view = pcall(require, "nvim-tree.view")
+  if not view_status_ok then
+    return
+  end
+  local a = vim.api
+
+  local curwin = a.nvim_get_current_win()
+  local curbuf = a.nvim_win_get_buf(curwin)
+  local bufnr = view.View.bufnr
+  local winnr = view.get_winnr()
+
+  if view.win_open() then
+    if curwin == winnr and curbuf == bufnr then
+      view.close()
+      if package.loaded["bufferline.state"] then
+        require("bufferline.state").set_offset(0)
+      end
+    else
+      view.focus()
+    end
+  else
+    view.open()
+    if package.loaded["bufferline.state"] then
+      -- require'bufferline.state'.set_offset(O.plugin.nvimtree.width + 1, 'File Explorer')
+      require("bufferline.state").set_offset(O.plugin.nvimtree.width + 1, "")
+    end
+  end
+end
 --
 M.toggle_tree = function()
   local view_status_ok, view = pcall(require, "nvim-tree.view")
@@ -78,8 +108,8 @@ M.toggle_tree = function()
     end
   else
     if package.loaded["bufferline.state"] and lvim.builtin.nvimtree.side == "left" then
-      -- require'bufferline.state'.set_offset(31, 'File Explorer')
-      require("bufferline.state").set_offset(31, "")
+      -- require'bufferline.state'.set_offset(O.plugin.nvimtree.width + 1, 'File Explorer')
+      require("bufferline.state").set_offset(O.plugin.nvimtree.width + 1, "")
     end
     require("nvim-tree").toggle()
   end


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add a new possible behavior to nvimtree :

pseudo-code:
```lua
if (isOpened) then
  if (isFocused) then
    close()
  else
    focus()
  end
else
  open()
end
```

Fixes #980 

## How Has This Been Tested?

Tested with multiple splits, windows.

### To activate follow this steps :

- Set in your lv-config.lua
```lua
lvim.builtin.which_key.mappings.e = {"<cmd>lua require'core.nvimtree'.focus_or_close()<CR>", "Explorer"}
```
- Now `<leader>e` will use this behavior instead of toggle

