### PR TITLE
[Bugfix] Use correct exe name for clang-format

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -94,7 +94,7 @@ lvim.lang = {
   },
   c = {
     formatter = {
-      exe = "clang_format",
+      exe = "clang-format",
       args = {},
       stdin = true,
     },
@@ -119,7 +119,7 @@ lvim.lang = {
   },
   cpp = {
     formatter = {
-      exe = "clang_format",
+      exe = "clang-format",
       args = {},
       stdin = true,
     },
@@ -160,7 +160,7 @@ lvim.lang = {
   },
   cs = {
     formatter = {
-      exe = "clang_format",
+      exe = "clang-format",
       args = {},
     },
     linters = {},


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix typo that broke `clang-format` calls.

## How Has This Been Tested?

* Called `vim.lsp.buf.formatting()` on CPP and C files with the fix.
