### PR TITLE
[Feature]: Keymap with custom opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ lvim.keys.normal_mode["<C-s>"] = ":w<cr>"
 -- lvim.keys.normal_mode["<C-Up>"] = ""
 -- edit a default keymapping
 -- lvim.keys.normal_mode["<C-q>"] = ":q<cr>"
+-- set keymap with custom opts
+-- lvim.keys.insert_mode["po"] = {'<ESC>', { noremap = true }}
 
 -- Use which-key to add extra bindings with the leader-key prefix
 -- lvim.builtin.which_key.mappings["P"] = { "<cmd>lua require'telescope'.extensions.project.project{}<CR>", "Projects" }


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Add capability to set keymap with custom opt. eg.

```lua
lvim.keys.insert_mode["jj"] = "<ESC>", -- use generic_opts
lvim.keys.insert_mode["<C-j>"] = {'pumvisible() ? "\\<C-n>" : "\\<C-j>"', { expr = true, noremap = true }}, -- use user defined opt
lvim.keys.insert_mode["<C-k>"] = {'pumvisible() ? "\\<C-p>" : "\\<C-k>"', { expr = true, noremap = true }}, -- use user defined opt
```

Fixes https://github.com/ChristianChiarulli/LunarVim/issues/1140#issuecomment-889728879

## How Has This Been Tested?

- Add `lvim.keys.insert_mode["<C-j>"] = {'pumvisible() ? "\\<C-n>" : "\\<C-j>"', { expr = true, noremap = true }`
- Press control+j on insert mode when completion box appear. Navigation works

