### PR TITLE
BufWritePre enables format on save for lv-config.lua

### DIFF
--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -71,7 +71,7 @@ local toggle_autoformat = function()
   end
 
   if not lvim.format_on_save then
-    vim.cmd [[if exists('#autoformat#BufWritePost')
+    vim.cmd [[if exists('#autoformat#BufWritePre')
   :autocmd! autoformat
   endif]]
   end

--- a/lua/lv-utils/init.lua
+++ b/lua/lv-utils/init.lua
@@ -62,7 +62,7 @@ local toggle_autoformat = function()
     require("core.autocmds").define_augroups {
       autoformat = {
         {
-          "BufWritePost",
+          "BufWritePre",
           "*",
           ":silent lua vim.lsp.buf.formatting_sync()",
         },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Currently, lv-config.lua does not get autoformatted. Changes the autocommand from `BufWritePost` to `BufWritePre`

## How Has This Been Tested?
Open lv-config.lua
set `lvim.format_on_save = true`
Save lv-config.lua.  Autoformat should be enabled


