### PR TITLE
[Bugfix] Wrap lsp default_keybindings in function instead of load on 1st require

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,6 +22,7 @@ require("settings").load_commands()
 require("core.autocmds").define_augroups(lvim.autocommands)
 
 require "keymappings"
+require("lsp").setup_default_bindings()
 
 local plugins = require "plugins"
 local plugin_loader = require("plugin-loader").init()

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -38,26 +38,28 @@ vim.fn.sign_define(
 --   { noremap = true, silent = true }
 -- )
 
-if lvim.lsp.default_keybinds then
-  vim.cmd "nnoremap <silent> gd <cmd>lua vim.lsp.buf.definition()<CR>"
-  vim.cmd "nnoremap <silent> gD <cmd>lua vim.lsp.buf.declaration()<CR>"
-  vim.cmd "nnoremap <silent> gr <cmd>lua vim.lsp.buf.references()<CR>"
-  vim.cmd "nnoremap <silent> gi <cmd>lua vim.lsp.buf.implementation()<CR>"
-  vim.api.nvim_set_keymap(
-    "n",
-    "gl",
-    '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = "single" })<CR>',
-    { noremap = true, silent = true }
-  )
+function lsp_config.setup_default_bindings()
+  if lvim.lsp.default_keybinds then
+    vim.cmd "nnoremap <silent> gd <cmd>lua vim.lsp.buf.definition()<CR>"
+    vim.cmd "nnoremap <silent> gD <cmd>lua vim.lsp.buf.declaration()<CR>"
+    vim.cmd "nnoremap <silent> gr <cmd>lua vim.lsp.buf.references()<CR>"
+    vim.cmd "nnoremap <silent> gi <cmd>lua vim.lsp.buf.implementation()<CR>"
+    vim.api.nvim_set_keymap(
+      "n",
+      "gl",
+      '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = "single" })<CR>',
+      { noremap = true, silent = true }
+    )
 
-  vim.cmd "nnoremap <silent> gp <cmd>lua require'lsp'.PeekDefinition()<CR>"
-  vim.cmd "nnoremap <silent> K :lua vim.lsp.buf.hover()<CR>"
-  vim.cmd "nnoremap <silent> <C-p> :lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = lvim.lsp.popup_border}})<CR>"
-  vim.cmd "nnoremap <silent> <C-n> :lua vim.lsp.diagnostic.goto_next({popup_opts = {border = lvim.lsp.popup_border}})<CR>"
-  vim.cmd "nnoremap <silent> <tab> <cmd>lua vim.lsp.buf.signature_help()<CR>"
-  -- scroll down hover doc or scroll in definition preview
-  -- scroll up hover doc
-  vim.cmd 'command! -nargs=0 LspVirtualTextToggle lua require("lsp/virtual_text").toggle()'
+    vim.cmd "nnoremap <silent> gp <cmd>lua require'lsp'.PeekDefinition()<CR>"
+    vim.cmd "nnoremap <silent> K :lua vim.lsp.buf.hover()<CR>"
+    vim.cmd "nnoremap <silent> <C-p> :lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = lvim.lsp.popup_border}})<CR>"
+    vim.cmd "nnoremap <silent> <C-n> :lua vim.lsp.diagnostic.goto_next({popup_opts = {border = lvim.lsp.popup_border}})<CR>"
+    vim.cmd "nnoremap <silent> <tab> <cmd>lua vim.lsp.buf.signature_help()<CR>"
+    -- scroll down hover doc or scroll in definition preview
+    -- scroll up hover doc
+    vim.cmd 'command! -nargs=0 LspVirtualTextToggle lua require("lsp/virtual_text").toggle()'
+  end
 end
 
 -- Set Default Prefix.


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

I noticed an issue where you could no longer set `lvim.lsp.default_keybinds = false`. This is because the lsp keybindings were set up on the first require of that module. Which happens before reading the user lv-config.lua. I simply wrapped it in a function instead and called it after keymappings.

## How Has This Been Tested?
- Set `lvim.lsp.default_keybinds = false` in `~/.config/lvim/lv-config.lua`.
- Open a file where an LSP would run.
- Press tab in normal mode on something you expect to have signature help.
- Nothing happens because the binding no longer exist.