### PR TITLE
[Bugfix] Add `lvim.lang` fields for `.tex` files

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -749,6 +749,22 @@ lvim.lang = {
       },
     },
   },
+  tex = {
+    formatter = {
+      exe = "latexindent",
+      args = {},
+      stdin = false,
+    },
+    linters = { "chketx" },
+    lsp = {
+      provider = "texlab",
+      setup = {
+        cmd = { DATA_PATH .. "/lspinstall/latex/texlab" },
+        on_attach = common_on_attach,
+        capabilities = common_capabilities,
+      },
+    },
+  },
   typescript = {
     -- @usage can be prettier or eslint
     formatter = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

lvim would complain on opening `.tex` files as there were no `lang` fields for them. This adds the required formatter, linter and lsp path for `.tex` files


## How Has This Been Tested?

Verify that `texlab` attaches on opening a `.tex` file and that formatting and linting works.

