### PR TITLE
splits up the settings file.  settings.lua gets required before lv-co…

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,12 +12,13 @@ vim.cmd [[
 ]]
 -- vim.opt.rtp:append() instead of vim.cmd ?
 require "default-config"
-require "settings"
+require("settings").options()
 local status_ok, error = pcall(vim.cmd, "luafile ~/.config/lvim/lv-config.lua")
 if not status_ok then
   print "something is wrong with your lv-config"
   print(error)
 end
+require("settings").commands()
 require("core.autocmds").define_augroups(lvim.autocommands)
 
 require "keymappings"

--- a/init.lua
+++ b/init.lua
@@ -12,13 +12,13 @@ vim.cmd [[
 ]]
 -- vim.opt.rtp:append() instead of vim.cmd ?
 require "default-config"
-require("settings").options()
+require("settings").load_options()
 local status_ok, error = pcall(vim.cmd, "luafile ~/.config/lvim/lv-config.lua")
 if not status_ok then
   print "something is wrong with your lv-config"
   print(error)
 end
-require("settings").commands()
+require("settings").load_commands()
 require("core.autocmds").define_augroups(lvim.autocommands)
 
 require "keymappings"

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-M.options = function()
+M.load_options = function()
   local opt = vim.opt
 
   local default_options = {
@@ -58,7 +58,7 @@ M.options = function()
   end
 end
 
-M.commands = function()
+M.load_commands = function()
   local cmd = vim.cmd
   if lvim.line_wrap_cursor_movement then
     cmd "set whichwrap+=<,>,[,],h,l"

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,72 +1,78 @@
----  HELPERS  ---
+local M = {}
 
-local cmd = vim.cmd
-local opt = vim.opt
+M.options = function()
+  local opt = vim.opt
 
-local default_options = {
-  backup = false, -- creates a backup file
-  clipboard = "unnamedplus", -- allows neovim to access the system clipboard
-  cmdheight = 2, -- more space in the neovim command line for displaying messages
-  colorcolumn = "99999", -- fixes indentline for now
-  completeopt = { "menuone", "noselect" },
-  conceallevel = 0, -- so that `` is visible in markdown files
-  fileencoding = "utf-8", -- the encoding written to a file
-  foldmethod = "manual", -- folding, set to "expr" for treesitter based foloding
-  foldexpr = "", -- set to "nvim_treesitter#foldexpr()" for treesitter based folding
-  guifont = "monospace:h17", -- the font used in graphical neovim applications
-  hidden = true, -- required to keep multiple buffers and open multiple buffers
-  hlsearch = true, -- highlight all matches on previous search pattern
-  ignorecase = true, -- ignore case in search patterns
-  mouse = "a", -- allow the mouse to be used in neovim
-  pumheight = 10, -- pop up menu height
-  showmode = false, -- we don't need to see things like -- INSERT -- anymore
-  showtabline = 2, -- always show tabs
-  smartcase = true, -- smart case
-  smartindent = true, -- make indenting smarter again
-  splitbelow = true, -- force all horizontal splits to go below current window
-  splitright = true, -- force all vertical splits to go to the right of current window
-  swapfile = false, -- creates a swapfile
-  termguicolors = true, -- set term gui colors (most terminals support this)
-  timeoutlen = 100, -- time to wait for a mapped sequence to complete (in milliseconds)
-  title = true, -- set the title of window to the value of the titlestring
-  -- opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
-  undodir = CACHE_PATH .. "/undo", -- set an undo directory
-  undofile = true, -- enable persisten undo
-  updatetime = 300, -- faster completion
-  writebackup = false, -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
-  expandtab = true, -- convert tabs to spaces
-  shiftwidth = 2, -- the number of spaces inserted for each indentation
-  tabstop = 2, -- insert 2 spaces for a tab
-  cursorline = true, -- highlight the current line
-  number = true, -- set numbered lines
-  relativenumber = false, -- set relative numbered lines
-  numberwidth = 4, -- set number column width to 2 {default 4}
-  signcolumn = "yes", -- always show the sign column, otherwise it would shift the text each time
-  wrap = false, -- display lines as one long line
-  spell = false,
-  spelllang = "en",
-  scrolloff = 8, -- is one of my fav
-  sidescrolloff = 8,
-} ---  VIM ONLY COMMANDS  ---cmd "filetype plugin on"cmd('let &titleold="' .. TERMINAL .. '"')cmd "set inccommand=split"cmd "set iskeyword+=-"
+  local default_options = {
+    backup = false, -- creates a backup file
+    clipboard = "unnamedplus", -- allows neovim to access the system clipboard
+    cmdheight = 2, -- more space in the neovim command line for displaying messages
+    colorcolumn = "99999", -- fixes indentline for now
+    completeopt = { "menuone", "noselect" },
+    conceallevel = 0, -- so that `` is visible in markdown files
+    fileencoding = "utf-8", -- the encoding written to a file
+    foldmethod = "manual", -- folding, set to "expr" for treesitter based foloding
+    foldexpr = "", -- set to "nvim_treesitter#foldexpr()" for treesitter based folding
+    guifont = "monospace:h17", -- the font used in graphical neovim applications
+    hidden = true, -- required to keep multiple buffers and open multiple buffers
+    hlsearch = true, -- highlight all matches on previous search pattern
+    ignorecase = true, -- ignore case in search patterns
+    mouse = "a", -- allow the mouse to be used in neovim
+    pumheight = 10, -- pop up menu height
+    showmode = false, -- we don't need to see things like -- INSERT -- anymore
+    showtabline = 2, -- always show tabs
+    smartcase = true, -- smart case
+    smartindent = true, -- make indenting smarter again
+    splitbelow = true, -- force all horizontal splits to go below current window
+    splitright = true, -- force all vertical splits to go to the right of current window
+    swapfile = false, -- creates a swapfile
+    termguicolors = true, -- set term gui colors (most terminals support this)
+    timeoutlen = 100, -- time to wait for a mapped sequence to complete (in milliseconds)
+    title = true, -- set the title of window to the value of the titlestring
+    -- opt.titlestring = "%<%F%=%l/%L - nvim" -- what the title of the window will be set to
+    undodir = CACHE_PATH .. "/undo", -- set an undo directory
+    undofile = true, -- enable persisten undo
+    updatetime = 300, -- faster completion
+    writebackup = false, -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
+    expandtab = true, -- convert tabs to spaces
+    shiftwidth = 2, -- the number of spaces inserted for each indentation
+    tabstop = 2, -- insert 2 spaces for a tab
+    cursorline = true, -- highlight the current line
+    number = true, -- set numbered lines
+    relativenumber = false, -- set relative numbered lines
+    numberwidth = 4, -- set number column width to 2 {default 4}
+    signcolumn = "yes", -- always show the sign column, otherwise it would shift the text each time
+    wrap = false, -- display lines as one long line
+    spell = false,
+    spelllang = "en",
+    scrolloff = 8, -- is one of my fav
+    sidescrolloff = 8,
+  } ---  VIM ONLY COMMANDS  ---cmd "filetype plugin on"cmd('let &titleold="' .. TERMINAL .. '"')cmd "set inccommand=split"cmd "set iskeyword+=-"
 
-if lvim.line_wrap_cursor_movement then
-  cmd "set whichwrap+=<,>,[,],h,l"
+  ---  SETTINGS  ---
+
+  opt.shortmess:append "c"
+
+  for k, v in pairs(default_options) do
+    vim.opt[k] = v
+  end
 end
 
-if lvim.transparent_window then
-  cmd "au ColorScheme * hi Normal ctermbg=none guibg=none"
-  cmd "au ColorScheme * hi SignColumn ctermbg=none guibg=none"
-  cmd "au ColorScheme * hi NormalNC ctermbg=none guibg=none"
-  cmd "au ColorScheme * hi MsgArea ctermbg=none guibg=none"
-  cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
-  cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
-  cmd "let &fcs='eob: '"
+M.commands = function()
+  local cmd = vim.cmd
+  if lvim.line_wrap_cursor_movement then
+    cmd "set whichwrap+=<,>,[,],h,l"
+  end
+
+  if lvim.transparent_window then
+    cmd "au ColorScheme * hi Normal ctermbg=none guibg=none"
+    cmd "au ColorScheme * hi SignColumn ctermbg=none guibg=none"
+    cmd "au ColorScheme * hi NormalNC ctermbg=none guibg=none"
+    cmd "au ColorScheme * hi MsgArea ctermbg=none guibg=none"
+    cmd "au ColorScheme * hi TelescopeBorder ctermbg=none guibg=none"
+    cmd "au ColorScheme * hi NvimTreeNormal ctermbg=none guibg=none"
+    cmd "let &fcs='eob: '"
+  end
 end
 
----  SETTINGS  ---
-
-opt.shortmess:append "c"
-
-for k, v in pairs(default_options) do
-  vim.opt[k] = v
-end
+return M


### PR DESCRIPTION
Splits up the settings file.  settings.lua remains required before lv-config.   toggleable-settings depends on lv-config settings and must be required after.

Re-enables these configuration options:
lvim.line_wrap_cursor_movement
lvim.transparent_window

Fixes #(issue)
https://github.com/ChristianChiarulli/LunarVim/issues/1088

