### PR TITLE
feat: add diagnostics source name

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -41,6 +41,7 @@ lvim = {
       },
       signs = true,
       underline = true,
+      severity_sort = true,
     },
     override = {},
     document_highlight = true,

--- a/lua/lsp/handlers.lua
+++ b/lua/lsp/handlers.lua
@@ -9,6 +9,40 @@ function M.setup()
     underline = lvim.lsp.document_highlight,
   })
 
+  vim.lsp.handlers["textDocument/publishDiagnostics"] = function(_, _, params, client_id, _)
+    local config = { -- your config
+      virtual_text = lvim.lsp.diagnostics.virtual_text,
+      signs = lvim.lsp.diagnostics.signs,
+      underline = lvim.lsp.diagnostics.underline,
+      update_in_insert = lvim.lsp.diagnostics.update_in_insert,
+      severity_sort = lvim.lsp.diagnostics.severity_sort,
+    }
+    local uri = params.uri
+    local bufnr = vim.uri_to_bufnr(uri)
+
+    if not bufnr then
+      return
+    end
+
+    local diagnostics = params.diagnostics
+
+    for i, v in ipairs(diagnostics) do
+      diagnostics[i].message = string.format("%s: %s", v.source, v.message)
+
+      if vim.tbl_contains(vim.tbl_keys(v), "code") then
+        diagnostics[i].message = diagnostics[i].message .. string.format(" [%s]", v.code)
+      end
+    end
+
+    vim.lsp.diagnostic.save(diagnostics, bufnr, client_id)
+
+    if not vim.api.nvim_buf_is_loaded(bufnr) then
+      return
+    end
+
+    vim.lsp.diagnostic.display(diagnostics, bufnr, client_id, config)
+  end
+
   vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
     border = lvim.lsp.popup_border,
   })


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Add diagnostics' source name and to help distinguish where it's coming from.
- Add diagonstics' code to make it easier for the user to turn it off if the provider supports that.

## Fixes

`setup_handlers()` from lsp wasn't getting called also.

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/59826753/127737864-f7c566aa-11ed-4ed5-bd4a-333c2e9467e1.png)


