### PR TITLE
Allow calling `add_lsp_keybindings` from anywhere

### DIFF
--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -151,6 +151,33 @@ function M.config()
   end
 end
 
+--- Add keybindings for LSP helper function (goto definition, etc)
+---@param bufnr will be used if specified, otherwise they will be global
+function M.add_lsp_keybindings(bufnr)
+  local keys = {
+    ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>", "Show hover" },
+    ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
+    ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>", "Goto declaration" },
+    ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>", "Goto references" },
+    ["gi"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>", "Goto implementation" },
+    ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>", "show signature help" },
+    ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>", "Peek definition" },
+    ["gl"] = {
+      "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = 'single' })<CR>",
+      "Show line diagnostics",
+    },
+  }
+  local opts = { mode = "n" }
+  if bufnr then
+    opts.buffer = bufnr
+  end
+  local status_ok, wk = pcall(require, "which-key")
+  if not status_ok then
+    error "Unable to load which-key to register keymappings."
+  end
+  wk.register(keys, opts)
+end
+
 function M.print(mode)
   print "List of LunarVim's default keymappings (not including which-key)"
   if mode then

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -33,24 +33,6 @@ local function lsp_highlight_document(client)
   end
 end
 
-local function add_lsp_buffer_keybindings(bufnr)
-  local wk = require "which-key"
-  local keys = {
-    ["K"] = { "<cmd>lua vim.lsp.buf.hover()<CR>", "Show hover" },
-    ["gd"] = { "<cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
-    ["gD"] = { "<cmd>lua vim.lsp.buf.declaration()<CR>", "Goto declaration" },
-    ["gr"] = { "<cmd>lua vim.lsp.buf.references()<CR>", "Goto references" },
-    ["gi"] = { "<cmd>lua vim.lsp.buf.implementation()<CR>", "Goto implementation" },
-    ["gs"] = { "<cmd>lua vim.lsp.buf.signature_help()<CR>", "show signature help" },
-    ["gp"] = { "<cmd>lua require'lsp.peek'.Peek('definition')<CR>", "Peek definition" },
-    ["gl"] = {
-      "<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ show_header = false, border = 'single' })<CR>",
-      "Show line diagnostics",
-    },
-  }
-  wk.register(keys, { mode = "n", buffer = bufnr })
-end
-
 function M.common_capabilities()
   local capabilities = vim.lsp.protocol.make_client_capabilities()
   capabilities.textDocument.completion.completionItem.snippetSupport = true
@@ -82,7 +64,7 @@ function M.common_on_attach(client, bufnr)
     lvim.lsp.on_attach_callback(client, bufnr)
   end
   lsp_highlight_document(client)
-  add_lsp_buffer_keybindings(bufnr)
+  require("keymappings").add_lsp_keybindings(bufnr)
   if lvim.lsp.smart_cwd then
     vim.api.nvim_set_current_dir(client.config.root_dir)
     require("core.nvimtree").change_tree_dir(client.config.root_dir)


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
I prefixed the title with one of the following tags:
 - [Feature]: For feature addition / improvements
 - [Bugfix]: When fixing a functionality
 - [Refactor]: When moving code without adding any functionality
 - [Doc]: On documentation updates

- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->
# Description

Allow calling `add_lsp_keybindings` from anywhere.

Fixes #1219

## How Has This Been Tested?

Press `g` and wait for which-key prompt to confirm they're still working.

