### PR TITLE
Move terminal keybindings to whichkey so they can be overridden by th…

### DIFF
--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -33,6 +33,7 @@ M.config = function()
       },
     },
   }
+  lvim.builtin.which_key.mappings["gg"] = { "<cmd>lua require('core.terminal')._lazygit_toggle()<CR>", "LazyGit" }
 end
 
 M.setup = function()

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -41,13 +41,6 @@ M.setup = function()
     print(terminal)
     return
   end
-  vim.api.nvim_set_keymap(
-    "n",
-    "<leader>gg",
-    "<cmd>lua require('core.terminal')._lazygit_toggle()<CR>",
-    { noremap = true, silent = true }
-  )
-  lvim.builtin.which_key.mappings["gg"] = "LazyGit"
   terminal.setup(lvim.builtin.terminal)
 end
 

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -195,10 +195,6 @@ M.setup = function()
     return
   end
 
-  if lvim.builtin.terminal.active then
-    lvim.builtin.which_key.mappings["gg"] = { "<cmd>lua require('core.terminal')._lazygit_toggle()<CR>", "LazyGit" }
-  end
-
   which_key.setup(lvim.builtin.which_key.setup)
 
   local opts = lvim.builtin.which_key.opts

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -195,6 +195,10 @@ M.setup = function()
     return
   end
 
+  if lvim.builtin.terminal.active then
+    lvim.builtin.which_key.mappings["gg"] = { "<cmd>lua require('core.terminal')._lazygit_toggle()<CR>", "LazyGit" }
+  end
+
   which_key.setup(lvim.builtin.which_key.setup)
 
   local opts = lvim.builtin.which_key.opts


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

Currently, the keybindings for LazyGit can't be overridden.  This pr moves keybindings to the config function  and removes the 'noremap'.   This pr is triggered by a user request.  User is remapping all the leader bindings.

Fixes #(issue)
Makes LazyGit bindings override-able.
## How Has This Been Tested?
Toggle on terminal
`lvim.builtin.terminal.active = true`
Clear all whichkey bindings
`lvim.builtin.which_key.mappings = {}`

