### PR TITLE
Conditionally enable TAB to trigger completion based on filetype. Disable completion for simple text files

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -54,6 +54,10 @@ lvim.autocommands = {
   _markdown = {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
+    { "FileType", "markdown", "map <Tab> <Tab>" },
+    { "FileType", "markdown", "map <S-Tab> <S-Tab>" },
+    { "FileType", "markdown", "imap <Tab> <Tab>" },
+    { "FileType", "markdown", "imap <S-Tab> <S-Tab>" },
   },
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -54,12 +54,9 @@ lvim.autocommands = {
   _markdown = {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
-    { "FileType", "markdown", "imap <Tab> <Tab>" },
-    { "FileType", "markdown", "imap <S-Tab> <S-Tab>" },
-    { "FileType", "md", "setlocal wrap" },
-    { "FileType", "md", "setlocal spell" },
-    { "FileType", "md", "imap <Tab> <Tab>" },
-    { "FileType", "md", "imap <S-Tab> <S-Tab>" },
+  },
+  _tab_bindings = {
+    { "FileType", "*", "lua require'core.compe'.set_tab_keybindings()" },
   },
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -54,10 +54,12 @@ lvim.autocommands = {
   _markdown = {
     { "FileType", "markdown", "setlocal wrap" },
     { "FileType", "markdown", "setlocal spell" },
-    { "FileType", "markdown", "map <Tab> <Tab>" },
-    { "FileType", "markdown", "map <S-Tab> <S-Tab>" },
     { "FileType", "markdown", "imap <Tab> <Tab>" },
     { "FileType", "markdown", "imap <S-Tab> <S-Tab>" },
+    { "FileType", "md", "setlocal wrap" },
+    { "FileType", "md", "setlocal spell" },
+    { "FileType", "md", "imap <Tab> <Tab>" },
+    { "FileType", "md", "imap <S-Tab> <S-Tab>" },
   },
   _buffer_bindings = {
     { "FileType", "floaterm", "nnoremap <silent> <buffer> q :q<CR>" },

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -30,6 +30,8 @@ M.config = function()
       emoji = { kind = " ﲃ  (Emoji)", filetypes = { "markdown", "text" } },
       -- for emoji press : (idk if that in compe tho)
     },
+    -- FileTypes in this list won't trigger auto-complete when TAB is pressed.  Hitting TAB will insert a tab character
+    exclude_filetypes = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" },
   }
 end
 
@@ -88,12 +90,9 @@ M.setup = function()
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })
 end
 
-local is_text_file = function(file_type)
-  local text_file_types = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" }
-  print(file_type)
-  for _, type in ipairs(text_file_types) do
+local is_excluded = function(file_type)
+  for _, type in ipairs(lvim.builtin.compe.exclude_filetypes) do
     if type == file_type then
-      print("type is " .. type .. " : filetype is " .. file_type)
       return true
     end
   end
@@ -102,7 +101,7 @@ end
 
 M.set_tab_keybindings = function()
   local file_type = vim.fn.expand "%:e"
-  if is_text_file(file_type) == false then
+  if is_excluded(file_type) == false then
     vim.api.nvim_buf_set_keymap(0, "i", "<Tab>", "v:lua.tab_complete()", { expr = true })
     vim.api.nvim_buf_set_keymap(0, "s", "<Tab>", "v:lua.tab_complete()", { expr = true })
     vim.api.nvim_buf_set_keymap(0, "i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -81,11 +81,6 @@ M.setup = function()
     end
   end
 
-  vim.api.nvim_set_keymap("i", "<Tab>", "v:lua.tab_complete()", { expr = true })
-  vim.api.nvim_set_keymap("s", "<Tab>", "v:lua.tab_complete()", { expr = true })
-  vim.api.nvim_set_keymap("i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
-  vim.api.nvim_set_keymap("s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
-
   vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
   -- vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-e>", "compe#close('<C-e>')", { noremap = true, silent = true, expr = true })
@@ -93,4 +88,25 @@ M.setup = function()
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })
 end
 
+local is_text_file = function(file_type)
+  local text_file_types = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" }
+  print(file_type)
+  for _, type in ipairs(text_file_types) do
+    if type == file_type then
+      print("type is " .. type .. " : filetype is " .. file_type)
+      return true
+    end
+  end
+  return false
+end
+
+M.set_tab_keybindings = function()
+  local file_type = vim.fn.expand "%:e"
+  if is_text_file(file_type) == false then
+    vim.api.nvim_buf_set_keymap(0, "i", "<Tab>", "v:lua.tab_complete()", { expr = true })
+    vim.api.nvim_buf_set_keymap(0, "s", "<Tab>", "v:lua.tab_complete()", { expr = true })
+    vim.api.nvim_buf_set_keymap(0, "i", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
+    vim.api.nvim_buf_set_keymap(0, "s", "<S-Tab>", "v:lua.s_tab_complete()", { expr = true })
+  end
+end
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description
Currently, hitting TAB triggers autocomplete in all files.  In simple text files hitting TAB should insert a tab character.  
This pr allows a user to specify filetypes in which they don't want Compe mappings.
By default this pr excludes markdown and txt files.  
The list of filetypes can be specified with

``` 
lvim.builtin.compe.exclude_filetypes = { "md", "markdown", "mdown", "mkd", "mkdn", "mdwn", "text", "txt" },
```

Fixes #(issue)
https://github.com/ChristianChiarulli/LunarVim/issues/1121

## How Has This Been Tested?
Editing markdown files and making sure a tab character is inserted. 
Editing other files to make sure compe behavior remains the same
