### PR TITLE
include `package-lock.json` & `package.json` in root patterns

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -140,6 +140,16 @@ return {
     "airblade/vim-rooter",
     config = function()
       vim.g.rooter_silent_chdir = 1
+      vim.g.rooter_patterns = {
+        ".git",
+        "_darcs",
+        ".hg",
+        ".bzr",
+        ".svn",
+        "Makefile",
+        "package.json",
+        "package-lock.json",
+      }
       if lvim.builtin.rooter.on_config_done then
         lvim.builtin.rooter.on_config_done()
       end


### PR DESCRIPTION
* Just adds package.json and package-lock.json for the root patterns of
  vim-rooter

* The other ones are the default patterns, see `:help g:rooter_patterns`