### PR TITLE
show the actual command

### DIFF
--- a/lua/lsp/null-ls.lua
+++ b/lua/lsp/null-ls.lua
@@ -10,7 +10,7 @@ function M.get_registered_providers_by_filetype(ft)
   local matches = {}
   for _, provider in pairs(M.requested_providers) do
     if vim.tbl_contains(provider.filetypes, ft) then
-      table.insert(matches, provider.name)
+      table.insert(matches, provider._opts.command)
     end
   end
 


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

It gets confusing to show the `null-ls` provided name instead of the actual command name
