### PR TITLE
[Refactor] Define keymapppings helpers in utils.keymap

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,8 +22,10 @@ end
 require("settings").load_commands()
 autocmds.define_augroups(lvim.autocommands)
 
-require "keymappings"
--- require("lsp").setup_default_bindings()
+local keymap = require "utils.keymap"
+local default_keymaps = require "keymappings"
+keymap.load(default_keymaps.keymaps, default_keymaps.opts)
+keymap.load(lvim.keys, default_keymaps.opts)
 
 local plugins = require "plugins"
 local plugin_loader = require("plugin-loader").init()

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,16 +1,13 @@
-local keymap = require "utils.keymap"
-local MODE = keymap.MODE
-
 local opts = {
-  [MODE.INSERT] = { noremap = true, silent = true },
-  [MODE.NORMAL] = { noremap = true, silent = true },
-  [MODE.VISUAL] = { noremap = true, silent = true },
-  [MODE.VISUAL_BLOCK] = { noremap = true, silent = true },
-  [MODE.TERM] = { silent = true },
+  insert_mode = { noremap = true, silent = true },
+  normal_mode = { noremap = true, silent = true },
+  visual_mode = { noremap = true, silent = true },
+  visual_block_mode = { noremap = true, silent = true },
+  term_mode = { silent = true },
 }
 
 local default_keys = {
-  [MODE.INSERT] = {
+  insert_mode = {
     -- I hate escape
     { "jk", "<ESC>" },
     { "kj", "<ESC>" },
@@ -25,7 +22,7 @@ local default_keys = {
     { "<A-Right>", "<C-\\><C-N><C-w>l" },
   },
 
-  [MODE.NORMAL] = {
+  normal_mode = {
     -- Better window movement
     { "<C-h>", "<C-w>h" },
     { "<C-j>", "<C-w>j" },
@@ -54,7 +51,7 @@ local default_keys = {
     -- {'<C-TAB>', 'compe#complete()', {noremap = true, silent = true, expr = true}},
   },
 
-  [MODE.TERM] = {
+  term_mode = {
     -- Terminal window navigation
     { "<C-h>", "<C-\\><C-N><C-w>h" },
     { "<C-j>", "<C-\\><C-N><C-w>j" },
@@ -62,7 +59,7 @@ local default_keys = {
     { "<C-l>", "<C-\\><C-N><C-w>l" },
   },
 
-  [MODE.VISUAL] = {
+  visual_mode = {
     -- Better indenting
     { "<", "<gv" },
     { ">", ">gv" },
@@ -71,7 +68,7 @@ local default_keys = {
     -- { "P", '"0P', { silent = true } },
   },
 
-  [MODE.VISUAL_BLOCK] = {
+  visual_block_mode = {
     -- Move selected line / block of text in visual mode
     { "K", ":move '<-2<CR>gv-gv" },
     { "J", ":move '>+1<CR>gv-gv" },
@@ -84,14 +81,15 @@ local default_keys = {
 
 if vim.fn.has "mac" == 1 then
   -- TODO: fix this
-  default_keys[MODE.NORMAL][5][1] = "<A-Up>"
-  default_keys[MODE.NORMAL][6][1] = "<A-Down>"
-  default_keys[MODE.NORMAL][7][1] = "<A-Left>"
-  default_keys[MODE.NORMAL][8][1] = "<A-Right>"
+  default_keys.normal_mode[5][1] = "<A-Up>"
+  default_keys.normal_mode[6][1] = "<A-Down>"
+  default_keys.normal_mode[7][1] = "<A-Left>"
+  default_keys.normal_mode[8][1] = "<A-Right>"
 end
 
 vim.g.mapleader = lvim.leader == "space" and " " or lvim.leader
 
+local keymap = require "utils.keymap"
 local keymaps = vim.tbl_deep_extend("force", default_keys, lvim.keys)
 keymap.load(keymaps, opts)
 

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -6,7 +6,7 @@ local opts = {
   term_mode = { silent = true },
 }
 
-local default_keys = {
+local keymaps = {
   insert_mode = {
     -- I hate escape
     { "jk", "<ESC>" },
@@ -81,19 +81,17 @@ local default_keys = {
 
 if vim.fn.has "mac" == 1 then
   -- TODO: fix this
-  default_keys.normal_mode[5][1] = "<A-Up>"
-  default_keys.normal_mode[6][1] = "<A-Down>"
-  default_keys.normal_mode[7][1] = "<A-Left>"
-  default_keys.normal_mode[8][1] = "<A-Right>"
+  keymaps.normal_mode[5][1] = "<A-Up>"
+  keymaps.normal_mode[6][1] = "<A-Down>"
+  keymaps.normal_mode[7][1] = "<A-Left>"
+  keymaps.normal_mode[8][1] = "<A-Right>"
 end
 
 vim.g.mapleader = lvim.leader == "space" and " " or lvim.leader
-
-local keymap = require "utils.keymap"
-local keymaps = vim.tbl_deep_extend("force", default_keys, lvim.keys)
-keymap.load(keymaps, opts)
 
 -- navigate tab completion with <c-j> and <c-k>
 -- runs conditionally
 vim.cmd 'inoremap <expr> <C-j> pumvisible() ? "\\<C-n>" : "\\<C-j>"'
 vim.cmd 'inoremap <expr> <C-k> pumvisible() ? "\\<C-p>" : "\\<C-k>"'
+
+return { keymaps = keymaps, opts = opts }

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,15 +1,16 @@
-local utils = require "utils"
+local keymap = require "utils.keymap"
+local MODE = keymap.MODE
 
 local opts = {
-  nnoremap = { noremap = true, silent = true },
-  inoremap = { noremap = true, silent = true },
-  vnoremap = { noremap = true, silent = true },
-  xnoremap = { noremap = true, silent = true },
-  generic = { silent = true },
+  [MODE.INSERT] = { noremap = true, silent = true },
+  [MODE.NORMAL] = { noremap = true, silent = true },
+  [MODE.VISUAL] = { noremap = true, silent = true },
+  [MODE.VISUAL_BLOCK] = { noremap = true, silent = true },
+  [MODE.TERM] = { silent = true },
 }
 
 local default_keys = {
-  insert_mode = {
+  [MODE.INSERT] = {
     -- I hate escape
     { "jk", "<ESC>" },
     { "kj", "<ESC>" },
@@ -24,7 +25,7 @@ local default_keys = {
     { "<A-Right>", "<C-\\><C-N><C-w>l" },
   },
 
-  normal_mode = {
+  [MODE.NORMAL] = {
     -- Better window movement
     { "<C-h>", "<C-w>h" },
     { "<C-j>", "<C-w>j" },
@@ -53,7 +54,7 @@ local default_keys = {
     -- {'<C-TAB>', 'compe#complete()', {noremap = true, silent = true, expr = true}},
   },
 
-  term_mode = {
+  [MODE.TERM] = {
     -- Terminal window navigation
     { "<C-h>", "<C-\\><C-N><C-w>h" },
     { "<C-j>", "<C-\\><C-N><C-w>j" },
@@ -61,7 +62,7 @@ local default_keys = {
     { "<C-l>", "<C-\\><C-N><C-w>l" },
   },
 
-  visual_mode = {
+  [MODE.VISUAL] = {
     -- Better indenting
     { "<", "<gv" },
     { ">", ">gv" },
@@ -70,7 +71,7 @@ local default_keys = {
     -- { "P", '"0P', { silent = true } },
   },
 
-  visual_block_mode = {
+  [MODE.VISUAL_BLOCK] = {
     -- Move selected line / block of text in visual mode
     { "K", ":move '<-2<CR>gv-gv" },
     { "J", ":move '>+1<CR>gv-gv" },
@@ -83,31 +84,16 @@ local default_keys = {
 
 if vim.fn.has "mac" == 1 then
   -- TODO: fix this
-  default_keys.normal_mode[5][1] = "<A-Up>"
-  default_keys.normal_mode[6][1] = "<A-Down>"
-  default_keys.normal_mode[7][1] = "<A-Left>"
-  default_keys.normal_mode[8][1] = "<A-Right>"
+  default_keys[MODE.NORMAL][5][1] = "<A-Up>"
+  default_keys[MODE.NORMAL][6][1] = "<A-Down>"
+  default_keys[MODE.NORMAL][7][1] = "<A-Left>"
+  default_keys[MODE.NORMAL][8][1] = "<A-Right>"
 end
 
-if lvim.leader == " " or lvim.leader == "space" then
-  vim.g.mapleader = " "
-else
-  vim.g.mapleader = lvim.leader
-end
+vim.g.mapleader = lvim.leader == "space" and " " or lvim.leader
 
-local function get_user_keys(mode)
-  if lvim.keys[mode] == nil then
-    return default_keys[mode]
-  else
-    return lvim.keys[mode]
-  end
-end
-
-utils.add_keymap_normal_mode(opts.nnoremap, get_user_keys "normal_mode")
-utils.add_keymap_insert_mode(opts.inoremap, get_user_keys "insert_mode")
-utils.add_keymap_visual_mode(opts.vnoremap, get_user_keys "visual_mode")
-utils.add_keymap_visual_block_mode(opts.xnoremap, get_user_keys "visual_block_mode")
-utils.add_keymap_term_mode(opts.generic, get_user_keys "term_mode")
+local keymaps = vim.tbl_deep_extend("force", default_keys, lvim.keys)
+keymap.load(keymaps, opts)
 
 -- navigate tab completion with <c-j> and <c-k>
 -- runs conditionally

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -110,32 +110,6 @@ function utils.is_string(t)
   return type(t) == "string"
 end
 
-function utils.add_keymap(mode, opts, keymaps)
-  for _, keymap in ipairs(keymaps) do
-    vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)
-  end
-end
-
-function utils.add_keymap_normal_mode(opts, keymaps)
-  utils.add_keymap("n", opts, keymaps)
-end
-
-function utils.add_keymap_visual_mode(opts, keymaps)
-  utils.add_keymap("v", opts, keymaps)
-end
-
-function utils.add_keymap_visual_block_mode(opts, keymaps)
-  utils.add_keymap("x", opts, keymaps)
-end
-
-function utils.add_keymap_insert_mode(opts, keymaps)
-  utils.add_keymap("i", opts, keymaps)
-end
-
-function utils.add_keymap_term_mode(opts, keymaps)
-  utils.add_keymap("t", opts, keymaps)
-end
-
 function utils.unrequire(m)
   package.loaded[m] = nil
   _G[m] = nil

--- a/lua/utils/keymap.lua
+++ b/lua/utils/keymap.lua
@@ -1,18 +1,19 @@
-local M = {
-  MODE = {
-    INSERT = "i",
-    NORMAL = "n",
-    TERM = "t",
-    VISUAL = "v",
-    VISUAL_BLOCK = "x",
-  },
+local M = {}
+
+local mode_adapters = {
+  insert_mode = "i",
+  normal_mode = "n",
+  term_mode = "t",
+  visual_mode = "v",
+  visual_block_mode = "x",
 }
 
 -- Load key mappings for a given mode
--- @param mode One of the MODE enumeration values
+-- @param mode The keymap mode, can be one of the keys of mode_adapters
 -- @param keymaps The list of key mappings
 -- @param opts The mapping options
 M.load_mode = function(mode, keymaps, opts)
+  mode = mode_adapters[mode] and mode_adapters[mode] or mode
   for _, keymap in ipairs(keymaps) do
     vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)
   end

--- a/lua/utils/keymap.lua
+++ b/lua/utils/keymap.lua
@@ -1,0 +1,30 @@
+local M = {
+  MODE = {
+    INSERT = "i",
+    NORMAL = "n",
+    TERM = "t",
+    VISUAL = "v",
+    VISUAL_BLOCK = "x",
+  },
+}
+
+-- Load key mappings for a given mode
+-- @param mode One of the MODE enumeration values
+-- @param keymaps The list of key mappings
+-- @param opts The mapping options
+M.load_mode = function(mode, keymaps, opts)
+  for _, keymap in ipairs(keymaps) do
+    vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)
+  end
+end
+
+-- Load key mappings for all provided modes
+-- @param keymaps A list of key mappings for each mode
+-- @param opts The mapping options for each mode
+M.load = function(keymaps, opts)
+  for mode, mapping in pairs(keymaps) do
+    M.load_mode(mode, mapping, opts[mode])
+  end
+end
+
+return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Move key mapping helpers to utils/keymap.
Rework some logic which allows to remove some LOC.
Define mapping modes in a constant table.
Load user key maps on top of the default ones instead of merging them and excluding one or the other. This means that it's now possible to just provide additional mappings while keeping the defaults.

I could also replace all `nvim_set_keymap` calls with the new helpers.

Fix #1140 

## How Has This Been Tested?

I added Keymap:L18 ` print(mode, #mapping)`, modified `lvim.keys.n` and it worked as expected.

