### PR TITLE
Just removing the old way of updating LunarVim

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,6 @@ To update plugins:
 To update LunarVim:
 
 ```bash
-# Master Branch
-cd ~/.config/nvim && git pull
-:PackerSync  
-
-# Rolling Branch
 cd ~/.local/share/lunarvim/lvim && git pull
 :PackerSync
 ```


### PR DESCRIPTION
There is only 1 way of updating LunarVim now.