### PR TITLE
[Feature] Make keymaps of bufferline and compe configurable

### DIFF
--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -1,2 +1,16 @@
-vim.api.nvim_set_keymap("n", "<S-l>", ":BufferNext<CR>", { noremap = true, silent = true })
-vim.api.nvim_set_keymap("n", "<S-h>", ":BufferPrevious<CR>", { noremap = true, silent = true })
+lvim.builtin.bufferline = {
+  keymap = {
+    values = {
+      normal_mode = {
+        { "<S-l>", ":BufferNext<CR>" },
+        { "<S-h>", ":BufferPrevious<CR>" },
+      },
+    },
+    opts = {
+      normal_mode = { noremap = true, silent = true },
+    },
+  },
+}
+
+local keymap = require "utils.keymap"
+keymap.load(lvim.builtin.bufferline.keymap.values, lvim.builtin.bufferline.keymap.opts)

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -34,6 +34,22 @@ M.config = function()
       emoji = { kind = " ﲃ  (Emoji)", filetypes = { "markdown", "text" } },
       -- for emoji press : (idk if that in compe tho)
     },
+
+    keymap = {
+      values = {
+        insert_mode = {
+          { "<Tab>", 'pumvisible() ? "<C-n>" : "<Tab>"' },
+          { "<S-Tab>", 'pumvisible() ? "<C-p>" : "<S-Tab>"' },
+          { "<C-Space>", "compe#complete()" },
+          { "<C-e>", "compe#close('<C-e>')" },
+          { "<C-f>", "compe#scroll({ 'delta': +4 })" },
+          { "<C-d>", "compe#scroll({ 'delta': -4 })" },
+        },
+      },
+      opts = {
+        insert_mode = { noremap = true, silent = true, expr = true },
+      },
+    },
   }
 end
 
@@ -60,12 +76,6 @@ M.setup = function()
     end
   end
 
-  local remap = vim.api.nvim_set_keymap
-
-  remap("i", "<Tab>", 'pumvisible() ? "<C-n>" : "<Tab>"', { silent = true, noremap = true, expr = true })
-
-  remap("i", "<S-Tab>", 'pumvisible() ? "<C-p>" : "<S-Tab>"', { silent = true, noremap = true, expr = true })
-
   -- Use (s-)tab to:
   --- move to prev/next item in completion menuone
   --- jump to prev/next snippet's placeholder
@@ -91,11 +101,8 @@ M.setup = function()
     end
   end
 
-  vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
-  -- vim.api.nvim_set_keymap("i", "<CR>", "compe#confirm('<CR>')", { noremap = true, silent = true, expr = true })
-  vim.api.nvim_set_keymap("i", "<C-e>", "compe#close('<C-e>')", { noremap = true, silent = true, expr = true })
-  vim.api.nvim_set_keymap("i", "<C-f>", "compe#scroll({ 'delta': +4 })", { noremap = true, silent = true, expr = true })
-  vim.api.nvim_set_keymap("i", "<C-d>", "compe#scroll({ 'delta': -4 })", { noremap = true, silent = true, expr = true })
+  local keymap = require "utils.keymap"
+  keymap.load(lvim.builtin.compe.keymap.values, lvim.builtin.compe.keymap.opts)
 end
 
 return M


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Make compe and bufferline keymaps overridable.

