### PR TITLE
[Bugfix]: Don't override formatter with empty exe

### DIFF
--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -71,7 +71,7 @@ function M.common_on_init(client, bufnr)
   end
 
   local formatters = lvim.lang[vim.bo.filetype].formatters
-  if not vim.tbl_isempty(formatters) then
+  if not vim.tbl_isempty(formatters) and formatters[1].exe ~= "" then
     client.resolved_capabilities.document_formatting = false
     u.lvim_log(string.format("Overriding [%s] formatter with [%s]", client.name, formatters[1].exe))
   end

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -71,7 +71,7 @@ function M.common_on_init(client, bufnr)
   end
 
   local formatters = lvim.lang[vim.bo.filetype].formatters
-  if not vim.tbl_isempty(formatters) and formatters[1].exe ~= "" then
+  if not vim.tbl_isempty(formatters) and formatters[1]["exe"] ~= nil and formatters[1].exe ~= "" then
     client.resolved_capabilities.document_formatting = false
     u.lvim_log(string.format("Overriding [%s] formatter with [%s]", client.name, formatters[1].exe))
   end


### PR DESCRIPTION
# Description

As many filetypes have default formatters configuration with empty exe value, LunarVim needs to check if exe has been set before overriding the LSP clients formatter.

With e.g. `cs` filetype (i.e. C#), the csharp LSP client (OmniSharp) can do rudamentary formatting, but with default configuration the formatter is disabled because of 

## How Has This Been Tested?

Tested with C# project (OmniSharp LSP) without changing the `lvim.lang.cs.formatters` default configuration AND then later setting `clang_format` as formatter exe value. Without exe value, omnisharp formatting capability is not overridden with empty formatter, but with `clang_format` exe value, the clan_format will override omnisharp's formatting capability.