### PR TITLE
Fix ignored user autocommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ lvim.plugins = {
 }
 
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
--- lvim.autocommands = {{ "BufWinEnter", "*", "echo \"hi again\""}}
+-- lvim.autocommands.custom_groups = {
+--   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
+-- }
 
 ```
 

--- a/init.lua
+++ b/init.lua
@@ -18,6 +18,7 @@ if not status_ok then
   print "something is wrong with your lv-config"
   print(error)
 end
+require('core.autocmds').define_augroups(lvim.autocommands)
 
 require "keymappings"
 

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,0 +1,112 @@
+local autocommands = {}
+
+
+lvim.autocommands = {
+  _general_settings = {
+    {
+      "TextYankPost",
+      "*",
+      "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
+    },
+    {
+      "BufWinEnter",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    {
+      "BufWinEnter",
+      "dashboard",
+      "setlocal cursorline signcolumn=yes cursorcolumn number",
+    },
+    {
+      "BufRead",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    {
+      "BufNewFile",
+      "*",
+      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
+    },
+    { "BufWritePost",
+      "lv-config.lua",
+      "lua require('lv-utils').reload_lv_config()"
+    },
+    {
+      "FileType",
+      "qf",
+      "set nobuflisted"
+    },
+    -- { "VimLeavePre", "*", "set title set titleold=" },
+  },
+  _filetypechanges = {
+    { "BufWinEnter", ".tf", "setlocal filetype=hcl" },
+    { "BufRead", "*.tf", "setlocal filetype=hcl" },
+    { "BufNewFile", "*.tf", "setlocal filetype=hcl" },
+    { "BufWinEnter", ".zsh", "setlocal filetype=sh" },
+    { "BufRead", "*.zsh", "setlocal filetype=sh" },
+    { "BufNewFile", "*.zsh", "setlocal filetype=sh" },
+  },
+  -- _solidity = {
+  --     {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
+  --     {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
+  -- },
+  -- _gemini = {
+  --     {'BufWinEnter', '.gmi', 'setlocal filetype=markdown'}, {'BufRead', '*.gmi', 'setlocal filetype=markdown'},
+  --     {'BufNewFile', '*.gmi', 'setlocal filetype=markdown'}
+  -- },
+  _markdown = {
+    { "FileType", "markdown", "setlocal wrap" },
+    { "FileType", "markdown", "setlocal spell" },
+  },
+  _buffer_bindings = {
+    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
+  },
+  _auto_resize = {
+    -- will cause split windows to be resized evenly if main window is resized
+    { "VimResized", "*", "wincmd =" },
+  },
+  _packer_compile = {
+    -- will cause split windows to be resized evenly if main window is resized
+    { "BufWritePost", "plugins.lua", "PackerCompile" },
+  },
+  
+  -- _fterm_lazygit = {
+  --   -- will cause esc key to exit lazy git
+  --   {"TermEnter", "*", "call LazyGitNativation()"}
+  -- },
+  -- _mode_switching = {
+  --   -- will switch between absolute and relative line numbers depending on mode
+  --   {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
+  --   {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
+  --   {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
+  --   {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
+  -- },
+  custom_groups = {},
+}
+
+function autocommands.define_augroups(definitions) -- {{{1
+  -- Create autocommand groups based on the passed definitions
+  --
+  -- The key will be the name of the group, and each definition
+  -- within the group should have:
+  --    1. Trigger
+  --    2. Pattern
+  --    3. Text
+  -- just like how they would normally be defined from Vim itself
+  for group_name, definition in pairs(definitions) do
+    vim.cmd("augroup " .. group_name)
+    vim.cmd "autocmd!"
+
+    for _, def in pairs(definition) do
+      local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")
+      vim.cmd(command)
+    end
+
+    vim.cmd "augroup END"
+  end
+end
+
+
+
+return autocommands

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -82,7 +82,8 @@ M.setup = function()
 
   -- vim.g.dashboard_session_directory = CACHE_PATH..'/session'
   -- vim.g.dashboard_custom_footer = lvim.dashboard.footer
-  require("lv-utils").define_augroups {
+
+  require("core.autocmds").define_augroups {
     _dashboard = {
       -- seems to be nobuflisted that makes my stuff disapear will do more testing
       {

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -54,7 +54,7 @@ lvim = {
   },
 
   autocommands = {
-    { "FileType", "qf", "set nobuflisted" },
+    
   },
 }
 

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -266,7 +266,7 @@ function lsp_config.tsserver_on_attach(client, _)
   -- vim.api.nvim_buf_set_keymap(bufnr, "n", "gi", ":TSLspImportAll<CR>", {silent = true})
 end
 
-require("lv-utils").define_augroups {
+require("core.autocmds").define_augroups {
   _general_lsp = {
     { "FileType", "lspinfo", "nnoremap <silent> <buffer> q :q<CR>" },
   },

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -59,7 +59,7 @@ end
 -- autoformat
 local toggle_autoformat = function()
   if lvim.format_on_save then
-    require("lv-utils").define_augroups {
+    require("core.autocmds").define_augroups {
       autoformat = {
         {
           "BufWritePost",
@@ -130,109 +130,11 @@ function lv_utils.add_keymap_term_mode(opts, keymaps)
   lv_utils.add_keymap("t", opts, keymaps)
 end
 
-function lv_utils.define_augroups(definitions) -- {{{1
-  -- Create autocommand groups based on the passed definitions
-  --
-  -- The key will be the name of the group, and each definition
-  -- within the group should have:
-  --    1. Trigger
-  --    2. Pattern
-  --    3. Text
-  -- just like how they would normally be defined from Vim itself
-  for group_name, definition in pairs(definitions) do
-    vim.cmd("augroup " .. group_name)
-    vim.cmd "autocmd!"
-
-    for _, def in pairs(definition) do
-      local command = table.concat(vim.tbl_flatten { "autocmd", def }, " ")
-      vim.cmd(command)
-    end
-
-    vim.cmd "augroup END"
-  end
-end
 
 function lv_utils.unrequire(m)
   package.loaded[m] = nil
   _G[m] = nil
 end
-
-lv_utils.define_augroups {
-
-  _general_settings = {
-    {
-      "TextYankPost",
-      "*",
-      "lua require('vim.highlight').on_yank({higroup = 'Search', timeout = 200})",
-    },
-    {
-      "BufWinEnter",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    {
-      "BufWinEnter",
-      "dashboard",
-      "setlocal cursorline signcolumn=yes cursorcolumn number",
-    },
-    {
-      "BufRead",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    {
-      "BufNewFile",
-      "*",
-      "setlocal formatoptions-=c formatoptions-=r formatoptions-=o",
-    },
-    { "BufWritePost", "lv-config.lua", "lua require('lv-utils').reload_lv_config()" },
-    -- { "VimLeavePre", "*", "set title set titleold=" },
-  },
-  _filetypechanges = {
-    { "BufWinEnter", ".tf", "setlocal filetype=hcl" },
-    { "BufRead", "*.tf", "setlocal filetype=hcl" },
-    { "BufNewFile", "*.tf", "setlocal filetype=hcl" },
-    { "BufWinEnter", ".zsh", "setlocal filetype=sh" },
-    { "BufRead", "*.zsh", "setlocal filetype=sh" },
-    { "BufNewFile", "*.zsh", "setlocal filetype=sh" },
-  },
-  -- _solidity = {
-  --     {'BufWinEnter', '.sol', 'setlocal filetype=solidity'}, {'BufRead', '*.sol', 'setlocal filetype=solidity'},
-  --     {'BufNewFile', '*.sol', 'setlocal filetype=solidity'}
-  -- },
-  -- _gemini = {
-  --     {'BufWinEnter', '.gmi', 'setlocal filetype=markdown'}, {'BufRead', '*.gmi', 'setlocal filetype=markdown'},
-  --     {'BufNewFile', '*.gmi', 'setlocal filetype=markdown'}
-  -- },
-  _markdown = {
-    { "FileType", "markdown", "setlocal wrap" },
-    { "FileType", "markdown", "setlocal spell" },
-  },
-  _buffer_bindings = {
-    { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },
-  },
-  _auto_resize = {
-    -- will cause split windows to be resized evenly if main window is resized
-    { "VimResized", "*", "wincmd =" },
-  },
-  _packer_compile = {
-    -- will cause split windows to be resized evenly if main window is resized
-    { "BufWritePost", "plugins.lua", "PackerCompile" },
-  },
-
-  -- _fterm_lazygit = {
-  --   -- will cause esc key to exit lazy git
-  --   {"TermEnter", "*", "call LazyGitNativation()"}
-  -- },
-  -- _mode_switching = {
-  --   -- will switch between absolute and relative line numbers depending on mode
-  --   {'InsertEnter', '*', 'if &relativenumber | let g:ms_relativenumberoff = 1 | setlocal number norelativenumber | endif'},
-  --   {'InsertLeave', '*', 'if exists("g:ms_relativenumberoff") | setlocal relativenumber | endif'},
-  --   {'InsertEnter', '*', 'if &cursorline | let g:ms_cursorlineoff = 1 | setlocal nocursorline | endif'},
-  --   {'InsertLeave', '*', 'if exists("g:ms_cursorlineoff") | setlocal cursorline | endif'},
-  -- },
-  _user_autocommands = lvim.autocommands,
-}
 
 function lv_utils.gsub_args(args)
   if args == nil or type(args) ~= "table" then

--- a/utils/installer/lv-config.example-no-ts.lua
+++ b/utils/installer/lv-config.example-no-ts.lua
@@ -58,6 +58,8 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- }
 
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
--- lvim.autocommands = {{ "BufWinEnter", "*", "echo \"hi again\""}}
+-- lvim.autocommands.custom_groups = {
+--   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
+-- }
 
 -- Additional Leader bindings for WhichKey

--- a/utils/installer/lv-config.example.lua
+++ b/utils/installer/lv-config.example.lua
@@ -67,7 +67,10 @@ lvim.builtin.treesitter.highlight.enabled = true
 --     }
 -- }
 
+
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
--- lvim.autocommands = {{ "BufWinEnter", "*", "echo \"hi again\""}}
+-- lvim.autocommands.custom_groups = {
+--   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
+-- }
 
 -- Additional Leader bindings for WhichKey


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Rename `lvim.autocommands` -> `lvim.autocommands.custom_group`. THis makkes it clearer that we're expecting a table and not a single entry. And it also allows us to expose `lvim.autocommands` to the user to allow for modification.
- Add `core.autocmds` to allow for evaluating the augroups _after_ `lvim.autocommands.custom_groups` has been updated.


## Fixes

Fix ignored user autocommands

## How Has This Been Tested?

Uncomment the example lines at the `lv-config[-examle].lua` to see the effect, or copy these lines manually

```lua
lvim.autocommands.custom_groups = {
  { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
}

```


