### PR TITLE
cleanup formatting handler

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -29,13 +29,11 @@ local function lsp_highlight_document(client)
 end
 
 local function formatter_handler(client)
-  local formatter_exe = lvim.lang[vim.bo.filetype].formatters[1].exe
-  if formatter_exe and formatter_exe ~= "" then
+  local formatters = lvim.lang[vim.bo.filetype].formatters
+  if not vim.tbl_isempty(formatters) then
     client.resolved_capabilities.document_formatting = false
-    -- NOTE: do we still need __FORMATTER_OVERRIDE?
-    -- __FORMATTER_OVERRIDE = true
     u.lvim_log(
-      string.format("Overriding [%s] formatting if exists, Using provider [%s] instead", client.name, formatter_exe)
+      string.format("Overriding [%s] formatting if exists, Using provider [%s] instead", client.name, formatters[1].exe)
     )
   end
 end

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -110,16 +110,6 @@ function utils.is_string(t)
   return type(t) == "string"
 end
 
-function utils.has_value(tab, val)
-  for _, value in ipairs(tab) do
-    if value == val then
-      return true
-    end
-  end
-
-  return false
-end
-
 function utils.add_keymap(mode, opts, keymaps)
   for _, keymap in ipairs(keymaps) do
     vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Clean up `formatting_handler`

## How Has This Been Tested?

Formatting still works with `stylua`
