### PR TITLE
[Refactor] Allow editing default keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,26 @@ lvim.colorscheme = "spacegray"
 
 lvim.builtin.compe.autocomplete = true
 
--- keymappings
+-- keymappings [view all the defaults by pressing <leader>Lk]
 lvim.leader = "space"
+-- add your own keymapping
+lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
+-- unmap a default keymapping
+-- lvim.keys.normal_mode["<C-Up>"] = ""
+-- edit a default keymapping
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
+
+-- Use which-key to add extra bindings with the leader-key prefix
+-- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }
+-- lvim.builtin.which_key.mappings["t"] = {
+--   name = "+Trouble",
+--   r = { "<cmd>Trouble lsp_references<cr>", "References" },
+--   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
+--   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnosticss" },
+--   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
+--   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
+--   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnosticss" },
+-- }
 
 -- After changing plugin config exit and reopen LunarVim, Run :PackerInstall :PackerCompile
 lvim.builtin.dashboard.active = true
@@ -123,17 +141,6 @@ lvim.plugins = {
 --   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
 -- }
 
--- Additional Leader bindings for WhichKey
--- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }
--- lvim.builtin.which_key.mappings["t"] = {
---   name = "+Trouble",
---   r = { "<cmd>Trouble lsp_references<cr>", "References" },
---   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
---   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnosticss" },
---   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
---   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
---   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnosticss" },
--- }
 
 ```
 

--- a/init.lua
+++ b/init.lua
@@ -42,11 +42,6 @@ end
 require("settings").load_commands()
 autocmds.define_augroups(lvim.autocommands)
 
-local keymap = require "utils.keymap"
-local default_keymaps = require "keymappings"
-keymap.load(default_keymaps.keymaps, default_keymaps.opts)
-keymap.load(lvim.keys, default_keymaps.opts)
-
 local plugins = require "plugins"
 local plugin_loader = require("plugin-loader").init()
 plugin_loader:load { plugins, lvim.plugins }
@@ -72,6 +67,8 @@ if lsp_settings_status_ok then
     config_home = os.getenv "HOME" .. "/.config/lvim/lsp-settings",
   }
 end
+
+require("keymappings").setup()
 
 -- TODO: these guys need to be in language files
 -- if lvim.lang.emmet.active then

--- a/lua/core/bufferline.lua
+++ b/lua/core/bufferline.lua
@@ -1,16 +1,11 @@
 lvim.builtin.bufferline = {
   keymap = {
-    values = {
-      normal_mode = {
-        ["<S-l>"] = { ":BufferNext<CR>" },
-        ["<S-h>"] = { ":BufferPrevious<CR>" },
-      },
-    },
-    opts = {
-      normal_mode = { noremap = true, silent = true },
+    normal_mode = {
+      ["<S-l>"] = ":BufferNext<CR>",
+      ["<S-h>"] = ":BufferPrevious<CR>",
     },
   },
 }
 
-local keymap = require "utils.keymap"
-keymap.load(lvim.builtin.bufferline.keymap.values, lvim.builtin.bufferline.keymap.opts)
+local keymap = require "keymappings"
+keymap.append_to_defaults(lvim.builtin.bufferline.keymap)

--- a/lua/core/compe.lua
+++ b/lua/core/compe.lua
@@ -42,12 +42,12 @@ M.config = function()
     keymap = {
       values = {
         insert_mode = {
-          ["<Tab>"] = { 'pumvisible() ? "<C-n>" : "<Tab>"' },
-          ["<S-Tab>"] = { 'pumvisible() ? "<C-p>" : "<S-Tab>"' },
-          ["<C-Space>"] = { "compe#complete()" },
-          ["<C-e>"] = { "compe#close('<C-e>')" },
-          ["<C-f>"] = { "compe#scroll({ 'delta': +4 })" },
-          ["<C-d>"] = { "compe#scroll({ 'delta': -4 })" },
+          ["<Tab>"] = 'pumvisible() ? "<C-n>" : "<Tab>"',
+          ["<S-Tab>"] = 'pumvisible() ? "<C-p>" : "<S-Tab>"',
+          ["<C-Space>"] = "compe#complete()",
+          ["<C-e>"] = "compe#close('<C-e>')",
+          ["<C-f>"] = "compe#scroll({ 'delta': +4 })",
+          ["<C-d>"] = "compe#scroll({ 'delta': -4 })",
         },
       },
       opts = {
@@ -105,7 +105,7 @@ M.setup = function()
     end
   end
 
-  local keymap = require "utils.keymap"
+  local keymap = require "keymappings"
   keymap.load(lvim.builtin.compe.keymap.values, lvim.builtin.compe.keymap.opts)
 end
 

--- a/lua/core/which-key.lua
+++ b/lua/core/which-key.lua
@@ -166,6 +166,10 @@ M.config = function()
           "Workspace Symbols",
         },
       },
+      L = {
+        name = "+LunarVim",
+        k = { "<cmd>lua require('keymappings').print()<cr>", "View LunarVim's default keymappings" },
+      },
 
       s = {
         name = "Search",

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -1214,6 +1214,7 @@ lvim.lang = {
   },
 }
 
+require("keymappings").config()
 require("core.which-key").config()
 require "core.status_colors"
 require("core.gitsigns").config()

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,109 +1,157 @@
-local opts = {
-  insert_mode = { noremap = true, silent = true },
-  normal_mode = { noremap = true, silent = true },
-  visual_mode = { noremap = true, silent = true },
-  visual_block_mode = { noremap = true, silent = true },
-  term_mode = { silent = true },
+local M = {}
+
+local generic_opts_any = { noremap = true, silent = true }
+
+local mode_adapters = {
+  insert_mode = "i",
+  normal_mode = "n",
+  term_mode = "t",
+  visual_mode = "v",
+  visual_block_mode = "x",
 }
 
-local keymaps = {
-  insert_mode = {
-    -- I hate escape
-    ["jk"] = { "<ESC>" },
-    ["kj"] = { "<ESC>" },
-    ["jj"] = { "<ESC>" },
-    -- Move current line / block with Alt-j/k ala vscode.
-    ["<A-j>"] = { "<Esc>:m .+1<CR>==gi" },
-    ["<A-k>"] = { "<Esc>:m .-2<CR>==gi" },
-    -- navigation
-    ["<A-Up>"] = { "<C-\\><C-N><C-w>k" },
-    ["<A-Down>"] = { "<C-\\><C-N><C-w>j" },
-    ["<A-Left>"] = { "<C-\\><C-N><C-w>h" },
-    ["<A-Right>"] = { "<C-\\><C-N><C-w>l" },
-  },
-
-  normal_mode = {
-    -- Better window movement
-    ["<C-h>"] = { "<C-w>h" },
-    ["<C-j>"] = { "<C-w>j" },
-    ["<C-k>"] = { "<C-w>k" },
-    ["<C-l>"] = { "<C-w>l" },
-
-    -- Resize with arrows
-    ["<C-Up>"] = { ":resize -2<CR>" },
-    ["<C-Down>"] = { ":resize +2<CR>" },
-    ["<C-Left>"] = { ":vertical resize -2<CR>" },
-    ["<C-Right>"] = { ":vertical resize +2<CR>" },
-
-    -- Tab switch buffer
-    -- { "<TAB>", ":bnext<CR>" },
-    -- { "<S-TAB>", ":bprevious<CR>" },
-
-    -- Move current line / block with Alt-j/k a la vscode.
-    ["<A-j>"] = { ":m .+1<CR>==" },
-    ["<A-k>"] = { ":m .-2<CR>==" },
-
-    -- QuickFix
-    ["]q"] = { ":cnext<CR>" },
-    ["[q"] = { ":cprev<CR>" },
-    ["<C-q>"] = { ":call QuickFixToggle()<CR>" },
-
-    -- {'<C-TAB>', 'compe#complete()', {noremap = true, silent = true, expr = true}},
-
-    -- LSP
-    ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>" },
-    ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>" },
-    ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>" },
-    ["gi"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>" },
-    ["gl"] = { "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = 'single' })<CR>" },
-    ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>" },
-    ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>" },
-    ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>" },
-    ["<C-p>"] = { "<cmd>lua vim.lsp.diagnostic.goto_prev({popup_opts = {border = lvim.lsp.popup_border}})<CR>" },
-    ["<C-n>"] = { "<cmd>lua vim.lsp.diagnostic.goto_next({popup_opts = {border = lvim.lsp.popup_border}})<CR>" },
-  },
-
-  term_mode = {
-    -- Terminal window navigation
-    ["<C-h>"] = { "<C-\\><C-N><C-w>h" },
-    ["<C-j>"] = { "<C-\\><C-N><C-w>j" },
-    ["<C-k>"] = { "<C-\\><C-N><C-w>k" },
-    ["<C-l>"] = { "<C-\\><C-N><C-w>l" },
-  },
-
-  visual_mode = {
-    -- Better indenting
-    ["<"] = { "<gv" },
-    [">"] = { ">gv" },
-
-    -- { "p", '"0p', { silent = true } },
-    -- { "P", '"0P', { silent = true } },
-  },
-
-  visual_block_mode = {
-    -- Move selected line / block of text in visual mode
-    ["K"] = { ":move '<-2<CR>gv-gv" },
-    ["J"] = { ":move '>+1<CR>gv-gv" },
-
-    -- Move current line / block with Alt-j/k ala vscode.
-    ["<A-j>"] = { ":m '>+1<CR>gv-gv" },
-    ["<A-k>"] = { ":m '<-2<CR>gv-gv" },
-  },
-}
-
-if vim.fn.has "mac" == 1 then
-  -- TODO: fix this
-  keymaps.normal_mode["<A-Up>"] = keymaps.normal_mode["<C-Up>"]
-  keymaps.normal_mode["<A-Down>"] = keymaps.normal_mode["<C-Down>"]
-  keymaps.normal_mode["<A-Left>"] = keymaps.normal_mode["<C-Left>"]
-  keymaps.normal_mode["<A-Right>"] = keymaps.normal_mode["<C-Right>"]
+-- Append key mappings to lunarvim's defaults for a given mode
+-- @param keymaps The table of key mappings containing a list per mode (normal_mode, insert_mode, ..)
+function M.append_to_defaults(keymaps)
+  for mode, mappings in pairs(keymaps) do
+    for k, v in ipairs(mappings) do
+      lvim.keys[mode][k] = v
+    end
+  end
 end
 
-vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
+-- Load key mappings for a given mode
+-- @param mode The keymap mode, can be one of the keys of mode_adapters
+-- @param keymaps The list of key mappings
+-- @param opts The mapping options
+function M.load_mode(mode, keymaps, opts)
+  mode = mode_adapters[mode] and mode_adapters[mode] or mode
+  for k, v in pairs(keymaps) do
+    vim.api.nvim_set_keymap(mode, k, v, opts)
+  end
+end
 
--- navigate tab completion with <c-j> and <c-k>
--- runs conditionally
-vim.cmd 'inoremap <expr> <C-j> pumvisible() ? "\\<C-n>" : "\\<C-j>"'
-vim.cmd 'inoremap <expr> <C-k> pumvisible() ? "\\<C-p>" : "\\<C-k>"'
+-- Load key mappings for all provided modes
+-- @param keymaps A list of key mappings for each mode
+-- @param opts The mapping options for each mode
+function M.load(keymaps, opts)
+  for mode, mapping in pairs(keymaps) do
+    M.load_mode(mode, mapping, opts[mode])
+  end
+end
 
-return { keymaps = keymaps, opts = opts }
+function M.config()
+  lvim.keys = {
+    ---@usage change or add keymappings for insert mode
+    insert_mode = {
+      -- 'jk' for quitting insert mode
+      ["jk"] = "<ESC>",
+      -- 'kj' for quitting insert mode
+      ["kj"] = "<ESC>",
+      -- 'jj' for quitting insert mode
+      ["jj"] = "<ESC>",
+      -- Move current line / block with Alt-j/k ala vscode.
+      ["<A-j>"] = "<Esc>:m .+1<CR>==gi",
+      -- Move current line / block with Alt-j/k ala vscode.
+      ["<A-k>"] = "<Esc>:m .-2<CR>==gi",
+      -- navigation
+      ["<A-Up>"] = "<C-\\><C-N><C-w>k",
+      ["<A-Down>"] = "<C-\\><C-N><C-w>j",
+      ["<A-Left>"] = "<C-\\><C-N><C-w>h",
+      ["<A-Right>"] = "<C-\\><C-N><C-w>l",
+    },
+
+    ---@usage change or add keymappings for normal mode
+    normal_mode = {
+      -- Better window movement
+      ["<C-h>"] = "<C-w>h",
+      ["<C-j>"] = "<C-w>j",
+      ["<C-k>"] = "<C-w>k",
+      ["<C-l>"] = "<C-w>l",
+
+      -- Resize with arrows
+      ["<C-Up>"] = ":resize -2<CR>",
+      ["<C-Down>"] = ":resize +2<CR>",
+      ["<C-Left>"] = ":vertical resize -2<CR>",
+      ["<C-Right>"] = ":vertical resize +2<CR>",
+
+      -- Tab switch buffer
+      ["<S-l>"] = ":BufferNext<CR>",
+      ["<S-h>"] = ":BufferPrevious<CR>",
+
+      -- Move current line / block with Alt-j/k a la vscode.
+      ["<A-j>"] = ":m .+1<CR>==",
+      ["<A-k>"] = ":m .-2<CR>==",
+
+      -- QuickFix
+      ["]q"] = ":cnext<CR>",
+      ["[q"] = ":cprev<CR>",
+      ["<C-q>"] = ":call QuickFixToggle()<CR>",
+    },
+
+    ---@usage change or add keymappings for terminal mode
+    term_mode = {
+      -- Terminal window navigation
+      ["<C-h>"] = "<C-\\><C-N><C-w>h",
+      ["<C-j>"] = "<C-\\><C-N><C-w>j",
+      ["<C-k>"] = "<C-\\><C-N><C-w>k",
+      ["<C-l>"] = "<C-\\><C-N><C-w>l",
+    },
+
+    ---@usage change or add keymappings for visual mode
+    visual_mode = {
+      -- Better indenting
+      ["<"] = "<gv",
+      [">"] = ">gv",
+
+      -- ["p"] = '"0p',
+      -- ["P"] = '"0P',
+    },
+
+    ---@usage change or add keymappings for visual block mode
+    visual_block_mode = {
+      -- Move selected line / block of text in visual mode
+      ["K"] = ":move '<-2<CR>gv-gv",
+      ["J"] = ":move '>+1<CR>gv-gv",
+
+      -- Move current line / block with Alt-j/k ala vscode.
+      ["<A-j>"] = ":m '>+1<CR>gv-gv",
+      ["<A-k>"] = ":m '<-2<CR>gv-gv",
+    },
+  }
+
+  if vim.fn.has "mac" == 1 then
+    lvim.keys.normal_mode["<A-Up>"] = lvim.keys.normal_mode["<C-Up>"]
+    lvim.keys.normal_mode["<A-Down>"] = lvim.keys.normal_mode["<C-Down>"]
+    lvim.keys.normal_mode["<A-Left>"] = lvim.keys.normal_mode["<C-Left>"]
+    lvim.keys.normal_mode["<A-Right>"] = lvim.keys.normal_mode["<C-Right>"]
+  end
+end
+
+function M.print(mode)
+  print "List of LunarVim's default keymappings (not including which-key)"
+  if mode then
+    print(vim.inspect(lvim.keys[mode]))
+  else
+    print(vim.inspect(lvim.keys))
+  end
+end
+
+function M.setup()
+  -- navigate tab completion with <c-j> and <c-k>
+  -- runs conditionally
+  vim.cmd 'inoremap <expr> <C-j> pumvisible() ? "\\<C-n>" : "\\<C-j>"'
+  vim.cmd 'inoremap <expr> <C-k> pumvisible() ? "\\<C-p>" : "\\<C-k>"'
+  local generic_opts = {
+    insert_mode = generic_opts_any,
+    normal_mode = generic_opts_any,
+    visual_mode = generic_opts_any,
+    visual_block_mode = generic_opts_any,
+    term_mode = { silent = true },
+  }
+
+  vim.g.mapleader = (lvim.leader == "space" and " ") or lvim.leader
+  M.load(lvim.keys, generic_opts)
+end
+
+return M

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -33,6 +33,24 @@ local function lsp_highlight_document(client)
   end
 end
 
+local function add_lsp_buffer_keybindings(bufnr)
+  local wk = require "which-key"
+  local keys = {
+    ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>", "Show hover" },
+    ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
+    ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>", "Goto declaration" },
+    ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>", "Goto references" },
+    ["gi"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>", "Goto implementation" },
+    ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>", "show signature help" },
+    ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>", "Peek definition" },
+    ["gl"] = {
+      "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = 'single' })<CR>",
+      "Show line diagnostics",
+    },
+  }
+  wk.register(keys, { mode = "n", buffer = bufnr })
+end
+
 function M.common_capabilities()
   local capabilities = vim.lsp.protocol.make_client_capabilities()
   capabilities.textDocument.completion.completionItem.snippetSupport = true
@@ -64,6 +82,7 @@ function M.common_on_attach(client, bufnr)
     lvim.lsp.on_attach_callback(client, bufnr)
   end
   lsp_highlight_document(client)
+  add_lsp_buffer_keybindings(bufnr)
   require("lsp.null-ls").setup(vim.bo.filetype)
 end
 

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -98,6 +98,7 @@ function utils.reload_lv_config()
   plugin_loader:load { plugins, lvim.plugins }
   vim.cmd ":PackerCompile"
   vim.cmd ":PackerInstall"
+  require("keymappings").setup()
   -- vim.cmd ":PackerClean"
 end
 

--- a/utils/installer/config.example-no-ts.lua
+++ b/utils/installer/config.example-no-ts.lua
@@ -5,17 +5,25 @@ lvim.format_on_save = true
 lvim.lint_on_save = true
 lvim.colorscheme = "spacegray"
 
--- keymappings
+-- keymappings [view all the defaults by pressing <leader>Lk]
 lvim.leader = "space"
--- overwrite/augment the key-mappings provided by LunarVim for any mode, or leave empty to keep the defaults.
--- lvim.keys.normal_mode = {
---   -- Page down/up
---   ["[d"] = { "<PageUp>" },
---   ["]d"] = { "<PageDown>" },
---
---   -- Navigate buffers
---   ["<Tab>"] = { ":bnext<CR>" },
---   ["<S-Tab>"] = { ":bprevious<CR>" },
+-- add your own keymapping
+lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
+-- unmap a default keymapping
+-- lvim.keys.normal_mode["<C-Up>"] = ""
+-- edit a default keymapping
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
+
+-- Use which-key to add extra bindings with the leader-key prefix
+-- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }
+-- lvim.builtin.which_key.mappings["t"] = {
+--   name = "+Trouble",
+--   r = { "<cmd>Trouble lsp_references<cr>", "References" },
+--   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
+--   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnosticss" },
+--   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
+--   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
+--   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnosticss" },
 -- }
 
 -- TODO: User Config for predefined plugins
@@ -69,5 +77,3 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- lvim.autocommands.custom_groups = {
 --   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
 -- }
-
--- Additional Leader bindings for WhichKey

--- a/utils/installer/config.example.lua
+++ b/utils/installer/config.example.lua
@@ -13,17 +13,26 @@ an executable
 lvim.format_on_save = true
 lvim.lint_on_save = true
 lvim.colorscheme = "spacegray"
--- keymappings
+
+-- keymappings [view all the defaults by pressing <leader>Lk]
 lvim.leader = "space"
--- overwrite/augment the key-mappings provided by LunarVim for any mode, or leave empty to keep the defaults.
--- lvim.keys.normal_mode = {
---   -- Page down/up
---   ["[d"] = { "<PageUp>" },
---   ["]d"] = { "<PageDown>" },
---
---   -- Navigate buffers
---   ["<Tab>"] = { ":bnext<CR>" },
---   ["<S-Tab>"] = { ":bprevious<CR>" },
+-- add your own keymapping
+lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
+-- unmap a default keymapping
+-- lvim.keys.normal_mode["<C-Up>"] = ""
+-- edit a default keymapping
+-- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
+
+-- Use which-key to add extra bindings with the leader-key prefix
+-- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }
+-- lvim.builtin.which_key.mappings["t"] = {
+--   name = "+Trouble",
+--   r = { "<cmd>Trouble lsp_references<cr>", "References" },
+--   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
+--   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnosticss" },
+--   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
+--   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
+--   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnosticss" },
 -- }
 
 -- TODO: User Config for predefined plugins
@@ -76,16 +85,4 @@ lvim.builtin.treesitter.highlight.enabled = true
 -- Autocommands (https://neovim.io/doc/user/autocmd.html)
 -- lvim.autocommands.custom_groups = {
 --   { "BufWinEnter", "*.lua", "setlocal ts=8 sw=8" },
--- }
-
--- Additional Leader bindings for WhichKey
--- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }
--- lvim.builtin.which_key.mappings["t"] = {
---   name = "+Trouble",
---   r = { "<cmd>Trouble lsp_references<cr>", "References" },
---   f = { "<cmd>Trouble lsp_definitions<cr>", "Definitions" },
---   d = { "<cmd>Trouble lsp_document_diagnostics<cr>", "Diagnosticss" },
---   q = { "<cmd>Trouble quickfix<cr>", "QuickFix" },
---   l = { "<cmd>Trouble loclist<cr>", "LocationList" },
---   w = { "<cmd>Trouble lsp_workspace_diagnostics<cr>", "Diagnosticss" },
 -- }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

A refactor of the core logic for keybindings

- Allow editing any default mapping _individually_ with autocomplete support in `~/.config/lvim/config.lua`
- Add a new key binding to view all the defaults `<leader>Lk`

Fixes #1194 and partially #490

## How Has This Been Tested?

See the examples in the README

