### PR TITLE
[Features]: Add  default python formatters and linters.

### DIFF
--- a/lua/default-config.lua
+++ b/lua/default-config.lua
@@ -864,12 +864,22 @@ lvim.lang = {
   python = {
     formatters = {
       {
-        -- @usage can be black or yapf or isort
-        exe = "",
+        -- @usage can be black and/or yapf and/or isort (multiple formatters allowed)
+        exe = "isort",
+        args = {"--profile", "black"}
+      },
+      {
+        exe = "black",
+        args = {}
+      }
+    },
+    linters = {
+      {
+        -- @usage can be flake8 or ... (multiple linters allowed)
+        exe = "flake8",
         args = {},
       },
     },
-    linters = {},
     lsp = {
       provider = "pyright",
       setup = {


### PR DESCRIPTION
# Description

Provide default python formatters (isort + black) + linter (flake8) to provide out of the box experience.

Fixes #1225 for Python

## How Has This Been Tested?

Tested manually on my notebook.