### PR TITLE
feat: get null-ls registered providers by filetype

### DIFF
--- a/lua/core/galaxyline.lua
+++ b/lua/core/galaxyline.lua
@@ -203,25 +203,19 @@ table.insert(gls.right, {
 local function get_attached_provider_name(msg)
   msg = msg or "LSP Inactive"
   local buf_clients = vim.lsp.buf_get_clients()
+  local utils = require "utils"
   if next(buf_clients) == nil then
     return msg
   end
   local buf_ft = vim.bo.filetype
   local buf_client_names = {}
-  local null_ls_providers = require("lsp.null-ls").requested_providers
+  local null_ls_providers = require("lsp.null-ls").get_registered_providers_by_filetype(buf_ft)
   for _, client in pairs(buf_clients) do
-    if client.name == "null-ls" then
-      for _, provider in pairs(null_ls_providers) do
-        if vim.tbl_contains(provider.filetypes, buf_ft) then
-          if not vim.tbl_contains(buf_client_names, provider.name) then
-            table.insert(buf_client_names, provider.name)
-          end
-        end
-      end
-    else
+    if client.name ~= "null-ls" then
       table.insert(buf_client_names, client.name)
     end
   end
+  utils.list_extend_unique(buf_client_names, null_ls_providers)
   return table.concat(buf_client_names, ", ")
 end
 

--- a/lua/lsp/null-ls.lua
+++ b/lua/lsp/null-ls.lua
@@ -6,6 +6,17 @@ local nodejs_local_providers = { "prettier", "prettierd", "prettier_d_slim", "es
 
 M.requested_providers = {}
 
+function M.get_registered_providers_by_filetype(ft)
+  local matches = {}
+  for _, provider in pairs(M.requested_providers) do
+    if vim.tbl_contains(provider.filetypes, ft) then
+      table.insert(matches, provider.name)
+    end
+  end
+
+  return matches
+end
+
 local function is_nodejs_provider(provider)
   for _, local_provider in ipairs(nodejs_local_providers) do
     if local_provider == provider.exe then

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -110,6 +110,32 @@ function utils.is_string(t)
   return type(t) == "string"
 end
 
+--- Extends a list-like table with the unique values of another list-like table.
+---
+--- NOTE: This mutates dst!
+---
+--@see |vim.tbl_extend()|
+---
+--@param dst list which will be modified and appended to.
+--@param src list from which values will be inserted.
+--@param start Start index on src. defaults to 1
+--@param finish Final index on src. defaults to #src
+--@returns dst
+function utils.list_extend_unique(dst, src, start, finish)
+  vim.validate {
+    dst = { dst, "t" },
+    src = { src, "t" },
+    start = { start, "n", true },
+    finish = { finish, "n", true },
+  }
+  for i = start or 1, finish or #src do
+    if not vim.tbl_contains(dst, src[i]) then
+      table.insert(dst, src[i])
+    end
+  end
+  return dst
+end
+
 function utils.add_keymap(mode, opts, keymaps)
   for _, keymap in ipairs(keymaps) do
     vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Adds a utility function to get the registered `null-ls` providers by the file type. 
This helps clean up the logic in `galaxyline` quite a bit, and it's useful for debugging purposes.

## How Has This Been Tested?

`null-ls` providers are still showing up correctly in `galaxyline`
