### PR TITLE
Refactor/remove logic from plugins

### DIFF
--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -1,51 +1,52 @@
--- if not package.loaded['nvim-autopairs'] then
---   return
--- end
-local status_ok, _ = pcall(require, "nvim-autopairs")
-if not status_ok then
-  return
-end
-local npairs = require "nvim-autopairs"
-local Rule = require "nvim-autopairs.rule"
+local M = {}
 
--- skip it, if you use another global object
-_G.MUtils = {}
+M.setup = function()
+  local npairs = require "nvim-autopairs"
+  local Rule = require "nvim-autopairs.rule"
 
-vim.g.completion_confirm_key = ""
-MUtils.completion_confirm = function()
-  if vim.fn.pumvisible() ~= 0 then
-    if vim.fn.complete_info()["selected"] ~= -1 then
-      return vim.fn["compe#confirm"](npairs.esc "<cr>")
+  -- skip it, if you use another global object
+  _G.MUtils = {}
+
+  vim.g.completion_confirm_key = ""
+  MUtils.completion_confirm = function()
+    if vim.fn.pumvisible() ~= 0 then
+      if vim.fn.complete_info()["selected"] ~= -1 then
+        return vim.fn["compe#confirm"](npairs.esc "<cr>")
+      else
+        return npairs.esc "<cr>"
+      end
     else
-      return npairs.esc "<cr>"
+      return npairs.autopairs_cr()
     end
-  else
-    return npairs.autopairs_cr()
   end
-end
 
-if package.loaded["compe"] then
-  require("nvim-autopairs.completion.compe").setup {
-    map_cr = true, --  map <CR> on insert mode
-    map_complete = true, -- it will auto insert `(` after select function or method item
+  if package.loaded["compe"] then
+    require("nvim-autopairs.completion.compe").setup {
+      map_cr = true, --  map <CR> on insert mode
+      map_complete = true, -- it will auto insert `(` after select function or method item
+    }
+  end
+
+  npairs.setup {
+    check_ts = true,
+    ts_config = {
+      lua = { "string" }, -- it will not add pair on that treesitter node
+      javascript = { "template_string" },
+      java = false, -- don't check treesitter on java
+    },
   }
+
+  require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
+
+  local ts_conds = require "nvim-autopairs.ts-conds"
+
+  -- press % => %% is only inside comment or string
+  npairs.add_rules {
+    Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
+    Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
+  }
+
+  return npairs
 end
 
-npairs.setup {
-  check_ts = true,
-  ts_config = {
-    lua = { "string" }, -- it will not add pair on that treesitter node
-    javascript = { "template_string" },
-    java = false, -- don't check treesitter on java
-  },
-}
-
-require("nvim-treesitter.configs").setup { autopairs = { enable = true } }
-
-local ts_conds = require "nvim-autopairs.ts-conds"
-
--- press % => %% is only inside comment or string
-npairs.add_rules {
-  Rule("%", "%", "lua"):with_pair(ts_conds.is_ts_node { "string", "comment" }),
-  Rule("$", "$", "lua"):with_pair(ts_conds.is_not_ts_node { "function" }),
-}
+return M

--- a/lua/core/autopairs.lua
+++ b/lua/core/autopairs.lua
@@ -1,4 +1,6 @@
-local M = {}
+local M = {
+  name = "autopairs",
+}
 
 M.setup = function()
   local npairs = require "nvim-autopairs"

--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -1,4 +1,6 @@
-local M = {}
+local M = {
+  name = "bufferline",
+}
 
 M.setup = function()
   vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })

--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -1,2 +1,8 @@
-vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
+local M = {}
+
+M.setup = function()
+  vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
+  vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
+end
+
+return M

--- a/lua/core/comment.lua
+++ b/lua/core/comment.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+M.setup = function()
+ local nvim_comment = require "nvim_comment"
+nvim_comment.setup()
+ return nvim_comment
+end
+
+return M

--- a/lua/core/comment.lua
+++ b/lua/core/comment.lua
@@ -1,9 +1,11 @@
-local M = {}
+local M = {
+  name = "comment",
+}
 
 M.setup = function()
- local nvim_comment = require "nvim_comment"
-nvim_comment.setup()
- return nvim_comment
+  local nvim_comment = require "nvim_comment"
+  nvim_comment.setup()
+  return nvim_comment
 end
 
 return M

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin.compe = {
     enabled = true,
@@ -36,11 +37,7 @@ end
 M.setup = function()
   vim.g.vsnip_snippet_dir = lvim.vsnip_dir
 
-  local status_ok, compe = pcall(require, "compe")
-  if not status_ok then
-    return
-  end
-
+  local compe = require("compe")
   compe.setup(lvim.builtin.compe)
 
   local t = function(str)
@@ -91,6 +88,8 @@ M.setup = function()
   vim.api.nvim_set_keymap("i", "<C-e>", "compe#close('<C-e>')", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-f>", "compe#scroll({ 'delta': +4 })", { noremap = true, silent = true, expr = true })
   vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })
+
+  return compe
 end
 
 return M

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "compe",
+}
 
 M.config = function()
-  lvim.builtin.compe = {
+  lvim[M.name] = {
     enabled = true,
     autocomplete = true,
     debug = false,
@@ -37,7 +39,7 @@ end
 M.setup = function()
   vim.g.vsnip_snippet_dir = lvim.vsnip_dir
 
-  local compe = require("compe")
+  local compe = require "compe"
   compe.setup(lvim.builtin.compe)
 
   local t = function(str)

--- a/lua/core/dap.lua
+++ b/lua/core/dap.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin.dap = {
     active = false,
@@ -12,10 +13,7 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, dap = pcall(require, "dap")
-  if not status_ok then
-    return
-  end
+  local dap = require "dap"
 
   vim.fn.sign_define("DapBreakpoint", lvim.builtin.dap.breakpoint)
   dap.defaults.fallback.terminal_win_cmd = "50vsplit new"
@@ -36,6 +34,8 @@ M.setup = function()
     s = { "<cmd>lua require'dap'.continue()<cr>", "Start" },
     q = { "<cmd>lua require'dap'.stop()<cr>", "Quit" },
   }
+
+  return dap
 end
 
 -- TODO put this up there ^^^ call in ftplugin

--- a/lua/core/dap.lua
+++ b/lua/core/dap.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "dap",
+}
 
 M.config = function()
-  lvim.builtin.dap = {
+  lvim.builtin[M.name] = {
     active = false,
     breakpoint = {
       text = "",

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin.dashboard = {
     active = false,

--- a/lua/core/dashboard.lua
+++ b/lua/core/dashboard.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "dashboard",
+}
 
 M.config = function()
-  lvim.builtin.dashboard = {
+  lvim.builtin[M.name] = {
     active = false,
     search_handler = "telescope",
     custom_header = {

--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -1,330 +1,331 @@
--- if not package.loaded['galaxyline'] then
---   return
--- end
-local status_ok, gl = pcall(require, "galaxyline")
-if not status_ok then
-  return
-end
+local M = {}
 
--- NOTE: if someone defines colors but doesn't have them then this will break
-local palette_status_ok, colors = pcall(require, lvim.colorscheme .. ".palette")
-if not palette_status_ok then
-  colors = lvim.builtin.galaxyline.colors
-end
+M.setup = function()
+  local gl = require "galaxyline"
 
-local condition = require "galaxyline.condition"
-local gls = gl.section
-gl.short_line_list = { "NvimTree", "vista", "dbui", "packer" }
+  -- NOTE: if someone defines colors but doesn't have them then this will break
+  local palette_status_ok, colors = pcall(require, lvim.colorscheme .. ".palette")
+  if not palette_status_ok then
+    colors = lvim.builtin.galaxyline.colors
+  end
 
-table.insert(gls.left, {
-  ViMode = {
-    provider = function()
-      -- auto change color according the vim mode
-      local mode_color = {
-        n = colors.blue,
-        i = colors.green,
-        v = colors.purple,
-        [""] = colors.purple,
-        V = colors.purple,
-        c = colors.magenta,
-        no = colors.blue,
-        s = colors.orange,
-        S = colors.orange,
-        [""] = colors.orange,
-        ic = colors.yellow,
-        R = colors.red,
-        Rv = colors.red,
-        cv = colors.blue,
-        ce = colors.blue,
-        r = colors.cyan,
-        rm = colors.cyan,
-        ["r?"] = colors.cyan,
-        ["!"] = colors.blue,
-        t = colors.blue,
-      }
-      vim.api.nvim_command("hi GalaxyViMode guifg=" .. mode_color[vim.fn.mode()])
-      return "▊"
-    end,
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { "NONE", colors.alt_bg },
-  },
-})
--- print(vim.fn.getbufvar(0, 'ts'))
-vim.fn.getbufvar(0, "ts")
+  local condition = require "galaxyline.condition"
+  local gls = gl.section
+  gl.short_line_list = { "NvimTree", "vista", "dbui", "packer" }
 
-table.insert(gls.left, {
-  GitIcon = {
-    provider = function()
-      return "  "
-    end,
-    condition = condition.check_git_workspace,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.orange, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    ViMode = {
+      provider = function()
+        -- auto change color according the vim mode
+        local mode_color = {
+          n = colors.blue,
+          i = colors.green,
+          v = colors.purple,
+          [""] = colors.purple,
+          V = colors.purple,
+          c = colors.magenta,
+          no = colors.blue,
+          s = colors.orange,
+          S = colors.orange,
+          [""] = colors.orange,
+          ic = colors.yellow,
+          R = colors.red,
+          Rv = colors.red,
+          cv = colors.blue,
+          ce = colors.blue,
+          r = colors.cyan,
+          rm = colors.cyan,
+          ["r?"] = colors.cyan,
+          ["!"] = colors.blue,
+          t = colors.blue,
+        }
+        vim.api.nvim_command("hi GalaxyViMode guifg=" .. mode_color[vim.fn.mode()])
+        return "▊"
+      end,
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { "NONE", colors.alt_bg },
+    },
+  })
+  -- print(vim.fn.getbufvar(0, 'ts'))
+  vim.fn.getbufvar(0, "ts")
 
-table.insert(gls.left, {
-  GitBranch = {
-    provider = "GitBranch",
-    condition = condition.check_git_workspace,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    GitIcon = {
+      provider = function()
+        return "  "
+      end,
+      condition = condition.check_git_workspace,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.orange, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  DiffAdd = {
-    provider = "DiffAdd",
-    condition = condition.hide_in_width,
-    icon = "  ",
-    highlight = { colors.green, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    GitBranch = {
+      provider = "GitBranch",
+      condition = condition.check_git_workspace,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  DiffModified = {
-    provider = "DiffModified",
-    condition = condition.hide_in_width,
-    icon = " 柳",
-    highlight = { colors.blue, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    DiffAdd = {
+      provider = "DiffAdd",
+      condition = condition.hide_in_width,
+      icon = "  ",
+      highlight = { colors.green, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  DiffRemove = {
-    provider = "DiffRemove",
-    condition = condition.hide_in_width,
-    icon = "  ",
-    highlight = { colors.red, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    DiffModified = {
+      provider = "DiffModified",
+      condition = condition.hide_in_width,
+      icon = " 柳",
+      highlight = { colors.blue, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.left, {
-  Filler = {
-    provider = function()
-      return " "
-    end,
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
--- get output from shell command
-function os.capture(cmd, raw)
-  local f = assert(io.popen(cmd, "r"))
-  local s = assert(f:read "*a")
-  f:close()
-  if raw then
+  table.insert(gls.left, {
+    DiffRemove = {
+      provider = "DiffRemove",
+      condition = condition.hide_in_width,
+      icon = "  ",
+      highlight = { colors.red, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.left, {
+    Filler = {
+      provider = function()
+        return " "
+      end,
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+  -- get output from shell command
+  function os.capture(cmd, raw)
+    local f = assert(io.popen(cmd, "r"))
+    local s = assert(f:read "*a")
+    f:close()
+    if raw then
+      return s
+    end
+    s = string.gsub(s, "^%s+", "")
+    s = string.gsub(s, "%s+$", "")
+    s = string.gsub(s, "[\n\r]+", " ")
     return s
   end
-  s = string.gsub(s, "^%s+", "")
-  s = string.gsub(s, "%s+$", "")
-  s = string.gsub(s, "[\n\r]+", " ")
-  return s
-end
--- cleanup virtual env
-local function env_cleanup(venv)
-  if string.find(venv, "/") then
-    local final_venv = venv
-    for w in venv:gmatch "([^/]+)" do
-      final_venv = w
+  -- cleanup virtual env
+  local function env_cleanup(venv)
+    if string.find(venv, "/") then
+      local final_venv = venv
+      for w in venv:gmatch "([^/]+)" do
+        final_venv = w
+      end
+      venv = final_venv
     end
-    venv = final_venv
+    return venv
   end
-  return venv
-end
-local PythonEnv = function()
-  if vim.bo.filetype == "python" then
-    local venv = os.getenv "CONDA_DEFAULT_ENV"
-    if venv ~= nil then
-      return "  (" .. env_cleanup(venv) .. ")"
-    end
-    venv = os.getenv "VIRTUAL_ENV"
-    if venv ~= nil then
-      return "  (" .. env_cleanup(venv) .. ")"
+  local PythonEnv = function()
+    if vim.bo.filetype == "python" then
+      local venv = os.getenv "CONDA_DEFAULT_ENV"
+      if venv ~= nil then
+        return "  (" .. env_cleanup(venv) .. ")"
+      end
+      venv = os.getenv "VIRTUAL_ENV"
+      if venv ~= nil then
+        return "  (" .. env_cleanup(venv) .. ")"
+      end
+      return ""
     end
     return ""
   end
-  return ""
-end
-table.insert(gls.left, {
-  VirtualEnv = {
-    provider = PythonEnv,
-    event = "BufEnter",
-    highlight = { colors.green, colors.alt_bg },
-  },
-})
+  table.insert(gls.left, {
+    VirtualEnv = {
+      provider = PythonEnv,
+      event = "BufEnter",
+      highlight = { colors.green, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  DiagnosticError = {
-    provider = "DiagnosticError",
-    icon = "  ",
-    highlight = { colors.red, colors.alt_bg },
-  },
-})
-table.insert(gls.right, {
-  DiagnosticWarn = {
-    provider = "DiagnosticWarn",
-    icon = "  ",
-    highlight = { colors.orange, colors.alt_bg },
-  },
-})
+  table.insert(gls.right, {
+    DiagnosticError = {
+      provider = "DiagnosticError",
+      icon = "  ",
+      highlight = { colors.red, colors.alt_bg },
+    },
+  })
+  table.insert(gls.right, {
+    DiagnosticWarn = {
+      provider = "DiagnosticWarn",
+      icon = "  ",
+      highlight = { colors.orange, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  DiagnosticInfo = {
-    provider = "DiagnosticInfo",
-    icon = "  ",
-    highlight = { colors.yellow, colors.alt_bg },
-  },
-})
+  table.insert(gls.right, {
+    DiagnosticInfo = {
+      provider = "DiagnosticInfo",
+      icon = "  ",
+      highlight = { colors.yellow, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  DiagnosticHint = {
-    provider = "DiagnosticHint",
-    icon = "  ",
-    highlight = { colors.blue, colors.alt_bg },
-  },
-})
+  table.insert(gls.right, {
+    DiagnosticHint = {
+      provider = "DiagnosticHint",
+      icon = "  ",
+      highlight = { colors.blue, colors.alt_bg },
+    },
+  })
 
-table.insert(gls.right, {
-  TreesitterIcon = {
-    provider = function()
-      if next(vim.treesitter.highlighter.active) ~= nil then
-        return "  "
-      end
-      return ""
-    end,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.green, colors.alt_bg },
-  },
-})
-
-local get_lsp_client = function(msg)
-  msg = msg or "LSP Inactive"
-  local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
-  local clients = vim.lsp.get_active_clients()
-  if next(clients) == nil then
-    return msg
-  end
-  local lsps = ""
-  for _, client in ipairs(clients) do
-    local filetypes = client.config.filetypes
-    if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
-      -- print(client.name)
-      if lsps == "" then
-        -- print("first", lsps)
-        lsps = client.name
-      else
-        if not string.find(lsps, client.name) then
-          lsps = lsps .. ", " .. client.name
+  table.insert(gls.right, {
+    TreesitterIcon = {
+      provider = function()
+        if next(vim.treesitter.highlighter.active) ~= nil then
+          return "  "
         end
-        -- print("more", lsps)
+        return ""
+      end,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.green, colors.alt_bg },
+    },
+  })
+
+  local get_lsp_client = function(msg)
+    msg = msg or "LSP Inactive"
+    local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
+    local clients = vim.lsp.get_active_clients()
+    if next(clients) == nil then
+      return msg
+    end
+    local lsps = ""
+    for _, client in ipairs(clients) do
+      local filetypes = client.config.filetypes
+      if filetypes and vim.fn.index(filetypes, buf_ft) ~= -1 then
+        -- print(client.name)
+        if lsps == "" then
+          -- print("first", lsps)
+          lsps = client.name
+        else
+          if not string.find(lsps, client.name) then
+            lsps = lsps .. ", " .. client.name
+          end
+          -- print("more", lsps)
+        end
       end
     end
+    if lsps == "" then
+      return msg
+    else
+      return lsps
+    end
   end
-  if lsps == "" then
-    return msg
-  else
-    return lsps
-  end
+
+  table.insert(gls.right, {
+    ShowLspClient = {
+      provider = get_lsp_client,
+      condition = function()
+        local tbl = { ["dashboard"] = true, [" "] = true }
+        if tbl[vim.bo.filetype] then
+          return false
+        end
+        return true
+      end,
+      icon = " ",
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    LineInfo = {
+      provider = "LineColumn",
+      separator = "  ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    PerCent = {
+      provider = "LinePercent",
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    Tabstop = {
+      provider = function()
+        local label = "Spaces: "
+        if not vim.api.nvim_buf_get_option(0, "expandtab") then
+          label = "Tab size: "
+        end
+        return label .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
+      end,
+      condition = condition.hide_in_width,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    BufferType = {
+      provider = "FileTypeName",
+      condition = condition.hide_in_width,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    FileEncode = {
+      provider = "FileEncode",
+      condition = condition.hide_in_width,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.right, {
+    Space = {
+      provider = function()
+        return " "
+      end,
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.grey, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.short_line_left, {
+    BufferType = {
+      provider = "FileTypeName",
+      separator = " ",
+      separator_highlight = { "NONE", colors.alt_bg },
+      highlight = { colors.alt_bg, colors.alt_bg },
+    },
+  })
+
+  table.insert(gls.short_line_left, {
+    SFileName = {
+      provider = "SFileName",
+      condition = condition.buffer_not_empty,
+      highlight = { colors.alt_bg, colors.alt_bg },
+    },
+  })
+
+  --table.insert(gls.short_line_right[1] = {BufferIcon = {provider = 'BufferIcon', highlight = {colors.grey, colors.alt_bg}}})
+  return gl
 end
 
-table.insert(gls.right, {
-  ShowLspClient = {
-    provider = get_lsp_client,
-    condition = function()
-      local tbl = { ["dashboard"] = true, [" "] = true }
-      if tbl[vim.bo.filetype] then
-        return false
-      end
-      return true
-    end,
-    icon = " ",
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  LineInfo = {
-    provider = "LineColumn",
-    separator = "  ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  PerCent = {
-    provider = "LinePercent",
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  Tabstop = {
-    provider = function()
-      local label = "Spaces: "
-      if not vim.api.nvim_buf_get_option(0, "expandtab") then
-        label = "Tab size: "
-      end
-      return label .. vim.api.nvim_buf_get_option(0, "shiftwidth") .. " "
-    end,
-    condition = condition.hide_in_width,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  BufferType = {
-    provider = "FileTypeName",
-    condition = condition.hide_in_width,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  FileEncode = {
-    provider = "FileEncode",
-    condition = condition.hide_in_width,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.right, {
-  Space = {
-    provider = function()
-      return " "
-    end,
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.grey, colors.alt_bg },
-  },
-})
-
-table.insert(gls.short_line_left, {
-  BufferType = {
-    provider = "FileTypeName",
-    separator = " ",
-    separator_highlight = { "NONE", colors.alt_bg },
-    highlight = { colors.alt_bg, colors.alt_bg },
-  },
-})
-
-table.insert(gls.short_line_left, {
-  SFileName = {
-    provider = "SFileName",
-    condition = condition.buffer_not_empty,
-    highlight = { colors.alt_bg, colors.alt_bg },
-  },
-})
-
---table.insert(gls.short_line_right[1] = {BufferIcon = {provider = 'BufferIcon', highlight = {colors.grey, colors.alt_bg}}})
+return M

--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -1,4 +1,6 @@
-local M = {}
+local M = {
+  name = "galaxyline",
+}
 
 M.setup = function()
   local gl = require "galaxyline"

--- a/lua/core/gitsigns.lua
+++ b/lua/core/gitsigns.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin.gitsigns = {
     signs = {
@@ -49,11 +50,9 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, gitsigns = pcall(require, "gitsigns")
-  if not status_ok then
-    return
-  end
+  local gitsigns = require "gitsigns"
   gitsigns.setup(lvim.builtin.gitsigns)
+  return gitsigns
 end
 
 return M

--- a/lua/core/gitsigns.lua
+++ b/lua/core/gitsigns.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "gitsigns",
+}
 
 M.config = function()
-  lvim.builtin.gitsigns = {
+  lvim.builtin[M.name] = {
     signs = {
       add = {
         hl = "GitSignsAdd",

--- a/lua/core/lspinstall.lua
+++ b/lua/core/lspinstall.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+M.setup = function()
+  local lspinstall = require "lspinstall"
+  lspinstall.setup()
+  return lspinstall
+end
+
+return M

--- a/lua/core/lspinstall.lua
+++ b/lua/core/lspinstall.lua
@@ -1,4 +1,6 @@
-local M = {}
+local M = {
+  name = "lspinstall",
+}
 
 M.setup = function()
   local lspinstall = require "lspinstall"

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "nvimtree",
+}
 --
 M.config = function()
-  lvim.builtin.nvimtree = {
+  lvim.builtin[M.name] = {
     side = "left",
     show_icons = {
       git = 1,
@@ -46,7 +48,7 @@ M.config = function()
 end
 --
 M.setup = function()
-  nvim_tree_config = require "nvim-tree.config"
+  local nvim_tree_config = require "nvim-tree.config"
 
   local g = vim.g
   for opt, val in pairs(lvim.builtin.nvimtree) do

--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -46,12 +46,9 @@ M.config = function()
 end
 --
 M.setup = function()
-  local status_ok, nvim_tree_config = pcall(require, "nvim-tree.config")
-  if not status_ok then
-    return
-  end
-  local g = vim.g
+  nvim_tree_config = require "nvim-tree.config"
 
+  local g = vim.g
   for opt, val in pairs(lvim.builtin.nvimtree) do
     g["nvim_tree_" .. opt] = val
   end
@@ -63,6 +60,8 @@ M.setup = function()
     { key = "h", cb = tree_cb "close_node" },
     { key = "v", cb = tree_cb "vsplit" },
   }
+
+  return nvim_tree_config
 end
 --
 --

--- a/lua/core/rooter.lua
+++ b/lua/core/rooter.lua
@@ -1,4 +1,6 @@
-local M = {}
+local M = {
+  name = "rooter",
+}
 
 M.setup = function()
   vim.g.rooter_silent_chdir = 1

--- a/lua/core/rooter.lua
+++ b/lua/core/rooter.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+M.setup = function()
+  vim.g.rooter_silent_chdir = 1
+end
+
+return M

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -1,4 +1,4 @@
-local M = {}
+local M = { name = "telescope" }
 
 M.config = function()
   local status_ok, actions = pcall(require, "telescope.actions")
@@ -6,8 +6,8 @@ M.config = function()
     return
   end
 
-  lvim.builtin.telescope = {
-    active = false,
+  lvim.builtin[M.name] = {
+    active = true,
     defaults = {
       prompt_prefix = " ",
       selection_caret = " ",

--- a/lua/core/telescope.lua
+++ b/lua/core/telescope.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   local status_ok, actions = pcall(require, "telescope.actions")
   if not status_ok then
@@ -77,11 +78,9 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, telescope = pcall(require, "telescope")
-  if not status_ok then
-    return
-  end
+  local telescope = require "telescope"
   telescope.setup(lvim.builtin.telescope)
+  return telescope
 end
 
 return M

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin["terminal"] = {
     -- size can be a number or function which is passed the current terminal
@@ -36,11 +37,8 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, terminal = pcall(require, "toggleterm")
-  if not status_ok then
-    print(terminal)
-    return
-  end
+  local terminal = require "toggleterm"
+
   vim.api.nvim_set_keymap(
     "n",
     "<leader>gg",
@@ -49,6 +47,7 @@ M.setup = function()
   )
   lvim.builtin.which_key.mappings["gg"] = "LazyGit"
   terminal.setup(lvim.builtin.terminal)
+  return terminal
 end
 
 local function is_installed(exe)
@@ -56,7 +55,7 @@ local function is_installed(exe)
 end
 
 M._lazygit_toggle = function()
-  if is_installed "lazygit" ~= true then
+  if is_installed "lazygit" == false then
     print "Please install lazygit. Check documentation for more information"
     return
   end

--- a/lua/core/terminal.lua
+++ b/lua/core/terminal.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "terminal",
+}
 
 M.config = function()
-  lvim.builtin["terminal"] = {
+  lvim.builtin[M.name] = {
     -- size can be a number or function which is passed the current terminal
     size = 5,
     -- open_mapping = [[<c-\>]],

--- a/lua/core/treesitter.lua
+++ b/lua/core/treesitter.lua
@@ -1,7 +1,9 @@
-local M = {}
+local M = {
+  name = "treesitter",
+}
 
 M.config = function()
-  lvim.builtin.treesitter = {
+  lvim.builtin[M.name] = {
     ensure_installed = {}, -- one of "all", "maintained" (parsers with maintainers), or a list of languages
     ignore_install = {},
     matchup = {

--- a/lua/core/treesitter.lua
+++ b/lua/core/treesitter.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin.treesitter = {
     ensure_installed = {}, -- one of "all", "maintained" (parsers with maintainers), or a list of languages
@@ -62,12 +63,9 @@ M.config = function()
 end
 
 M.setup = function()
-  local status_ok, treesitter_configs = pcall(require, "nvim-treesitter.configs")
-  if not status_ok then
-    return
-  end
-
+  local treesitter_configs = require "nvim-treesitter.configs"
   treesitter_configs.setup(lvim.builtin.treesitter)
+  return treesitter_configs
 end
 
 return M

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -1,8 +1,10 @@
-local M = {}
+local M = {
+  name = "which_key",
+}
 
 M.config = function()
-  lvim.builtin.which_key = {
-    active = false,
+  lvim.builtin[M.name] = {
+    active = true,
     setup = {
       plugins = {
         marks = true, -- shows a list of your marks on ' and `

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 M.config = function()
   lvim.builtin.which_key = {
     active = false,
@@ -187,14 +188,7 @@ M.config = function()
 end
 
 M.setup = function()
-  -- if not package.loaded['which-key'] then
-  --  return
-  -- end
-  local status_ok, which_key = pcall(require, "which-key")
-  if not status_ok then
-    return
-  end
-
+  local which_key = require "which-key"
   which_key.setup(lvim.builtin.which_key.setup)
 
   local opts = lvim.builtin.which_key.opts
@@ -203,10 +197,10 @@ M.setup = function()
   local mappings = lvim.builtin.which_key.mappings
   local vmappings = lvim.builtin.which_key.vmappings
 
-  local wk = require "which-key"
+  which_key.register(mappings, opts)
+  which_key.register(vmappings, vopts)
 
-  wk.register(mappings, opts)
-  wk.register(vmappings, vopts)
+  return which_key
 end
 
 return M

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -14,25 +14,6 @@ lvim = {
   database = { save_location = "~/.config/lunarvim_db", auto_execute = 1 },
   keys = {},
 
-  -- TODO why do we need this?
-  builtin = {
-    lspinstall = {},
-    telescope = {},
-    compe = {},
-    autopairs = {},
-    treesitter = {},
-    nvimtree = {},
-    gitsigns = {},
-    which_key = {},
-    comment = {},
-    rooter = {},
-    galaxyline = {},
-    bufferline = {},
-    dap = {},
-    dashboard = {},
-    terminal = {},
-  },
-
   lsp = {
     diagnostics = {
       virtual_text = {
@@ -48,6 +29,8 @@ lvim = {
     default_keybinds = true,
     on_attach_callback = nil,
   },
+
+  builtin = {},
 
   plugins = {
     -- use lv-config.lua for this not put here

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -7,13 +7,7 @@ return {
   {
     "kabouzeid/nvim-lspinstall",
     event = "VimEnter",
-    config = function()
-      local lspinstall = require "lspinstall"
-      lspinstall.setup()
-      if lvim.builtin.lspinstall.on_config_done then
-        lvim.builtin.lspinstall.on_config_done(lspinstall)
-      end
-    end,
+    config = require("core.lspinstall").setup,
   },
 
   { "nvim-lua/popup.nvim" },
@@ -23,36 +17,14 @@ return {
   -- Telescope
   {
     "nvim-telescope/telescope.nvim",
-    config = function()
-      require("core.telescope").setup()
-      if lvim.builtin.telescope.on_config_done then
-        lvim.builtin.telescope.on_config_done(require "telescope")
-      end
-    end,
+    config = require("core.telescope").setup,
   },
-
-  -- Autocomplete
-  -- {
-  --   "hrsh7th/nvim-compe",
-  --   event = "InsertEnter",
-  --   config = function()
-  --     require("core.compe").setup()
-  --     if lvim.builtin.compe.on_config_done then
-  --       lvim.builtin.compe.on_config_done(require "compe")
-  --     end
-  --   end,
-  -- },
 
   -- Completion & Snippets
   {
     "hrsh7th/nvim-compe",
     event = "InsertEnter",
-    config = function()
-      require("core.compe").setup()
-      if lvim.builtin.compe.on_config_done then
-        lvim.builtin.compe.on_config_done(require "compe")
-      end
-    end,
+    config = require("core.compe").setup,
     wants = "vim-vsnip",
     requires = {
       {
@@ -72,12 +44,7 @@ return {
     "windwp/nvim-autopairs",
     -- event = "InsertEnter",
     after = "nvim-compe",
-    config = function()
-      require "core.autopairs"
-      if lvim.builtin.autopairs.on_config_done then
-        lvim.builtin.autopairs.on_config_done(require "nvim-autopairs")
-      end
-    end,
+    config = require("core.autopairs").setup,
   },
 
   -- Treesitter
@@ -85,12 +52,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     branch = "0.5-compat",
     -- run = ":TSUpdate",
-    config = function()
-      require("core.treesitter").setup()
-      if lvim.builtin.treesitter.on_config_done then
-        lvim.builtin.treesitter.on_config_done(require "nvim-treesitter.configs")
-      end
-    end,
+    config = require("core.treesitter").setup,
   },
 
   -- NvimTree
@@ -99,35 +61,19 @@ return {
     -- event = "BufWinOpen",
     -- cmd = "NvimTreeToggle",
     -- commit = "fd7f60e242205ea9efc9649101c81a07d5f458bb",
-    config = function()
-      require("core.nvimtree").setup()
-      if lvim.builtin.nvimtree.on_config_done then
-        lvim.builtin.nvimtree.on_config_done(require "nvim-tree.config")
-      end
-    end,
+    config = require("core.nvimtree").setup,
   },
 
   {
     "lewis6991/gitsigns.nvim",
-
-    config = function()
-      require("core.gitsigns").setup()
-      if lvim.builtin.gitsigns.on_config_done then
-        lvim.builtin.gitsigns.on_config_done(require "gitsigns")
-      end
-    end,
+    config = require("core.gitsigns").setup,
     event = "BufRead",
   },
 
   -- Whichkey
   {
     "folke/which-key.nvim",
-    config = function()
-      require("core.which-key").setup()
-      if lvim.builtin.which_key.on_config_done then
-        lvim.builtin.which_key.on_config_done(require "which-key")
-      end
-    end,
+    config = require("core.which-key").setup,
     event = "BufWinEnter",
   },
 
@@ -135,27 +81,13 @@ return {
   {
     "terrortylor/nvim-comment",
     event = "BufRead",
-    config = function()
-      local status_ok, nvim_comment = pcall(require, "nvim_comment")
-      if not status_ok then
-        return
-      end
-      nvim_comment.setup()
-      if lvim.builtin.comment.on_config_done then
-        lvim.builtin.comment.on_config_done(nvim_comment)
-      end
-    end,
+    config = require("core.comment").setup,
   },
 
   -- vim-rooter
   {
     "airblade/vim-rooter",
-    config = function()
-      vim.g.rooter_silent_chdir = 1
-      if lvim.builtin.rooter.on_config_done then
-        lvim.builtin.rooter.on_config_done()
-      end
-    end,
+    config = require("core.rooter").setup,
   },
 
   -- Icons
@@ -164,24 +96,14 @@ return {
   -- Status Line and Bufferline
   {
     "glepnir/galaxyline.nvim",
-    config = function()
-      require "core.galaxyline"
-      if lvim.builtin.galaxyline.on_config_done then
-        lvim.builtin.galaxyline.on_config_done(require "galaxyline")
-      end
-    end,
+    config = require("core.galaxyline").setup,
     event = "BufWinEnter",
     disable = not lvim.builtin.galaxyline.active,
   },
 
   {
     "romgrk/barbar.nvim",
-    config = function()
-      require "core.bufferline"
-      if lvim.builtin.bufferline.on_config_done then
-        lvim.builtin.bufferline.on_config_done()
-      end
-    end,
+    config = require("core.bufferline").setup,
     event = "BufWinEnter",
   },
 
@@ -189,12 +111,7 @@ return {
   {
     "mfussenegger/nvim-dap",
     -- event = "BufWinEnter",
-    config = function()
-      require("core.dap").setup()
-      if lvim.builtin.dap.on_config_done then
-        lvim.builtin.dap.on_config_done(require "dap")
-      end
-    end,
+    config = require("core.dap").setup,
     disable = not lvim.builtin.dap.active,
   },
 
@@ -210,12 +127,7 @@ return {
   {
     "ChristianChiarulli/dashboard-nvim",
     event = "BufWinEnter",
-    config = function()
-      require("core.dashboard").setup()
-      if lvim.builtin.dashboard.on_config_done then
-        lvim.builtin.dashboard.on_config_done(require "dashboard")
-      end
-    end,
+    config = require("core.dashboard").setup,
     disable = not lvim.builtin.dashboard.active,
   },
 
@@ -223,12 +135,7 @@ return {
   {
     "akinsho/nvim-toggleterm.lua",
     event = "BufWinEnter",
-    config = function()
-      require("core.terminal").setup()
-      if lvim.builtin.terminal.on_config_done then
-        lvim.builtin.terminal.on_config_done(require "toggleterm")
-      end
-    end,
+    config = require("core.terminal").setup,
     disable = not lvim.builtin.terminal.active,
   },
 }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -7,7 +7,7 @@ return {
   {
     "kabouzeid/nvim-lspinstall",
     event = "VimEnter",
-    config = require("core.lspinstall").setup,
+    _builtin = require "core.lspinstall",
   },
 
   { "nvim-lua/popup.nvim" },
@@ -17,14 +17,13 @@ return {
   -- Telescope
   {
     "nvim-telescope/telescope.nvim",
-    config = require("core.telescope").setup,
+    _builtin = require "core.telescope",
   },
 
   -- Completion & Snippets
   {
     "hrsh7th/nvim-compe",
     event = "InsertEnter",
-    config = require("core.compe").setup,
     wants = "vim-vsnip",
     requires = {
       {
@@ -37,6 +36,7 @@ return {
         event = "InsertCharPre",
       },
     },
+    _builtin = require "core.compe",
   },
 
   -- Autopairs
@@ -44,7 +44,7 @@ return {
     "windwp/nvim-autopairs",
     -- event = "InsertEnter",
     after = "nvim-compe",
-    config = require("core.autopairs").setup,
+    _builtin = require "core.autopairs",
   },
 
   -- Treesitter
@@ -52,7 +52,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     branch = "0.5-compat",
     -- run = ":TSUpdate",
-    config = require("core.treesitter").setup,
+    _builtin = require "core.treesitter",
   },
 
   -- NvimTree
@@ -61,33 +61,33 @@ return {
     -- event = "BufWinOpen",
     -- cmd = "NvimTreeToggle",
     -- commit = "fd7f60e242205ea9efc9649101c81a07d5f458bb",
-    config = require("core.nvimtree").setup,
+    _builtin = require "core.nvimtree",
   },
 
   {
     "lewis6991/gitsigns.nvim",
-    config = require("core.gitsigns").setup,
     event = "BufRead",
+    _builtin = require "core.gitsigns",
   },
 
   -- Whichkey
   {
     "folke/which-key.nvim",
-    config = require("core.which-key").setup,
     event = "BufWinEnter",
+    _builtin = require "core.which-key",
   },
 
   -- Comments
   {
     "terrortylor/nvim-comment",
     event = "BufRead",
-    config = require("core.comment").setup,
+    _builtin = require "core.comment",
   },
 
   -- vim-rooter
   {
     "airblade/vim-rooter",
-    config = require("core.rooter").setup,
+    _builtin = require "core.rooter",
   },
 
   -- Icons
@@ -96,23 +96,21 @@ return {
   -- Status Line and Bufferline
   {
     "glepnir/galaxyline.nvim",
-    config = require("core.galaxyline").setup,
     event = "BufWinEnter",
-    disable = not lvim.builtin.galaxyline.active,
+    _builtin = require "core.galaxyline",
   },
 
   {
     "romgrk/barbar.nvim",
-    config = require("core.bufferline").setup,
     event = "BufWinEnter",
+    _builtin = require "core.bufferline",
   },
 
   -- Debugging
   {
     "mfussenegger/nvim-dap",
     -- event = "BufWinEnter",
-    config = require("core.dap").setup,
-    disable = not lvim.builtin.dap.active,
+    _builtin = require "core.dap",
   },
 
   -- Debugger management
@@ -120,22 +118,19 @@ return {
     "Pocco81/DAPInstall.nvim",
     -- event = "BufWinEnter",
     -- event = "BufRead",
-    disable = not lvim.builtin.dap.active,
   },
 
   -- Dashboard
   {
     "ChristianChiarulli/dashboard-nvim",
     event = "BufWinEnter",
-    config = require("core.dashboard").setup,
-    disable = not lvim.builtin.dashboard.active,
+    _builtin = require "core.dashboard",
   },
 
   -- Terminal
   {
     "akinsho/nvim-toggleterm.lua",
     event = "BufWinEnter",
-    config = require("core.terminal").setup,
-    disable = not lvim.builtin.terminal.active,
+    _builtin = require "core.terminal",
   },
 }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

This removes logic from plugins.lua (as it should be).
What stays in plugins.lua is all the hardcoded configuration liek the package name, events lazy loading the plugin, ect ...
The logic that's configurable by the user like the disable flag or the new callback provided once the plugin is loaded would be automatically handled by the plugin-loader.
Doing this we make sure that the plugin configuration is taken into account and minimize the risk of forgetting things while refactoring / implementing new features.
One [example](https://github.com/ChristianChiarulli/LunarVim/blob/0.5.1/lua/core/which-key.lua#L4) among probably many more.

This PR will stay a draft as long as [packer relies on strings.dump](https://github.com/wbthomason/packer.nvim/discussions/513)
I had this on a separate branch, but I think it's better to share it with everyone.