### PR TITLE
[Bugfix] Disable dashboard when telescope is inactive

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,3 +1,8 @@
+if lvim.builtin.dashboard.active and not lvim.builtin.telescope.active then
+  lvim.builtin.dashboard.active = false
+  print "Telescope plugin must be active in order to use Dashboard"
+end
+
 return {
   -- Packer can manage itself as an optional plugin
   { "wbthomason/packer.nvim" },


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Disable Dashboard when Telescope is inactive since it depends on it. 

## How Has This Been Tested?

lv-config.lua
```
lvim.builtin.dashboard.active = true
lvim.builtin.telescope.active = false
```
