### PR TITLE
[Bugfix] Ensures formatting is done prewrite

### DIFF
--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -64,7 +64,7 @@ local toggle_autoformat = function()
         {
           "BufWritePost",
           "*",
-          ":silent lua vim.lsp.buf.formatting()",
+          ":silent lua vim.lsp.buf.formatting_sync()",
         },
       },
     }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

With `format_on_save` enabled, the user is required to save twice (tested on go and cpp) as the formatting is applied postwrite.
This change ensures formatting is done prewrite.


## How Has This Been Tested?

Verify only one save is required to keep the foramtting changes

