### PR TITLE
[Feature] Add exec to lvim binary

### DIFF
--- a/utils/bin/lvim
+++ b/utils/bin/lvim
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-nvim -u ~/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=~/.local/share/lunarvim/lvim" "$@"
+exec nvim -u ~/.local/share/lunarvim/lvim/init.lua --cmd "set runtimepath+=~/.local/share/lunarvim/lvim" "$@"


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Currently, the nvim process is launched as a child of the shell process. In my case, this made the tmux think that the running process is a shell script rather than the nvim. This led to the broken tmux-nvim integration, wrong tmux window title and etc. Also, I believe that this update has many other user cases.

## Solution

`exec` shell command replaces the shell process with the given command.

## How Has This Been Tested?

I've updated the shell script locally and tested that the LunarVim itself is working fine and that the tmux determines the process correctly.