### PR TITLE
[Bugfix]: Fix lsp reporting when v.source is nil

### DIFF
--- a/lua/lsp/handlers.lua
+++ b/lua/lsp/handlers.lua
@@ -28,10 +28,14 @@ function M.setup()
 
     for i, v in ipairs(diagnostics) do
       local source = v.source
-      if string.find(v.source, "/") then
-        source = string.sub(v.source, string.find(v.source, "([%w-_]+)$"))
+      if source then
+        if string.find(source, "/") then
+          source = string.sub(v.source, string.find(v.source, "([%w-_]+)$"))
+        end
+        diagnostics[i].message = string.format("%s: %s", source, v.message)
+      else
+        diagnostics[i].message = string.format("%s", v.message)
       end
-      diagnostics[i].message = string.format("%s: %s", source, v.message)
 
       if vim.tbl_contains(vim.tbl_keys(v), "code") then
         diagnostics[i].message = diagnostics[i].message .. string.format(" [%s]", v.code)


### PR DESCRIPTION
# Description

On an LSP I use that isn't a part of lunarvim, the source is nil, so after editing a line, I got the error that line 31 had a nil value when it wasn't expected.

`Error executing vim.schedule lua callback: /Users/will/.local/share/lunarvim/lvim/lua/lsp/handlers.lua:31: bad argument #1 to 'find' (string expected, got nil)`

## How Has This Been Tested?

I edited the same line after making this change and I did not get the error. Now that LSP reports correctly, and my other LSP that has a source is still reporting with it's source name and a colon
