### PR TITLE
[Feature] multiple lang server providers for single language

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -71,14 +71,14 @@ function M.setup(lang)
   local lsp = lvim.lang[lang].lsp
 
   -- normalize the lsp config to be a table of providers
-  if lsp['provider'] ~= nil then
-    lsp = {[lsp.provider] = lsp}
+  if lsp["provider"] ~= nil then
+    lsp = { [lsp.provider] = lsp }
   end
 
   -- initialize language server for each provider
   for provider, single_lang_server in pairs(lsp) do
     if not require("utils").check_lsp_client_active(provider) then
-        require("lspconfig")[provider].setup(single_lang_server.setup)
+      require("lspconfig")[provider].setup(single_lang_server.setup)
     end
   end
 end

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -69,12 +69,18 @@ end
 
 function M.setup(lang)
   local lsp = lvim.lang[lang].lsp
-  if require("utils").check_lsp_client_active(lsp.provider) then
-    return
+
+  -- normalize the lsp config to be a table of providers
+  if lsp['provider'] ~= nil then
+    lsp = {[lsp.provider] = lsp}
   end
 
-  local lspconfig = require "lspconfig"
-  lspconfig[lsp.provider].setup(lsp.setup)
+  -- initialize language server for each provider
+  for provider, single_lang_server in pairs(lsp) do
+    if not require("utils").check_lsp_client_active(provider) then
+        require("lspconfig")[provider].setup(single_lang_server.setup)
+    end
+  end
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

The changes in this PR allow users to supply multiple language servers to `lvim.lang.<lang>.lsp`.
The table will be looped over and every language server will be initialized.

Fixes #1107 

## How Has This Been Tested?

1. Starting lvim with the default config causes no errors.
2. Adding something something like this correctly initializes 2 language servers:
```lua
lvim.lang.php.lsp = {
  intelephense = {
    provider = "intelephense", -- we shouldn't need this line anymore because we can use the key above for provider name
    setup = {
      cmd = {
        DATA_PATH .. "/lspinstall/php/node_modules/.bin/intelephense",
        "--stdio",
      },
      filetypes = { "php", "phtml" },
      settings = {
        intelephense = {
          environment = {
            phpVersion = "7.4",
          },
        },
      },
    },
  },
  phpactor = {
    provider = "phpactor",  -- we shouldn't need this line anymore because we can use the key above for provider name
    setup = {
      handlers = {
        -- rely on intelephense for hover
        ["textDocument/hover"] = function() end,
      },
    },
  },
}
```

If you are going to test this PR with my php example above, you'll need to have [phpactor](https://phpactor.readthedocs.io/en/master/usage/standalone.html) and `intelephense` installed.
For `intelephense`, `:LspInstall php` should do the trick, but for `phpactor` you will need to follow the instructions [here](https://phpactor.readthedocs.io/en/master/usage/standalone.html).

Thanks.

