### PR TITLE
Bugfix: Protect against a strict umask

### DIFF
--- a/utils/installer/install.sh
+++ b/utils/installer/install.sh
@@ -113,6 +113,7 @@ cloneconfig() {
 	esac
 	mkdir -p "$HOME/.config/lvim"
 	sudo cp "$HOME/.local/share/lunarvim/lvim/utils/bin/lvim" "/usr/local/bin"
+	sudo chmod a+rx /usr/local/bin/lvim
 	cp "$HOME/.local/share/lunarvim/lvim/utils/installer/lv-config.example-no-ts.lua" "$HOME/.config/lvim/lv-config.lua"
 
 	nvim -u ~/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=~/.local/share/lunarvim/lvim" --headless \


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

When a user has a non-permissive umask, the execute or even read permissions may be missing on /usr/local/bin/lvim after the sudo cp step

Fixes #(issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. \
Provide instructions so we can reproduce. \
Please also list any relevant details for your test configuration.

- Run command `:mycommand`
- Check logs
- ...

