### PR TITLE
[Bugfix]: autocmd custom_groups not loaded

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,6 +12,7 @@ vim.cmd [[
 ]]
 -- vim.opt.rtp:append() instead of vim.cmd ?
 require "default-config"
+local autocmds = require "core.autocmds"
 require("settings").load_options()
 local status_ok, error = pcall(vim.cmd, "luafile ~/.config/lvim/lv-config.lua")
 if not status_ok then
@@ -19,7 +20,7 @@ if not status_ok then
   print(error)
 end
 require("settings").load_commands()
-require("core.autocmds").define_augroups(lvim.autocommands)
+autocmds.define_augroups(lvim.autocommands)
 
 require "keymappings"
 -- require("lsp").setup_default_bindings()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Setting up auto commands from `lv-config` didn't work. Default autocommands (`core.autocmds`) is loaded after `lv-config` is loaded, so the `lvim.autocommands.custom_groups` has never been assigned. I change the order to load the module `core.autocmds` to fix this issue.

## How Has This Been Tested?

- Add some autocmd on `lv-config` file.
```lua
lvim.autocommands.custom_groups = {
    { "ColorScheme", "*", "hi Visual guibg=#383d45" },
}
```
- Check the visual color is changed

