### PR TITLE
[Bugfix] Show correct indentation settings in galaxyline

### DIFF
--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -266,7 +266,11 @@ table.insert(gls.right, {
 table.insert(gls.right, {
   Tabstop = {
     provider = function()
-      return "Spaces: " .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
+      local label = "Spaces: "
+      if not vim.api.nvim_buf_get_option(0, "expandtab") then
+        label = "Tab size: "
+      end
+      return label .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
     end,
     condition = condition.hide_in_width,
     separator = " ",


### PR DESCRIPTION
Display "Tab size: " instead of "Spaces: " if indenting with tabs.

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

In the galaxyline, LunarVim displays a text like "Spaces: _n_", where _n_ is the amount of spaces the user indents with, extracted from `shiftwidth`.
However, if a user indents with tabs, LunarVim still displays "Spaces: _n_", which can be very misleading.

This fix additionally checks the `expandtab` option and changes sets the text to "Tab size: _n_" if `expandtab` is `false`.

Just like the check on `shiftwidth`, I check the option for the current buffer.

Fixes #(issue)

## How Has This Been Tested?

Alternatingly set different values for the following options and confirm the expected behavior:
`set tabstop=4`
`set shiftwidth=4`
`set expandtab` / `set noexpandtab`
