### PR TITLE
fix: correct vue lsp provider name

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -955,7 +955,7 @@ lvim.lang = {
     },
     linters = {},
     lsp = {
-      provider = "vetur",
+      provider = "vuels",
       setup = {
         cmd = {
           DATA_PATH .. "/lspinstall/vue/node_modules/.bin/vls",


### PR DESCRIPTION
# Description

Vue.js language server provider name vetur -> vuels

Fixes #1148 

## How Has This Been Tested?

Open a Vue.js project and vuels activates without issues
