### PR TITLE
[Bugfix] Allow users to define their own nvim-tree bindings

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -58,11 +58,13 @@ M.setup = function()
 
   local tree_cb = nvim_tree_config.nvim_tree_callback
 
-  g.nvim_tree_bindings = {
-    { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
-    { key = "h", cb = tree_cb "close_node" },
-    { key = "v", cb = tree_cb "vsplit" },
-  }
+  if not g.nvim_tree_bindings then
+    g.nvim_tree_bindings = {
+      { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
+      { key = "h", cb = tree_cb "close_node" },
+      { key = "v", cb = tree_cb "vsplit" },
+    }
+  end
 end
 --
 --


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add a check to see if the user has defined their own `g.nvim_tree_bindings` before defining the defaults.

## How Has This Been Tested?
* Add if guard to `nvimtree.lua`
* Run `lvim` without a user defined `g.nvim_tree_bindings`. Default bindings work as expected.
* Run `lvim` with a user defined `g.nvim_tree_bindings` in `~/.config/lvim/lv-config.lua`. User's bindings work as expected.
