### PR TITLE
[Bugfix]: WarningMsg color is red instead of orange

### DIFF
--- a/lua/spacegray/highlights.lua
+++ b/lua/spacegray/highlights.lua
@@ -26,7 +26,7 @@ local highlights = {
   NormalFloat = { bg = C.alt_bg },
   Visual = { bg = C.alt_bg },
   VisualNOS = { bg = C.alt_bg },
-  WarningMsg = { fg = C.error_red, bg = C.bg },
+  WarningMsg = { fg = C.warning_orange, bg = C.bg },
   DiffAdd = { fg = C.alt_bg, bg = C.sign_add },
   DiffChange = { fg = C.alt_bg, bg = C.sign_change, style = "underline" },
   DiffDelete = { fg = C.alt_bg, bg = C.sign_delete },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I use `WarningMsg` highlight group in my config and saw that it is set to orange in `spacegray` colorsheme