### PR TITLE
[Doc]: comment typos

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -63,7 +63,7 @@ lvim.autocommands = {
     { "VimResized", "*", "wincmd =" },
   },
   _packer_compile = {
-    -- will cause split windows to be resized evenly if main window is resized
+    -- will run PackerCompile after writing plugins.lua
     { "BufWritePost", "plugins.lua", "PackerCompile" },
   },
   _general_lsp = {


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Fix comment typos in autocmds.lua