### PR TITLE
chore: minor cleanup to root_dir comments

### DIFF
--- a/lua/lsp/null-ls.lua
+++ b/lua/lsp/null-ls.lua
@@ -24,21 +24,19 @@ function M.get_registered_providers_by_filetype(ft)
 end
 
 local function validate_nodejs_provider(requests, provider)
-  local root_dir = ""
+  local root_dir
   if lvim.builtin.rooter.active then
-    --- old logic to set root_dir
+    --- use vim-rooter to set root_dir
     vim.cmd "let root_dir = FindRootDirectory()"
     root_dir = vim.api.nvim_get_var "root_dir"
   else
-    --- new logic to set root_dir
+    --- use LSP to set root_dir
     local ts_client = require("utils").get_active_client_by_ft "typescript"
-    if ts_client then
-      root_dir = ts_client.config.root_dir
-    end
     if ts_client == nil then
       u.lvim_log "Unable to determine root directory since tsserver didn't start correctly"
       return
     end
+    root_dir = ts_client.config.root_dir
   end
   local local_nodejs_command = root_dir .. "/node_modules/.bin/" .. provider._opts.command
   u.lvim_log(string.format("checking [%s] for local node module: [%s]", local_nodejs_command, vim.inspect(provider)))


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

- Use more stateful comments regarding `root_dir` detection logic.
- Remove redundant `if ts_clien then` since it's guaranteed after 
passing the first condition.

## How has this been tested?

1. Add this to your `config.lua` 

`lvim.builtin.rooter.active = false`

2. Check that CWD is still updating with LSP
