### PR TITLE
Move leader keybinding into the whichkey config

### DIFF
--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -1,27 +1,2 @@
 vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<leader>c", ":BufferClose<CR>", { noremap = true, silent = true })
-
-lvim.builtin.which_key.mappings["b"] = {
-  name = "Buffers",
-  j = { "<cmd>BufferPick<cr>", "jump to buffer" },
-  f = { "<cmd>Telescope buffers<cr>", "Find buffer" },
-  w = { "<cmd>BufferWipeout<cr>", "wipeout buffer" },
-  e = {
-    "<cmd>BufferCloseAllButCurrent<cr>",
-    "close all but current buffer",
-  },
-  h = { "<cmd>BufferCloseBuffersLeft<cr>", "close all buffers to the left" },
-  l = {
-    "<cmd>BufferCloseBuffersRight<cr>",
-    "close all BufferLines to the right",
-  },
-  D = {
-    "<cmd>BufferOrderByDirectory<cr>",
-    "sort BufferLines automatically by directory",
-  },
-  L = {
-    "<cmd>BufferOrderByLanguage<cr>",
-    "sort BufferLines automatically by language",
-  },
-}

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -90,7 +90,6 @@ M.setup = function()
     return
   end
   telescope.setup(lvim.builtin.telescope)
-  vim.api.nvim_set_keymap("n", "<Leader>f", ":Telescope find_files<CR>", { noremap = true, silent = true })
 end
 
 return M

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -68,6 +68,29 @@ M.config = function()
       ["e"] = { "<cmd>lua require'core.nvimtree'.toggle_tree()<CR>", "Explorer" },
       ["f"] = { "<cmd>Telescope find_files<CR>", "Find File" },
       ["h"] = { '<cmd>let @/=""<CR>', "No Highlight" },
+      b = {
+        name = "Buffers",
+        j = { "<cmd>BufferPick<cr>", "jump to buffer" },
+        f = { "<cmd>Telescope buffers<cr>", "Find buffer" },
+        w = { "<cmd>BufferWipeout<cr>", "wipeout buffer" },
+        e = {
+          "<cmd>BufferCloseAllButCurrent<cr>",
+          "close all but current buffer",
+        },
+        h = { "<cmd>BufferCloseBuffersLeft<cr>", "close all buffers to the left" },
+        l = {
+          "<cmd>BufferCloseBuffersRight<cr>",
+          "close all BufferLines to the right",
+        },
+        D = {
+          "<cmd>BufferOrderByDirectory<cr>",
+          "sort BufferLines automatically by directory",
+        },
+        L = {
+          "<cmd>BufferOrderByLanguage<cr>",
+          "sort BufferLines automatically by language",
+        },
+      },
       p = {
         name = "Packer",
         c = { "<cmd>PackerCompile<cr>", "Compile" },

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -1,5 +1,5 @@
 --[[
-O is the global options object
+lvim is the global options object
 
 Linters should be
 filled in as strings with either


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description


Move leader keybindings into the whichkey configuration file

Fixes #(issue)
When resetting keybindings via whichkey.reset()  or `lvim.builtin.which_key.mappings = nil`,  some keybindings are still available because they are defined in other configuration files.   

## How Has This Been Tested?
Check keybindings to make sure they still work



