### PR TITLE
[Refactor] Remove defaults.find_command from telescope

### DIFF
--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -8,14 +8,6 @@ M.config = function()
   lvim.builtin.telescope = {
     active = false,
     defaults = {
-      find_command = {
-        "rg",
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-        "--smart-case",
-      },
       prompt_prefix = " ",
       selection_caret = " ",
       entry_prefix = "  ",


### PR DESCRIPTION
# Description
There is no `defaults.find_command` option for telescope setup. Its inclusion in `telescope.lua` would confuse users that expect the default behavior of telescope to change using this option. So we remove the option.

## How Has This Been Tested?
- Remove the option from `telescope.lua`
- Check that telescope command returns the same results: `Telescope find_file`
