### PR TITLE
[Feature]: Add path on status line galaxyline

### DIFF
--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -155,6 +155,37 @@ table.insert(gls.left, {
   },
 })
 
+table.insert(gls.left, {
+  FilePath = {
+    provider = function()
+      -- reduce longer path
+      -- eg. path/foo/bar/file.html -> ../bar/file.html
+      local path_div = function(path)
+        if path == nil then
+          return path
+        end
+        local paths = string.gmatch(path, "[^/]+")
+
+        local s = {}
+        for f in paths do
+          table.insert(s, f)
+        end
+
+        if #s <= 2 then
+          return path
+        end
+
+        return "../" .. table.concat(s, "/", #s - 1, #s)
+      end
+
+      vim.cmd "let path = expand('%:p')"
+      local path = vim.api.nvim_get_var "path"
+      return path_div(path)
+    end,
+    highlight = { colors.grey, colors.alt_bg },
+  },
+})
+
 table.insert(gls.right, {
   DiagnosticError = {
     provider = "DiagnosticError",


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Just small changes, adding the path status :)

Before:
![Screen Shot 2021-07-29 at 11 24 30](https://user-images.githubusercontent.com/3104624/127431432-b4dd3f44-a9cc-404d-8e23-a50d62b2e375.png)

After:
![Screen Shot 2021-07-29 at 11 25 22](https://user-images.githubusercontent.com/3104624/127431445-5f407547-6f9e-4f87-a35d-b5bc38593d14.png)


## How Has This Been Tested?

- Open lvim for specific file path:
    - `/example.txt` will be printed as `/example.txt`
    - `/tmp/example.txt` will be printed as `/tmp/example.txt`
    - `/tmp/files/path/example.txt` will be printed as `../path/example.txt`

