### PR TITLE
[Bugfix] Fix formatter and linter for r

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -712,11 +712,10 @@ lvim.lang = {
       },
     },
   },
-  -- R -e 'install.packages("formatR",repos = "http://cran.us.r-project.org")'
-  -- R -e 'install.packages("readr",repos = "http://cran.us.r-project.org")'
+  -- R -e 'install::packages("languageserver")'
   r = {
     formatter = {
-      exe = "format_r",
+      exe = "",
       args = {},
     },
     linters = {},


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

After I updated LunarVim to 0.5.1, I got a warning when an`.Rmd` file is opened. `galaxyline` complains about `formatter`. 

![Screenshot from 2021-07-29 10-12-19](https://user-images.githubusercontent.com/60116296/127543056-60bd1a66-ef68-4d69-8a79-8f941dc065f1.png)

After checking the original default config for r, 
I notice a typo for the `formatter` field. It should be `formatR`, instead of `format_r`. After I changed it, the bug was fixed.
But then I looked at the `READEME` file for [`languageserver`](https://cran.r-project.org/web/packages/languageserver/readme/README.html)
and found that this lsp uses `styler` for formatting and `lintr` for linting. 

It is also mentioned in the book [R Markdown Cookbook](https://bookdown.org/yihui/rmarkdown-cookbook/opts-tidy.html) that,

> The **styler** package has richer features than **formatR**. 

These two packages are automatically installed when the package `r_language_server` package is installed in R. I feel setting the default `formatter` to `styler` will be better and easier for the users.

So I removed the dependencies and modified `formatter` and `linter` fields for R in the default-config.lua file. I added a comment line on installation of the language server itself. 

Fixes #(issue)
This improves the fix to issue #953, @abzcoding.

## How Has This Been Tested?

This is tested by introducing format errors to an R file and to an R code chunks in Rmd file, followed by:
* Run command :w
* Check the file and found the errors were automatically corrected.

