### PR TITLE
[Refactor] Adopt which key mapping style

### DIFF
--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -2,8 +2,8 @@ lvim.builtin.bufferline = {
   keymap = {
     values = {
       normal_mode = {
-        { "<S-l>", ":BufferNext<CR>" },
-        { "<S-h>", ":BufferPrevious<CR>" },
+        ["<S-l>"] = { ":BufferNext<CR>" },
+        ["<S-h>"] = { ":BufferPrevious<CR>" },
       },
     },
     opts = {

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -42,12 +42,12 @@ M.config = function()
     keymap = {
       values = {
         insert_mode = {
-          { "<Tab>", 'pumvisible() ? "<C-n>" : "<Tab>"' },
-          { "<S-Tab>", 'pumvisible() ? "<C-p>" : "<S-Tab>"' },
-          { "<C-Space>", "compe#complete()" },
-          { "<C-e>", "compe#close('<C-e>')" },
-          { "<C-f>", "compe#scroll({ 'delta': +4 })" },
-          { "<C-d>", "compe#scroll({ 'delta': -4 })" },
+          ["<Tab>"] = { 'pumvisible() ? "<C-n>" : "<Tab>"' },
+          ["<S-Tab>"] = { 'pumvisible() ? "<C-p>" : "<S-Tab>"' },
+          ["<C-Space>"] = { "compe#complete()" },
+          ["<C-e>"] = { "compe#close('<C-e>')" },
+          ["<C-f>"] = { "compe#scroll({ 'delta': +4 })" },
+          ["<C-d>"] = { "compe#scroll({ 'delta': -4 })" },
         },
       },
       opts = {

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -9,72 +9,72 @@ local opts = {
 local keymaps = {
   insert_mode = {
     -- I hate escape
-    { "jk", "<ESC>" },
-    { "kj", "<ESC>" },
-    { "jj", "<ESC>" },
+    ["jk"] = { "<ESC>" },
+    ["kj"] = { "<ESC>" },
+    ["jj"] = { "<ESC>" },
     -- Move current line / block with Alt-j/k ala vscode.
-    { "<A-j>", "<Esc>:m .+1<CR>==gi" },
-    { "<A-k>", "<Esc>:m .-2<CR>==gi" },
+    ["<A-j>"] = { "<Esc>:m .+1<CR>==gi" },
+    ["<A-k>"] = { "<Esc>:m .-2<CR>==gi" },
     -- navigation
-    { "<A-Up>", "<C-\\><C-N><C-w>k" },
-    { "<A-Down>", "<C-\\><C-N><C-w>j" },
-    { "<A-Left>", "<C-\\><C-N><C-w>h" },
-    { "<A-Right>", "<C-\\><C-N><C-w>l" },
+    ["<A-Up>"] = { "<C-\\><C-N><C-w>k" },
+    ["<A-Down>"] = { "<C-\\><C-N><C-w>j" },
+    ["<A-Left>"] = { "<C-\\><C-N><C-w>h" },
+    ["<A-Right>"] = { "<C-\\><C-N><C-w>l" },
   },
 
   normal_mode = {
     -- Better window movement
-    { "<C-h>", "<C-w>h" },
-    { "<C-j>", "<C-w>j" },
-    { "<C-k>", "<C-w>k" },
-    { "<C-l>", "<C-w>l" },
+    ["<C-h>"] = { "<C-w>h" },
+    ["<C-j>"] = { "<C-w>j" },
+    ["<C-k>"] = { "<C-w>k" },
+    ["<C-l>"] = { "<C-w>l" },
 
     -- Resize with arrows
-    { "<C-Up>", ":resize -2<CR>" },
-    { "<C-Down>", ":resize +2<CR>" },
-    { "<C-Left>", ":vertical resize -2<CR>" },
-    { "<C-Right>", ":vertical resize +2<CR>" },
+    ["<C-Up>"] = { ":resize -2<CR>" },
+    ["<C-Down>"] = { ":resize +2<CR>" },
+    ["<C-Left>"] = { ":vertical resize -2<CR>" },
+    ["<C-Right>"] = { ":vertical resize +2<CR>" },
 
     -- Tab switch buffer
     -- { "<TAB>", ":bnext<CR>" },
     -- { "<S-TAB>", ":bprevious<CR>" },
 
     -- Move current line / block with Alt-j/k a la vscode.
-    { "<A-j>", ":m .+1<CR>==" },
-    { "<A-k>", ":m .-2<CR>==" },
+    ["<A-j>"] = { ":m .+1<CR>==" },
+    ["<A-k>"] = { ":m .-2<CR>==" },
 
     -- QuickFix
-    { "]q", ":cnext<CR>" },
-    { "[q", ":cprev<CR>" },
-    { "<C-q>", ":call QuickFixToggle()<CR>" },
+    ["]q"] = { ":cnext<CR>" },
+    ["[q"] = { ":cprev<CR>" },
+    ["<C-q>"] = { ":call QuickFixToggle()<CR>" },
 
     -- {'<C-TAB>', 'compe#complete()', {noremap = true, silent = true, expr = true}},
 
     -- LSP
-    { "gd", "<cmd>lua vim.lsp.buf.definition()<CR>" },
-    { "gD", "<cmd>lua vim.lsp.buf.declaration()<CR>" },
-    { "gr", "<cmd>lua vim.lsp.buf.references()<CR>" },
-    { "gi", "<cmd>lua vim.lsp.buf.implementation()<CR>" },
-    { "gl", "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = 'single' })<CR>" },
-    { "gs", "<cmd>lua vim.lsp.buf.signature_help()<CR>" },
-    { "gp", "<cmd>lua require'lsp.peek'.Peek('definition')<CR>" },
-    { "K", "<cmd>lua vim.lsp.buf.hover()<CR>" },
-    { "<C-p>", "<cmd>lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = lvim.lsp.popup_border}})<CR>" },
-    { "<C-n>", "<cmd>lua vim.lsp.diagnostic.goto_next({popup_opts = {border = lvim.lsp.popup_border}})<CR>" },
+    ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>" },
+    ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>" },
+    ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>" },
+    ["gi"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>" },
+    ["gl"] = { "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = 'single' })<CR>" },
+    ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>" },
+    ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>" },
+    ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>" },
+    ["<C-p>"] = { "<cmd>lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = lvim.lsp.popup_border}})<CR>" },
+    ["<C-n>"] = { "<cmd>lua vim.lsp.diagnostic.goto_next({popup_opts = {border = lvim.lsp.popup_border}})<CR>" },
   },
 
   term_mode = {
     -- Terminal window navigation
-    { "<C-h>", "<C-\\><C-N><C-w>h" },
-    { "<C-j>", "<C-\\><C-N><C-w>j" },
-    { "<C-k>", "<C-\\><C-N><C-w>k" },
-    { "<C-l>", "<C-\\><C-N><C-w>l" },
+    ["<C-h>"] = { "<C-\\><C-N><C-w>h" },
+    ["<C-j>"] = { "<C-\\><C-N><C-w>j" },
+    ["<C-k>"] = { "<C-\\><C-N><C-w>k" },
+    ["<C-l>"] = { "<C-\\><C-N><C-w>l" },
   },
 
   visual_mode = {
     -- Better indenting
-    { "<", "<gv" },
-    { ">", ">gv" },
+    ["<"] = { "<gv" },
+    [">"] = { ">gv" },
 
     -- { "p", '"0p', { silent = true } },
     -- { "P", '"0P', { silent = true } },
@@ -82,21 +82,21 @@ local keymaps = {
 
   visual_block_mode = {
     -- Move selected line / block of text in visual mode
-    { "K", ":move '<-2<CR>gv-gv" },
-    { "J", ":move '>+1<CR>gv-gv" },
+    ["K"] = { ":move '<-2<CR>gv-gv" },
+    ["J"] = { ":move '>+1<CR>gv-gv" },
 
     -- Move current line / block with Alt-j/k ala vscode.
-    { "<A-j>", ":m '>+1<CR>gv-gv" },
-    { "<A-k>", ":m '<-2<CR>gv-gv" },
+    ["<A-j>"] = { ":m '>+1<CR>gv-gv" },
+    ["<A-k>"] = { ":m '<-2<CR>gv-gv" },
   },
 }
 
 if vim.fn.has "mac" == 1 then
   -- TODO: fix this
-  keymaps.normal_mode[5][1] = "<A-Up>"
-  keymaps.normal_mode[6][1] = "<A-Down>"
-  keymaps.normal_mode[7][1] = "<A-Left>"
-  keymaps.normal_mode[8][1] = "<A-Right>"
+  keymaps.normal_mode["<A-Up>"] = keymaps.normal_mode["<C-Up>"]
+  keymaps.normal_mode["<A-Down>"] = keymaps.normal_mode["<C-Down>"]
+  keymaps.normal_mode["<A-Left>"] = keymaps.normal_mode["<C-Left>"]
+  keymaps.normal_mode["<A-Right>"] = keymaps.normal_mode["<C-Right>"]
 end
 
 vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader

--- a/lua/utils/keymap.lua
+++ b/lua/utils/keymap.lua
@@ -14,8 +14,8 @@ local mode_adapters = {
 -- @param opts The mapping options
 M.load_mode = function(mode, keymaps, opts)
   mode = mode_adapters[mode] and mode_adapters[mode] or mode
-  for _, keymap in ipairs(keymaps) do
-    vim.api.nvim_set_keymap(mode, keymap[1], keymap[2], opts)
+  for key, mapping in pairs(keymaps) do
+    vim.api.nvim_set_keymap(mode, key, mapping[1], opts)
   end
 end
 

--- a/utils/installer/config.example-no-ts.lua
+++ b/utils/installer/config.example-no-ts.lua
@@ -7,23 +7,16 @@ lvim.colorscheme = "spacegray"
 
 -- keymappings
 lvim.leader = "space"
--- overwrite the key-mappings provided by LunarVim for any mode, or leave it empty to keep them
+-- overwrite/augment the key-mappings provided by LunarVim for any mode, or leave empty to keep the defaults.
 -- lvim.keys.normal_mode = {
---   Page down/up
---   {'[d', '<PageUp>'},
---   {']d', '<PageDown>'},
+--   -- Page down/up
+--   ["[d"] = { "<PageUp>" },
+--   ["]d"] = { "<PageDown>" },
 --
---   Navigate buffers
---   {'<Tab>', ':bnext<CR>'},
---   {'<S-Tab>', ':bprevious<CR>'},
+--   -- Navigate buffers
+--   ["<Tab>"] = { ":bnext<CR>" },
+--   ["<S-Tab>"] = { ":bprevious<CR>" },
 -- }
--- if you just want to augment the existing ones then use the utility function
--- require("utils").add_keymap_insert_mode({ silent = true }, {
--- { "<C-s>", ":w<cr>" },
--- { "<C-c>", "<ESC>" },
--- })
--- you can also use the native vim way directly
--- vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
 
 -- TODO: User Config for predefined plugins
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -15,23 +15,16 @@ lvim.lint_on_save = true
 lvim.colorscheme = "spacegray"
 -- keymappings
 lvim.leader = "space"
--- overwrite the key-mappings provided by LunarVim for any mode, or leave it empty to keep them
+-- overwrite/augment the key-mappings provided by LunarVim for any mode, or leave empty to keep the defaults.
 -- lvim.keys.normal_mode = {
---   Page down/up
---   {'[d', '<PageUp>'},
---   {']d', '<PageDown>'},
+--   -- Page down/up
+--   ["[d"] = { "<PageUp>" },
+--   ["]d"] = { "<PageDown>" },
 --
---   Navigate buffers
---   {'<Tab>', ':bnext<CR>'},
---   {'<S-Tab>', ':bprevious<CR>'},
+--   -- Navigate buffers
+--   ["<Tab>"] = { ":bnext<CR>" },
+--   ["<S-Tab>"] = { ":bprevious<CR>" },
 -- }
--- if you just want to augment the existing ones then use the utility function
--- require("utils").add_keymap_insert_mode({ silent = true }, {
--- { "<C-s>", ":w<cr>" },
--- { "<C-c>", "<ESC>" },
--- })
--- you can also use the native vim way directly
--- vim.api.nvim_set_keymap("i", "<C-Space>", "compe#complete()", { noremap = true, silent = true, expr = true })
 
 -- TODO: User Config for predefined plugins
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Convert our keymappings to match which-key style.
This will allow us to migrate all our keymappings to which key once we will be able to do it.
It is also more explicit for the user in case he wants to replace a specific keymap.

! It will break user-defined keymappings in config.lua as the format has changed.

## How Has This Been Tested?

`:map`, `:nmap` ...
