### PR TITLE
[Feature]: Add gdscript LSP support

### DIFF
--- a/ftplugin/gdscript.lua
+++ b/ftplugin/gdscript.lua
@@ -1,0 +1,1 @@
+require("lsp").setup "gdscript"

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1000,6 +1000,22 @@ lvim.lang = {
       },
     },
   },
+  gdscript = {
+    formatter = {},
+    linters = {},
+    lsp = {
+      provider = "gdscript",
+      setup = {
+        cmd = {
+          "nc",
+          "localhost",
+          "6008",
+        },
+        on_attach = common_on_attach,
+        capabilities = common_capabilities,
+      },
+    },
+  },
 }
 
 require("core.which-key").config()


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Close #358 by adding LSP support for gdscript, **syntax highlighting is already supported by tree-sitter.**

LSP config reference: https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#gdscript

One small problem about using `nc` as executable is that **some** version of `nc` doesn't work.
In my testing the GNU `nc` installed with homebrew failed to run, but BSD `nc` bundled with macOs work just fine, also `ncat` from `nmap` work fine too.

Furthermore, windows user *may* want to use their own version of `nc` binary replacement.


To use custom `nc`, small hack in `lv-config.lua`:
```lua
lvim.lang.gdscript.lsp.setup.cmd[1] = "ncat"
```
or just fix path..


Fixes
#358

## How Has This Been Tested?

With Godot Engine opened, LspInfo show that it's attached and code completion is working.


