### PR TITLE
feat: add lvim.lsp.smart_cwd

### DIFF
--- a/lua/core/nvimtree.lua
+++ b/lua/core/nvimtree.lua
@@ -117,4 +117,10 @@ M.toggle_tree = function()
   end
 end
 --
+function M.change_tree_dir(dir)
+  if vim.g.loaded_tree then
+    require("nvim-tree.lib").change_dir(dir)
+  end
+end
+--
 return M

--- a/lua/core/rooter.lua
+++ b/lua/core/rooter.lua
@@ -1,0 +1,15 @@
+local M = {}
+function M.config()
+  lvim.builtin.rooter = {
+    --- This is on by default since it's currently the expected behavior.
+    ---@usage set to false to disable vim-rooter.
+    active = true,
+    silent_chdir = 1,
+    manual_only = 0,
+  }
+end
+function M.setup()
+  vim.g.rooter_silent_chdir = lvim.builtin.rooter.silent_chdir
+  vim.g.rooter_manual_only = lvim.builtin.rooter.manual_only
+end
+return M

--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -85,6 +85,8 @@ lvim = {
     popup_border = "single",
     on_attach_callback = nil,
     on_init_callback = nil,
+    ---@usage query the project directory from the language server and use it to set the CWD
+    smart_cwd = true,
   },
 
   plugins = {
@@ -1248,3 +1250,4 @@ require("core.terminal").config()
 require("core.telescope").config()
 require("core.treesitter").config()
 require("core.nvimtree").config()
+require("core.rooter").config()

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -83,6 +83,10 @@ function M.common_on_attach(client, bufnr)
   end
   lsp_highlight_document(client)
   add_lsp_buffer_keybindings(bufnr)
+  if lvim.lsp.smart_cwd then
+    vim.api.nvim_set_current_dir(client.config.root_dir)
+    require("core.nvimtree").change_tree_dir(client.config.root_dir)
+  end
   require("lsp.null-ls").setup(vim.bo.filetype)
 end
 

--- a/lua/lsp/null-ls.lua
+++ b/lua/lsp/null-ls.lua
@@ -24,10 +24,14 @@ function M.get_registered_providers_by_filetype(ft)
 end
 
 local function validate_nodejs_provider(requests, provider)
-  vim.cmd "let root_dir = FindRootDirectory()"
-  local root_dir = vim.api.nvim_get_var "root_dir"
+  local ts_client = require("utils").get_active_client_by_ft "typescript"
+  if ts_client == nil then
+    u.lvim_log "Unable to determine root directory since tsserver didn't start correctly"
+    return
+  end
+  local root_dir = ts_client.config.root_dir
   local local_nodejs_command = root_dir .. "/node_modules/.bin/" .. provider._opts.command
-  u.lvim_log(string.format("checking for local node module: [%s]", vim.inspect(provider)))
+  u.lvim_log(string.format("checking [%s] for local node module: [%s]", local_nodejs_command, vim.inspect(provider)))
   if vim.fn.executable(local_nodejs_command) == 1 then
     provider._opts.command = local_nodejs_command
     table.insert(requests, provider)

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -147,12 +147,14 @@ return {
   -- vim-rooter
   {
     "airblade/vim-rooter",
+    event = "BufReadPre",
     config = function()
-      vim.g.rooter_silent_chdir = 1
+      require("core.rooter").setup()
       if lvim.builtin.rooter.on_config_done then
         lvim.builtin.rooter.on_config_done()
       end
     end,
+    disable = not lvim.builtin.rooter.active,
   },
 
   -- Icons

--- a/lua/utils/init.lua
+++ b/lua/utils/init.lua
@@ -112,6 +112,16 @@ function utils.check_lsp_client_active(name)
   return false
 end
 
+function utils.get_active_client_by_ft(filetype)
+  local clients = vim.lsp.get_active_clients()
+  for _, client in pairs(clients) do
+    if client.name == lvim.lang[filetype].lsp.provider then
+      return client
+    end
+  end
+  return nil
+end
+
 --- Extends a list-like table with the unique values of another list-like table.
 ---
 --- NOTE: This mutates dst!


### PR DESCRIPTION

<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Enable querying the language-server for the `root_dir`
- Use `root_dir` to set the current working-directory (CWD) and enable it by default
- Make vim-rooter configurable and add an option to disable it

Inspired by "ahmedkhalf/lsp-rooter.nvim"

## How Has This Been Tested?

1- Disable vim-rooter

```lua
lvim.builtin.rooter.active = false
```

2- Open any file with LSP support and see the "smart_cwd" in action :)
